### PR TITLE
fix(profile): correct /users/me endpoint URL and normalize reputationPoints to trustScore

### DIFF
--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -84,13 +84,17 @@ export async function login(payload: LoginPayload) {
 }
 
 export async function getMe() {
-  const res = await fetch(`${API_BASE}/api/auth/me/`, { headers: authHeaders() });
+  const res = await fetch(`${API_BASE}/api/auth/users/me`, { headers: authHeaders() });
   const data = await res.json().catch(() => ({}));
+  if (res.ok) {
+    data.trustScore = data.trustScore ?? data.reputationPoints ?? 0;
+    data.status = data.status ?? data.accountStatus ?? 'ACTIVE';
+  }
   return { ok: res.ok, status: res.status, data };
 }
 
 export async function updateMe(payload: { fullName: string }) {
-  const res = await fetch(`${API_BASE}/api/auth/me/`, { method: 'PUT', headers: authHeaders(), body: JSON.stringify(payload) });
+  const res = await fetch(`${API_BASE}/api/auth/users/me`, { method: 'PUT', headers: authHeaders(), body: JSON.stringify(payload) });
   const data = await res.json().catch(() => ({}));
   return { ok: res.ok, status: res.status, data };
 }


### PR DESCRIPTION
## Description

Fixes the Profile screen showing `—` for all fields. The frontend was calling the old `/api/auth/me/` stub path which no longer exists, and field names from the new `MeView` response were not mapped to what the UI expects.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes

- `src/services/auth.ts` — Updated `getMe` and `updateMe` to call `/api/auth/users/me` matching the route registered in PR #128
- `src/services/auth.ts` — Added response normalization in `getMe`: maps `reputationPoints` → `trustScore` and `accountStatus` → `status` so the rest of the app is unaffected

## How to Test

1. Start backend: `docker compose up`
2. Start frontend: `cd frontend && npx expo start --clear`, press `w`
3. Register or log in with an existing account
4. Navigate to the Profile tab — name, email, and trust score should all be visible
5. Tap the edit icon, change the name, tap Save — updated name should appear immediately

## Screenshots (if applicable)

<!-- Add a screenshot of the Profile screen showing name/email/trust score populated -->

## Checklist

- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue

- Closes #130 

## Notes

- The backend `users/me` route has no trailing slash — this is intentional to match the Django `path()` registration. If the backend later adds a trailing slash, the frontend should follow.
