### PR TITLE
fixed report issue on backend

### DIFF
--- a/backend/apps/reports/serializers.py
+++ b/backend/apps/reports/serializers.py
@@ -24,7 +24,7 @@ class ReportSerializer(serializers.Serializer):
     )
 
 class ReportResponseSerializer(serializers.Serializer):
-    reportId = serializers.IntegerField(source="id")
+    reportId = serializers.UUIDField(source="id")
     status = serializers.CharField()
     autoVerified = serializers.SerializerMethodField()
     duplicateCandidate = serializers.SerializerMethodField()

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -9,7 +9,7 @@ from .models import Report, Photo, ReportStatus, ObstacleCategory
 
 
 def _get_supabase_client():
-    return create_client(settings.SUPABASE_URL, settings.SUPABASE_ANON_KEY)
+    return create_client(settings.SUPABASE_URL, settings.SUPABASE_SERVICE_ROLE_KEY)
 
 
 def _upload_photo_to_supabase(client, base64_string: str) -> tuple[str, str]:

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -122,6 +122,7 @@ USE_TZ = True
 
 SUPABASE_URL = config('SUPABASE_URL', default='')
 SUPABASE_ANON_KEY = config('SUPABASE_ANON_KEY', default='')
+SUPABASE_SERVICE_ROLE_KEY = config('SUPABASE_SERVICE_ROLE_KEY', default='')
 SUPABASE_PHOTOS_BUCKET = config('SUPABASE_PHOTOS_BUCKET', default='report-photos')
 
 STATIC_URL = '/static/'


### PR DESCRIPTION
## Description
Fixes `reportId` being returned as integer instead of UUID in the report creation response.

## Type of Change
- [x] `feat` — new feature
- [x] `fix` — bug fix

## Changes
- Fixed `reportId` field in `ReportResponseSerializer` from `IntegerField` to `UUIDField`
- Switched Supabase storage client to use `SUPABASE_SERVICE_ROLE_KEY` to bypass storage RLS



## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author


## Notes
- `SUPABASE_SERVICE_ROLE_KEY` must be set in `backend/.env` — get it from Supabase dashboard → Project Settings → API
- Run on shared DB if not done: `ALTER TABLE mobility_profiles RENAME COLUMN mobility_aid TO mobility_aid_type;`
