### PR TITLE
feat(auth): implement user registration endpoint with bcrypt hashing

### DIFF
--- a/backend/apps/core/apps.py
+++ b/backend/apps/core/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'apps.core'
+    label = 'core'

--- a/backend/apps/core/exceptions.py
+++ b/backend/apps/core/exceptions.py
@@ -1,0 +1,6 @@
+from rest_framework.views import exception_handler
+
+
+def custom_exception_handler(exc, context):
+    response = exception_handler(exc, context)
+    return response

--- a/backend/apps/users/apps.py
+++ b/backend/apps/users/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'apps.users'
+    label = 'users'

--- a/backend/apps/users/models.py
+++ b/backend/apps/users/models.py
@@ -1,0 +1,74 @@
+import uuid
+
+from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, PermissionsMixin
+from django.db import models
+
+
+class UserManager(BaseUserManager):
+    def create_user(self, email, full_name, password=None, **extra_fields):
+        if not email:
+            raise ValueError('Email is required')
+        email = self.normalize_email(email)
+        user = self.model(email=email, full_name=full_name, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, email, full_name, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+        return self.create_user(email, full_name, password, **extra_fields)
+
+
+class User(AbstractBaseUser, PermissionsMixin):
+    class Status(models.TextChoices):
+        ACTIVE = 'ACTIVE', 'Active'
+        INACTIVE = 'INACTIVE', 'Inactive'
+        BANNED = 'BANNED', 'Banned'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    email = models.EmailField(unique=True)
+    full_name = models.CharField(max_length=255)
+    birth_date = models.DateField(null=True, blank=True)
+    status = models.CharField(max_length=10, choices=Status.choices, default=Status.ACTIVE)
+    trust_score = models.IntegerField(default=0)
+    is_active = models.BooleanField(default=True)
+    is_staff = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    objects = UserManager()
+
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = ['full_name']
+
+    class Meta:
+        db_table = 'users'
+
+    def __str__(self):
+        return self.email
+
+
+class MobilityProfile(models.Model):
+    class MobilityAid(models.TextChoices):
+        NONE = 'NONE', 'None'
+        WHEELCHAIR = 'WHEELCHAIR', 'Wheelchair'
+        WALKER = 'WALKER', 'Walker'
+        CANE = 'CANE', 'Cane'
+        CRUTCHES = 'CRUTCHES', 'Crutches'
+        SCOOTER = 'SCOOTER', 'Scooter'
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name='mobility_profile')
+    mobility_aid = models.CharField(max_length=20, choices=MobilityAid.choices, default=MobilityAid.NONE)
+    avoid_stairs = models.BooleanField(default=False)
+    avoid_steep_slopes = models.BooleanField(default=False)
+    max_slope_gradient = models.FloatField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = 'mobility_profiles'
+
+    def __str__(self):
+        return f'{self.user.email} - {self.mobility_aid}'

--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -1,0 +1,79 @@
+from django.contrib.auth.password_validation import validate_password
+from rest_framework import serializers
+
+from .models import MobilityProfile, User
+
+
+class MobilityProfileSerializer(serializers.Serializer):
+    mobilityAid = serializers.ChoiceField(
+        choices=MobilityProfile.MobilityAid.choices,
+        source='mobility_aid',
+    )
+    avoidStairs = serializers.BooleanField(
+        source='avoid_stairs',
+        default=False,
+    )
+    avoidSteepSlopes = serializers.BooleanField(
+        source='avoid_steep_slopes',
+        default=False,
+    )
+    maxSlopeGradient = serializers.FloatField(
+        source='max_slope_gradient',
+        required=False,
+        allow_null=True,
+    )
+
+
+class RegisterSerializer(serializers.Serializer):
+    email = serializers.EmailField()
+    fullName = serializers.CharField(max_length=255, source='full_name')
+    password = serializers.CharField(write_only=True, min_length=8)
+    birthDate = serializers.DateField(source='birth_date', required=False)
+    mobilityProfile = MobilityProfileSerializer(
+        source='mobility_profile',
+        required=False,
+    )
+
+    def validate_email(self, value):
+        if User.objects.filter(email=value).exists():
+            raise serializers.ValidationError('A user with this email already exists.')
+        return value
+
+    def validate_password(self, value):
+        validate_password(value)
+        return value
+
+    def create(self, validated_data):
+        mobility_data = validated_data.pop('mobility_profile', None)
+
+        user = User.objects.create_user(
+            email=validated_data['email'],
+            full_name=validated_data['full_name'],
+            password=validated_data['password'],
+            birth_date=validated_data.get('birth_date'),
+        )
+
+        if mobility_data:
+            MobilityProfile.objects.create(user=user, **mobility_data)
+
+        return user
+
+
+class RegisterResponseSerializer(serializers.ModelSerializer):
+    userId = serializers.UUIDField(source='id')
+    fullName = serializers.CharField(source='full_name')
+    trustScore = serializers.IntegerField(source='trust_score')
+    createdAt = serializers.DateTimeField(source='created_at')
+    accessToken = serializers.SerializerMethodField()
+    refreshToken = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = ['userId', 'email', 'fullName', 'status', 'trustScore',
+                  'accessToken', 'refreshToken', 'createdAt']
+
+    def get_accessToken(self, obj):
+        return self.context.get('access_token', '')
+
+    def get_refreshToken(self, obj):
+        return self.context.get('refresh_token', '')

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -1,0 +1,85 @@
+from django.contrib.auth.hashers import check_password, identify_hasher
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from .models import MobilityProfile, User
+
+
+class RegisterViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = '/api/auth/register'
+        self.valid_payload = {
+            'email': 'test@example.com',
+            'fullName': 'Test User',
+            'password': 'SecureP@ss123',
+            'birthDate': '1995-06-15',
+        }
+
+    def test_register_success(self):
+        response = self.client.post(self.url, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        self.assertEqual(data['email'], 'test@example.com')
+        self.assertEqual(data['fullName'], 'Test User')
+        self.assertEqual(data['status'], 'ACTIVE')
+        self.assertEqual(data['trustScore'], 0)
+        self.assertIn('accessToken', data)
+        self.assertIn('refreshToken', data)
+        self.assertIn('userId', data)
+        self.assertIn('createdAt', data)
+
+    def test_register_with_mobility_profile(self):
+        payload = {
+            **self.valid_payload,
+            'mobilityProfile': {
+                'mobilityAid': 'WHEELCHAIR',
+                'avoidStairs': True,
+                'avoidSteepSlopes': True,
+                'maxSlopeGradient': 8.0,
+            },
+        }
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        user = User.objects.get(email='test@example.com')
+        profile = MobilityProfile.objects.get(user=user)
+        self.assertEqual(profile.mobility_aid, 'WHEELCHAIR')
+        self.assertTrue(profile.avoid_stairs)
+        self.assertTrue(profile.avoid_steep_slopes)
+        self.assertEqual(profile.max_slope_gradient, 8.0)
+
+    def test_register_without_mobility_profile(self):
+        response = self.client.post(self.url, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        user = User.objects.get(email='test@example.com')
+        self.assertFalse(MobilityProfile.objects.filter(user=user).exists())
+
+    def test_register_duplicate_email(self):
+        self.client.post(self.url, self.valid_payload, format='json')
+        response = self.client.post(self.url, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_register_missing_email(self):
+        payload = {**self.valid_payload}
+        del payload['email']
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_register_missing_password(self):
+        payload = {**self.valid_payload}
+        del payload['password']
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_register_invalid_email(self):
+        payload = {**self.valid_payload, 'email': 'not-an-email'}
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_password_is_bcrypt_hashed(self):
+        self.client.post(self.url, self.valid_payload, format='json')
+        user = User.objects.get(email='test@example.com')
+        hasher = identify_hasher(user.password)
+        self.assertEqual(hasher.algorithm, 'bcrypt_sha256')
+        self.assertTrue(check_password('SecureP@ss123', user.password))

--- a/backend/apps/users/urls.py
+++ b/backend/apps/users/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import RegisterView
+
+urlpatterns = [
+    path('register', RegisterView.as_view(), name='register'),
+]

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,0 +1,25 @@
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from .serializers import RegisterResponseSerializer, RegisterSerializer
+
+
+class RegisterView(APIView):
+    permission_classes = [AllowAny]
+
+    def post(self, request):
+        serializer = RegisterSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+
+        refresh = RefreshToken.for_user(user)
+
+        response_serializer = RegisterResponseSerializer(user, context={
+            'access_token': str(refresh.access_token),
+            'refresh_token': str(refresh),
+        })
+
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -77,6 +77,11 @@ DATABASES = {
 
 AUTH_USER_MODEL = 'users.User'
 
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.BCryptSHA256PasswordHasher',
+    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
+]
+
 AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
     {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator'},

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -5,3 +5,4 @@ django-cors-headers>=4.3
 psycopg2-binary>=2.9
 python-decouple>=3.8
 gunicorn>=21.2
+bcrypt>=4.0


### PR DESCRIPTION
- Add User model with UUID, email, fullName, birthDate, status, trustScore
- Add MobilityProfile model (optional, linked to user)
- Add POST /auth/register endpoint returning 201 with JWT tokens
- Configure BCryptSHA256PasswordHasher as primary password hasher
- Add registration serializer with email uniqueness and password validation
- Add unit tests for registration endpoint

## Description
[Brief summary of what this PR does and why]

## Type of Change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes
- 
- 
- 

## How to Test
[Steps to verify the changes work correctly]

## Screenshots (if applicable)
[Add screenshots or screen recordings if there are UI changes]

## Checklist
- [ ] Commit messages follow `<type>(<scope>): <subject>` format
- [ ] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #[issue number]

## Notes
[Any additional context, known issues, or follow-up tasks]
