### PR TITLE
feat(map): Google Maps-style overlay UI with route planning

### DIFF
--- a/frontend/app/tabs/_layout.tsx
+++ b/frontend/app/tabs/_layout.tsx
@@ -5,8 +5,8 @@ import { COLORS } from '../../src/constants/theme';
 export default function TabsLayout() {
   return (
     <Tabs screenOptions={{ headerStyle: { backgroundColor: COLORS.green900 }, headerTintColor: COLORS.white, headerTitleStyle: { fontWeight: '700', fontSize: 17 }, headerShadowVisible: false, tabBarActiveTintColor: COLORS.blue600, tabBarInactiveTintColor: COLORS.gray400, tabBarStyle: { backgroundColor: COLORS.white, borderTopWidth: 1, borderTopColor: COLORS.gray200, height: 58, paddingBottom: 6, paddingTop: 6 }, tabBarLabelStyle: { fontSize: 10, fontWeight: '600' } }}>
-      <Tabs.Screen name="index" options={{ title: 'Route', headerTitle: 'Campus Map', tabBarIcon: ({ color, size }) => <Ionicons name="map-outline" size={size} color={color} /> }} />
-      <Tabs.Screen name="plan" options={{ title: 'Plan', tabBarIcon: ({ color, size }) => <Ionicons name="document-text-outline" size={size} color={color} /> }} />
+      <Tabs.Screen name="index" options={{ title: 'Map', headerTitle: 'Access Map', tabBarIcon: ({ color, size }) => <Ionicons name="map-outline" size={size} color={color} /> }} />
+      <Tabs.Screen name="plan" options={{ href: null }} />
       <Tabs.Screen name="report" options={{ title: 'Report', headerTitle: 'Report Obstacle', tabBarIcon: ({ color, size }) => <Ionicons name="flag-outline" size={size} color={color} /> }} />
       <Tabs.Screen name="profile" options={{ title: 'Profile', headerTitle: 'Profile', tabBarIcon: ({ color, size }) => <Ionicons name="person-outline" size={size} color={color} /> }} />
     </Tabs>

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -1,14 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import WebView from 'react-native-webview';
+import * as Location from 'expo-location';
 
 import { fetchObstacles, searchLocations, type Obstacle } from '../../api/map';
+import { calculateRoute, type GuestPreferences, type RouteResult } from '../../api/routes';
+import { isLoggedIn } from '../../services/auth';
 import { COLORS } from '../../constants/theme';
 
 const BOUN_CENTER = { lat: 41.0847, lng: 29.0503 };
 
-// ── Static HTML — built once, never changes ─────────────────────────────────
+// ── Static HTML — built once ─────────────────────────────────────────────────
 
 const MAP_HTML = `<!DOCTYPE html>
 <html>
@@ -46,11 +49,12 @@ const MAP_HTML = `<!DOCTYPE html>
   }).addTo(map);
   L.control.zoom({ position: 'bottomright' }).addTo(map);
 
-  var markers = [];
+  // ── Obstacles ──────────────────────────────────────────────────────────────
+  var obstacleMarkers = [];
 
   function renderObstacles(obstacles, showPassive) {
-    markers.forEach(function(m) { map.removeLayer(m); });
-    markers = [];
+    obstacleMarkers.forEach(function(m) { map.removeLayer(m); });
+    obstacleMarkers = [];
     var currentZoom = map.getZoom();
     obstacles.forEach(function(obs) {
       if (obs.isIndoor && currentZoom < 18) return;
@@ -74,10 +78,38 @@ const MAP_HTML = `<!DOCTYPE html>
         window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'PIN_CLICK', id: obs.id }));
       });
       marker.addTo(map);
-      markers.push(marker);
+      obstacleMarkers.push(marker);
     });
   }
 
+  // ── Route / pin-drop ───────────────────────────────────────────────────────
+  var originMarker = null, destMarker = null, routeLine = null;
+  var pinModeState = null;
+
+  function makeIcon(color) {
+    return L.divIcon({
+      html: '<div style="width:14px;height:14px;border-radius:50%;background:' + color + ';border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,0.35)"></div>',
+      className: '', iconSize: [14, 14], iconAnchor: [7, 7]
+    });
+  }
+
+  map.on('click', function(e) {
+    if (!pinModeState) return;
+    var lat = e.latlng.lat, lng = e.latlng.lng;
+    if (pinModeState === 'origin') {
+      if (originMarker) map.removeLayer(originMarker);
+      originMarker = L.marker([lat, lng], { icon: makeIcon('#27724A') }).addTo(map);
+    } else {
+      if (destMarker) map.removeLayer(destMarker);
+      destMarker = L.marker([lat, lng], { icon: makeIcon('#EF4444') }).addTo(map);
+    }
+    window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({
+      type: 'PIN_DROPPED', kind: pinModeState, lat: lat, lng: lng
+    }));
+    pinModeState = null;
+  });
+
+  // ── Bounds tracking ────────────────────────────────────────────────────────
   var boundsTimer = null;
   map.on('moveend zoomend', function() {
     clearTimeout(boundsTimer);
@@ -92,12 +124,33 @@ const MAP_HTML = `<!DOCTYPE html>
     }, 300);
   });
 
-  window.updateObstacles = function(json, showPassive) {
-    renderObstacles(JSON.parse(json), showPassive);
+  // ── Exposed API ────────────────────────────────────────────────────────────
+  window.updateObstacles = function(json, showPassive) { renderObstacles(JSON.parse(json), showPassive); };
+  window.flyTo = function(lat, lng, z) { map.flyTo([lat, lng], z || 18); };
+  window.setPinMode = function(mode) { pinModeState = mode; };
+  window.setOrigin = function(lat, lng) {
+    if (originMarker) map.removeLayer(originMarker);
+    originMarker = L.marker([lat, lng], { icon: makeIcon('#27724A') }).addTo(map);
   };
-
-  window.flyTo = function(lat, lng, z) {
-    map.flyTo([lat, lng], z || 18);
+  window.setDest = function(lat, lng) {
+    if (destMarker) map.removeLayer(destMarker);
+    destMarker = L.marker([lat, lng], { icon: makeIcon('#EF4444') }).addTo(map);
+  };
+  window.showRoute = function(waypointsJson) {
+    if (routeLine) map.removeLayer(routeLine);
+    var waypoints = JSON.parse(waypointsJson);
+    if (waypoints.length < 2) return;
+    routeLine = L.polyline(waypoints, { color: '#3B82F6', weight: 5, opacity: 0.85 }).addTo(map);
+    map.fitBounds(routeLine.getBounds(), { padding: [40, 40] });
+  };
+  window.fitBothPoints = function() {
+    if (originMarker && destMarker) {
+      var group = L.featureGroup([originMarker, destMarker]);
+      map.fitBounds(group.getBounds(), { padding: [60, 60] });
+    }
+  };
+  window.clearRoute = function() {
+    if (routeLine) { map.removeLayer(routeLine); routeLine = null; }
   };
 
   // Signal ready
@@ -106,22 +159,51 @@ const MAP_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface MapPoint { lat: number; lng: number; label: string; }
+
+function formatDistance(m: number): string {
+  return m >= 1000 ? `${(m / 1000).toFixed(1)} km` : `${Math.round(m)} m`;
+}
+function formatTime(sec: number): string {
+  const mins = Math.round(sec / 60);
+  if (mins < 60) return `${mins} min`;
+  const h = Math.floor(mins / 60), rem = mins % 60;
+  return rem > 0 ? `${h}h ${rem}min` : `${h}h`;
+}
+
 // ── Main component ───────────────────────────────────────────────────────────
 
 export default function MapView() {
   const webViewRef = useRef<WebView>(null);
-  const readyRef = useRef(false);
+  const readyRef   = useRef(false);
 
+  // Obstacle state
   const [showPassive, setShowPassive] = useState(false);
-  const [loading, setLoading]         = useState(false);
-  const [query, setQuery]             = useState('');
-  const [searchLoading, setSearchLoading] = useState(false);
-
-  const currentBoundsRef = useRef<{ north: number; south: number; east: number; west: number } | null>(null);
-  const showPassiveRef   = useRef(showPassive);
+  const showPassiveRef = useRef(showPassive);
   showPassiveRef.current = showPassive;
+  const currentBoundsRef = useRef<{ north: number; south: number; east: number; west: number } | null>(null);
+
+  // Search / route state
+  const [searchExpanded, setSearchExpanded] = useState(false);
+  const [originQ, setOriginQ] = useState('');
+  const [destQ,   setDestQ]   = useState('');
+  const [origin, setOrigin]   = useState<MapPoint | null>(null);
+  const [dest,   setDest]     = useState<MapPoint | null>(null);
+  const [pinMode, setPinModeState] = useState<'origin' | 'dest' | null>(null);
+  const [route,   setRoute]   = useState<RouteResult | null>(null);
+  const [routeLoading, setRouteLoading] = useState(false);
+  const [routeError,   setRouteError]   = useState<string | null>(null);
+  const [showPrefs, setShowPrefs] = useState(false);
+  const [prefs, setPrefs] = useState<GuestPreferences>({
+    avoidStairs: true, avoidSteepSlopes: false, maxSlopeGradient: 8,
+  });
+  const [locLoading, setLocLoading] = useState(false);
 
   const source = useMemo(() => ({ html: MAP_HTML }), []);
+
+  // ── Obstacles ──────────────────────────────────────────────────────────────
 
   const pushObstacles = useCallback((data: Obstacle[], passive: boolean) => {
     if (!readyRef.current) return;
@@ -139,10 +221,10 @@ export default function MapView() {
   }, [pushObstacles]);
 
   useEffect(() => {
-    if (currentBoundsRef.current) {
-      loadObstacles(currentBoundsRef.current, showPassive);
-    }
+    if (currentBoundsRef.current) loadObstacles(currentBoundsRef.current, showPassive);
   }, [showPassive, loadObstacles]);
+
+  // ── WebView messages ───────────────────────────────────────────────────────
 
   const handleMessage = useCallback((event: any) => {
     try {
@@ -153,61 +235,132 @@ export default function MapView() {
         const bbox = { north: msg.north, south: msg.south, east: msg.east, west: msg.west };
         currentBoundsRef.current = bbox;
         loadObstacles(bbox, showPassiveRef.current);
+      } else if (msg.type === 'PIN_DROPPED') {
+        (async () => {
+          const coordLabel = `${(msg.lat as number).toFixed(5)}, ${(msg.lng as number).toFixed(5)}`;
+          const point: MapPoint = { lat: msg.lat, lng: msg.lng, label: coordLabel };
+          if (msg.kind === 'origin') { setOrigin(point); setOriginQ(coordLabel); }
+          else                        { setDest(point);   setDestQ(coordLabel);   }
+          setPinModeState(null);
+          webViewRef.current?.injectJavaScript(`window.fitBothPoints(); true;`);
+          try {
+            const res = await fetch(
+              `https://nominatim.openstreetmap.org/reverse?lat=${msg.lat}&lon=${msg.lng}&format=json&accept-language=en`,
+              { headers: { 'User-Agent': 'AccessMap/1.0' } },
+            );
+            if (res.ok) {
+              const data = await res.json();
+              const short = ((data.display_name ?? coordLabel) as string).split(',').slice(0, 3).join(',').trim();
+              const named: MapPoint = { lat: msg.lat, lng: msg.lng, label: short };
+              if (msg.kind === 'origin') { setOrigin(named); setOriginQ(short); }
+              else                        { setDest(named);   setDestQ(short);   }
+            }
+          } catch {}
+        })();
       }
     } catch {}
   }, [loadObstacles]);
 
-  const handleSearch = async () => {
-    const q = query.trim();
-    if (!q) return;
-    setSearchLoading(true);
+  // ── Search ─────────────────────────────────────────────────────────────────
+
+  const searchAndSet = useCallback(async (q: string, kind: 'origin' | 'dest') => {
+    if (!q.trim()) return;
+    const results = await searchLocations(q.trim());
+    if (!results.length) return;
+    const r = results[0];
+    const point: MapPoint = { lat: r.latitude, lng: r.longitude, label: r.name };
+    if (kind === 'origin') {
+      setOrigin(point); setOriginQ(r.name);
+      webViewRef.current?.injectJavaScript(`window.setOrigin(${r.latitude}, ${r.longitude}); true;`);
+      webViewRef.current?.injectJavaScript(`window.flyTo(${r.latitude}, ${r.longitude}, 17); true;`);
+    } else {
+      setDest(point); setDestQ(r.name);
+      webViewRef.current?.injectJavaScript(`window.setDest(${r.latitude}, ${r.longitude}); true;`);
+      webViewRef.current?.injectJavaScript(`window.flyTo(${r.latitude}, ${r.longitude}, 17); true;`);
+    }
+  }, []);
+
+  // ── GPS / current location ─────────────────────────────────────────────────
+
+  const handleUseCurrentLocation = async () => {
+    setLocLoading(true);
+    setRouteError(null);
     try {
-      const results = await searchLocations(q);
-      if (results.length > 0) {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== 'granted') { setRouteError('Location permission denied.'); return; }
+      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+      const { latitude, longitude } = loc.coords;
+      const label = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+      setOrigin({ lat: latitude, lng: longitude, label });
+      setOriginQ(label);
+      webViewRef.current?.injectJavaScript(`window.setOrigin(${latitude}, ${longitude}); true;`);
+      webViewRef.current?.injectJavaScript(`window.flyTo(${latitude}, ${longitude}, 17); true;`);
+      try {
+        const res = await fetch(
+          `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json&accept-language=en`,
+          { headers: { 'User-Agent': 'AccessMap/1.0' } },
+        );
+        if (res.ok) {
+          const data = await res.json();
+          const short = ((data.display_name ?? label) as string).split(',').slice(0, 3).join(',').trim();
+          setOrigin({ lat: latitude, lng: longitude, label: short });
+          setOriginQ(short);
+        }
+      } catch {}
+    } catch { setRouteError('Could not get your location.'); }
+    finally { setLocLoading(false); }
+  };
+
+  // ── Pin mode ───────────────────────────────────────────────────────────────
+
+  const activatePinMode = (kind: 'origin' | 'dest') => {
+    const next = pinMode === kind ? null : kind;
+    setPinModeState(next);
+    webViewRef.current?.injectJavaScript(`window.setPinMode(${next ? `'${next}'` : 'null'}); true;`);
+  };
+
+  // ── Route calculation ──────────────────────────────────────────────────────
+
+  const doCalculate = useCallback(async (guestPrefs?: GuestPreferences) => {
+    if (!origin || !dest) return;
+    setShowPrefs(false);
+    setRouteLoading(true);
+    setRouteError(null);
+    setRoute(null);
+    webViewRef.current?.injectJavaScript(`window.clearRoute(); true;`);
+    const result = await calculateRoute({
+      originLat: origin.lat, originLng: origin.lng,
+      destinationLat: dest.lat, destinationLng: dest.lng,
+      preferences: guestPrefs,
+    });
+    setRouteLoading(false);
+    if (result) {
+      setRoute(result);
+      if (result.waypoints.length > 1) {
         webViewRef.current?.injectJavaScript(
-          `window.flyTo(${results[0].latitude}, ${results[0].longitude}, 18); true;`
+          `window.showRoute(${JSON.stringify(JSON.stringify(result.waypoints))}); true;`
         );
       }
-    } finally {
-      setSearchLoading(false);
+    } else {
+      setRouteError('Could not calculate route. Please try again.');
     }
-  };
+  }, [origin, dest]);
+
+  const handleGetRoute = useCallback(() => {
+    if (!origin || !dest) { setRouteError('Please set both origin and destination.'); return; }
+    if (isLoggedIn()) doCalculate();
+    else setShowPrefs(true);
+  }, [origin, dest, doCalculate]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
     <View style={s.container}>
-      <View style={s.toolbar}>
-        <View style={s.searchWrap}>
-          <Ionicons name="search-outline" size={16} color={COLORS.gray400} />
-          <TextInput
-            style={s.searchInput}
-            placeholder="Search campus locations…"
-            placeholderTextColor={COLORS.gray400}
-            value={query}
-            onChangeText={setQuery}
-            onSubmitEditing={handleSearch}
-            returnKeyType="search"
-          />
-          {searchLoading ? (
-            <ActivityIndicator size="small" color={COLORS.green600} />
-          ) : query.length > 0 ? (
-            <TouchableOpacity onPress={handleSearch} style={s.searchGoBtn}>
-              <Ionicons name="arrow-forward-circle" size={28} color={COLORS.green700} />
-            </TouchableOpacity>
-          ) : null}
-        </View>
 
-        <TouchableOpacity
-          style={[s.passiveChip, showPassive && s.passiveChipActive]}
-          onPress={() => setShowPassive((v) => !v)}
-        >
-          <View style={[s.chipDot, showPassive && s.chipDotActive]} />
-          <Text style={[s.chipText, showPassive && s.chipTextActive]}>Passive</Text>
-        </TouchableOpacity>
-      </View>
-
+      {/* Full-screen map */}
       <WebView
         ref={webViewRef}
-        style={s.map}
+        style={StyleSheet.absoluteFill}
         source={source}
         onMessage={handleMessage}
         originWhitelist={['*']}
@@ -221,38 +374,378 @@ export default function MapView() {
         )}
       />
 
+      {/* ── Search overlay ── */}
+      <View style={s.searchOverlay} pointerEvents="box-none">
+        {!searchExpanded ? (
+
+          /* Collapsed state */
+          <View style={s.collapsedRow} pointerEvents="box-none">
+            <TouchableOpacity
+              style={s.searchBarCollapsed}
+              onPress={() => setSearchExpanded(true)}
+              activeOpacity={0.9}
+            >
+              <Ionicons name="search-outline" size={16} color={COLORS.gray400} />
+              <Text style={s.searchPlaceholder}>Search for a location</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[s.passiveChip, showPassive && s.passiveChipActive]}
+              onPress={() => setShowPassive(v => !v)}
+            >
+              <View style={[s.chipDot, showPassive && s.chipDotActive]} />
+              <Text style={[s.chipText, showPassive && s.chipTextActive]}>Passive</Text>
+            </TouchableOpacity>
+          </View>
+
+        ) : (
+
+          /* Expanded state */
+          <View style={s.expandedCard}>
+            <View style={s.expandedHeader}>
+              <Ionicons name="navigate-circle-outline" size={18} color={COLORS.green600} />
+              <Text style={s.expandedTitle}>Plan Route</Text>
+              <TouchableOpacity style={s.collapseBtn} onPress={() => setSearchExpanded(false)}>
+                <Ionicons name="chevron-up-outline" size={20} color={COLORS.gray500} />
+              </TouchableOpacity>
+            </View>
+
+            {/* Origin row */}
+            <View style={s.inputRow}>
+              <View style={[s.dot, s.dotOrigin]} />
+              <TextInput
+                style={s.input}
+                placeholder="Origin"
+                placeholderTextColor={COLORS.gray400}
+                value={originQ}
+                onChangeText={t => { setOriginQ(t); setRouteError(null); }}
+                onSubmitEditing={() => searchAndSet(originQ, 'origin')}
+                returnKeyType="search"
+              />
+              {locLoading ? (
+                <ActivityIndicator size="small" color={COLORS.blue600} style={s.iconBtn} />
+              ) : (
+                <TouchableOpacity style={s.iconBtn} onPress={handleUseCurrentLocation}>
+                  <Ionicons name="locate-outline" size={19} color={COLORS.blue600} />
+                </TouchableOpacity>
+              )}
+              <TouchableOpacity
+                style={[s.pinBtn, pinMode === 'origin' && s.pinBtnActive]}
+                onPress={() => activatePinMode('origin')}
+              >
+                <Ionicons name="location-outline" size={18} color={pinMode === 'origin' ? COLORS.green700 : COLORS.gray400} />
+              </TouchableOpacity>
+            </View>
+
+            <View style={s.connector}><View style={s.connectorLine} /></View>
+
+            {/* Destination row */}
+            <View style={s.inputRow}>
+              <View style={[s.dot, s.dotDest]} />
+              <TextInput
+                style={s.input}
+                placeholder="Destination"
+                placeholderTextColor={COLORS.gray400}
+                value={destQ}
+                onChangeText={t => { setDestQ(t); setRouteError(null); }}
+                onSubmitEditing={() => searchAndSet(destQ, 'dest')}
+                returnKeyType="search"
+              />
+              <TouchableOpacity
+                style={[s.pinBtn, pinMode === 'dest' && s.pinBtnActive]}
+                onPress={() => activatePinMode('dest')}
+              >
+                <Ionicons name="location-outline" size={18} color={pinMode === 'dest' ? COLORS.red500 : COLORS.gray400} />
+              </TouchableOpacity>
+            </View>
+
+            {/* Pin mode hint */}
+            {pinMode && (
+              <View style={s.pinHintRow}>
+                <Ionicons name="finger-print-outline" size={13} color={COLORS.green700} />
+                <Text style={s.pinHintText}>Tap map to set {pinMode === 'origin' ? 'origin' : 'destination'}</Text>
+                <TouchableOpacity onPress={() => activatePinMode(pinMode)}>
+                  <Ionicons name="close-outline" size={16} color={COLORS.gray400} />
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {/* Get Route */}
+            <TouchableOpacity
+              style={[s.routeBtn, (!origin || !dest) && s.routeBtnDisabled]}
+              onPress={handleGetRoute}
+              disabled={routeLoading}
+              activeOpacity={0.8}
+            >
+              {routeLoading ? (
+                <ActivityIndicator size="small" color={COLORS.white} />
+              ) : (
+                <>
+                  <Ionicons name="navigate-outline" size={16} color={COLORS.white} />
+                  <Text style={s.routeBtnText}>Get Route</Text>
+                </>
+              )}
+            </TouchableOpacity>
+
+            {routeError && (
+              <View style={s.errorRow}>
+                <Ionicons name="alert-circle-outline" size={14} color={COLORS.red500} />
+                <Text style={s.errorText}>{routeError}</Text>
+              </View>
+            )}
+
+            {/* Passive toggle */}
+            <TouchableOpacity
+              style={[s.passiveRow, showPassive && s.passiveRowActive]}
+              onPress={() => setShowPassive(v => !v)}
+              activeOpacity={0.8}
+            >
+              <View style={[s.chipDot, showPassive && s.chipDotActive]} />
+              <Text style={[s.chipText, showPassive && s.chipTextActive]}>Show passive obstacles</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+
+      {/* ── Route summary (bottom card) ── */}
+      {route && !showPrefs && (
+        <View style={s.summaryCard}>
+          <View style={s.summaryRow}>
+            <View style={s.summaryItem}>
+              <Ionicons name="walk-outline" size={18} color={COLORS.green700} />
+              <Text style={s.summaryValue}>{formatDistance(route.distanceMeters)}</Text>
+              <Text style={s.summaryLabel}>Distance</Text>
+            </View>
+            <View style={s.summaryDivider} />
+            <View style={s.summaryItem}>
+              <Ionicons name="time-outline" size={18} color={COLORS.green700} />
+              <Text style={s.summaryValue}>{formatTime(route.estimatedTimeSeconds)}</Text>
+              <Text style={s.summaryLabel}>Est. time</Text>
+            </View>
+            <View style={s.summaryDivider} />
+            <View style={s.summaryItem}>
+              <Ionicons name="shield-checkmark-outline" size={18} color={COLORS.green700} />
+              <Text style={s.summaryValue}>{route.avoidedObstaclesCount ?? 0}</Text>
+              <Text style={s.summaryLabel}>Avoided</Text>
+            </View>
+          </View>
+          {route.warnings && route.warnings.length > 0 && (
+            <View style={s.warningsBox}>
+              {route.warnings.map((w, i) => (
+                <View key={i} style={s.warningRow}>
+                  <Ionicons name="warning-outline" size={13} color={COLORS.orange500} />
+                  <Text style={s.warningText}>{w}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* ── Guest preferences overlay ── */}
+      {showPrefs && (
+        <View style={s.overlay}>
+          <View style={s.prefsCard}>
+            <Text style={s.prefsTitle}>Route Preferences</Text>
+            <Text style={s.prefsSubtitle}>
+              Sign in to save your profile. For now, set your preferences below.
+            </Text>
+            <View style={s.prefRow}>
+              <View style={s.prefLabel}>
+                <Ionicons name="footsteps-outline" size={16} color={COLORS.gray700} />
+                <Text style={s.prefLabelText}>Avoid stairs</Text>
+              </View>
+              <Switch
+                value={prefs.avoidStairs}
+                onValueChange={v => setPrefs(p => ({ ...p, avoidStairs: v }))}
+                trackColor={{ false: COLORS.gray200, true: COLORS.green400 }}
+                thumbColor={COLORS.white}
+              />
+            </View>
+            <View style={s.prefRow}>
+              <View style={s.prefLabel}>
+                <Ionicons name="trending-up-outline" size={16} color={COLORS.gray700} />
+                <Text style={s.prefLabelText}>Avoid steep slopes</Text>
+              </View>
+              <Switch
+                value={prefs.avoidSteepSlopes}
+                onValueChange={v => setPrefs(p => ({ ...p, avoidSteepSlopes: v }))}
+                trackColor={{ false: COLORS.gray200, true: COLORS.green400 }}
+                thumbColor={COLORS.white}
+              />
+            </View>
+            <View style={s.prefRow}>
+              <View style={s.prefLabel}>
+                <Ionicons name="speedometer-outline" size={16} color={COLORS.gray700} />
+                <Text style={s.prefLabelText}>Max slope gradient (%)</Text>
+              </View>
+              <TextInput
+                style={s.slopeInput}
+                keyboardType="numeric"
+                value={String(prefs.maxSlopeGradient)}
+                onChangeText={v => {
+                  const n = parseInt(v, 10);
+                  if (!isNaN(n) && n >= 1 && n <= 30) setPrefs(p => ({ ...p, maxSlopeGradient: n }));
+                }}
+              />
+            </View>
+            <TouchableOpacity style={s.prefsCalcBtn} onPress={() => doCalculate(prefs)}>
+              <Ionicons name="navigate-outline" size={16} color={COLORS.white} />
+              <Text style={s.prefsCalcBtnText}>Calculate Route</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={s.prefsCancelBtn} onPress={() => setShowPrefs(false)}>
+              <Text style={s.prefsCancelText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
     </View>
   );
 }
 
+// ── Styles ────────────────────────────────────────────────────────────────────
+
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: COLORS.white },
-  toolbar: {
-    flexDirection: 'row', alignItems: 'center', gap: 10,
-    paddingHorizontal: 12, paddingVertical: 10,
-    backgroundColor: COLORS.white, borderBottomWidth: 1, borderBottomColor: COLORS.gray200,
+  mapLoading: { ...StyleSheet.absoluteFillObject, alignItems: 'center', justifyContent: 'center', backgroundColor: COLORS.white },
+
+  // Search overlay
+  searchOverlay: {
+    position: 'absolute', top: 12, left: 12, right: 12, zIndex: 10,
   },
-  searchWrap: {
+  collapsedRow: { flexDirection: 'row', gap: 8, alignItems: 'center' },
+  searchBarCollapsed: {
     flex: 1, flexDirection: 'row', alignItems: 'center', gap: 8,
-    height: 42, backgroundColor: COLORS.gray100, borderRadius: 10,
-    paddingHorizontal: 12, borderWidth: 1, borderColor: COLORS.gray200,
+    height: 44, backgroundColor: COLORS.white, borderRadius: 12,
+    paddingHorizontal: 14, borderWidth: 1, borderColor: COLORS.gray200,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1, shadowRadius: 6, elevation: 4,
   },
-  searchInput: { flex: 1, height: 42, fontSize: 14, color: COLORS.gray800, paddingHorizontal: 4 },
-  searchGoBtn: { padding: 2 },
+  searchPlaceholder: { flex: 1, fontSize: 14, color: COLORS.gray400 },
+
+  // Expanded card
+  expandedCard: {
+    backgroundColor: COLORS.white, borderRadius: 14, padding: 14,
+    borderWidth: 1, borderColor: COLORS.gray200,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.12, shadowRadius: 8, elevation: 6,
+    gap: 4,
+  },
+  expandedHeader: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 },
+  expandedTitle: { flex: 1, fontSize: 14, fontWeight: '700', color: COLORS.gray800 },
+  collapseBtn: { padding: 2 },
+
+  // Input rows
+  inputRow: { flexDirection: 'row', alignItems: 'center', height: 44, gap: 8 },
+  dot: {
+    width: 11, height: 11, borderRadius: 6, borderWidth: 2.5, borderColor: COLORS.white,
+    flexShrink: 0, shadowColor: '#000', shadowOpacity: 0.2, shadowRadius: 2, elevation: 2,
+  },
+  dotOrigin: { backgroundColor: COLORS.green700 },
+  dotDest:   { backgroundColor: COLORS.red500 },
+  connector: { paddingLeft: 4, height: 8, justifyContent: 'center' },
+  connectorLine: { width: 1, height: 8, backgroundColor: COLORS.gray300, marginLeft: 4 },
+  input: {
+    flex: 1, height: 40, backgroundColor: COLORS.gray100,
+    borderRadius: 9, paddingHorizontal: 12, fontSize: 14,
+    color: COLORS.gray800, borderWidth: 1, borderColor: COLORS.gray200,
+  },
+  iconBtn: { width: 36, height: 36, alignItems: 'center', justifyContent: 'center' },
+  pinBtn: {
+    width: 36, height: 36, borderRadius: 9, borderWidth: 1,
+    borderColor: COLORS.gray200, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: COLORS.white, flexShrink: 0,
+  },
+  pinBtnActive: { borderColor: COLORS.green500, backgroundColor: COLORS.green50 },
+
+  // Pin hint
+  pinHintRow: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    backgroundColor: COLORS.green50, borderRadius: 8,
+    paddingHorizontal: 10, paddingVertical: 6,
+  },
+  pinHintText: { flex: 1, fontSize: 12, color: COLORS.green700, fontWeight: '500' },
+
+  // Route button
+  routeBtn: {
+    marginTop: 4, height: 44, borderRadius: 11, backgroundColor: COLORS.green700,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
+  },
+  routeBtnDisabled: { backgroundColor: COLORS.gray300 },
+  routeBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
+  errorRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  errorText: { fontSize: 12, color: COLORS.red500, flex: 1 },
+
+  // Passive toggle (in expanded card)
+  passiveRow: {
+    flexDirection: 'row', alignItems: 'center', gap: 7,
+    paddingVertical: 7, paddingHorizontal: 4,
+  },
+  passiveRowActive: {},
+
+  // Passive chip (collapsed)
   passiveChip: {
-    flexDirection: 'row', alignItems: 'center', gap: 6, height: 42,
-    paddingHorizontal: 14, borderRadius: 10, borderWidth: 1.5,
+    flexDirection: 'row', alignItems: 'center', gap: 6, height: 44,
+    paddingHorizontal: 12, borderRadius: 12, borderWidth: 1.5,
     borderColor: COLORS.gray200, backgroundColor: COLORS.white,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1, shadowRadius: 6, elevation: 4,
   },
   passiveChipActive: { borderColor: COLORS.green500, backgroundColor: COLORS.green50 },
   chipDot: { width: 7, height: 7, borderRadius: 4, backgroundColor: COLORS.gray300 },
   chipDotActive: { backgroundColor: COLORS.green500 },
   chipText: { fontSize: 12, fontWeight: '600', color: COLORS.gray500 },
   chipTextActive: { color: COLORS.green700 },
-  loadingBar: {
-    position: 'absolute', left: 0, right: 0, bottom: 0, zIndex: 10,
-    height: 3, backgroundColor: COLORS.green500,
+
+  // Route summary card
+  summaryCard: {
+    position: 'absolute', bottom: 0, left: 0, right: 0,
+    backgroundColor: COLORS.white, borderTopWidth: 1, borderTopColor: COLORS.gray200,
+    paddingHorizontal: 16, paddingVertical: 14,
+    shadowColor: '#000', shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.08, shadowRadius: 8, elevation: 6,
   },
-  map: { flex: 1 },
-  mapLoading: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  summaryRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around' },
+  summaryItem: { alignItems: 'center', gap: 3, flex: 1 },
+  summaryDivider: { width: 1, height: 36, backgroundColor: COLORS.gray200 },
+  summaryValue: { fontSize: 16, fontWeight: '700', color: COLORS.gray800 },
+  summaryLabel: { fontSize: 11, color: COLORS.gray400, fontWeight: '500' },
+  warningsBox: {
+    marginTop: 10, backgroundColor: COLORS.orange100,
+    borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8, gap: 4,
+  },
+  warningRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 6 },
+  warningText: { flex: 1, fontSize: 12, color: COLORS.gray700, lineHeight: 17 },
+
+  // Guest prefs overlay
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    alignItems: 'center', justifyContent: 'center', zIndex: 2000,
+  },
+  prefsCard: {
+    width: '90%', maxWidth: 400, backgroundColor: COLORS.white,
+    borderRadius: 16, padding: 24, gap: 16,
+    shadowColor: '#000', shadowOpacity: 0.25, shadowRadius: 16, elevation: 10,
+  },
+  prefsTitle: { fontSize: 18, fontWeight: '700', color: COLORS.gray800 },
+  prefsSubtitle: { fontSize: 13, color: COLORS.gray500, lineHeight: 18, marginTop: -8 },
+  prefRow: {
+    flexDirection: 'row', alignItems: 'center',
+    justifyContent: 'space-between', paddingVertical: 4,
+  },
+  prefLabel: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  prefLabelText: { fontSize: 14, color: COLORS.gray700, fontWeight: '500' },
+  slopeInput: {
+    width: 56, height: 36, borderRadius: 8,
+    borderWidth: 1.5, borderColor: COLORS.gray300,
+    textAlign: 'center', fontSize: 15, fontWeight: '600', color: COLORS.gray800,
+  },
+  prefsCalcBtn: {
+    height: 46, borderRadius: 11, backgroundColor: COLORS.green700,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+    gap: 8, marginTop: 4,
+  },
+  prefsCalcBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
+  prefsCancelBtn: { alignItems: 'center', paddingVertical: 4 },
+  prefsCancelText: { fontSize: 14, color: COLORS.gray400 },
 });

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -4,11 +4,13 @@ import 'leaflet/dist/leaflet.css';
 
 import L from 'leaflet';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, StyleSheet, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Switch, Text, TextInput, TouchableOpacity, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { CircleMarker, MapContainer, Marker, Popup, TileLayer, ZoomControl, useMapEvents } from 'react-leaflet';
+import { CircleMarker, MapContainer, Marker, Polyline, Popup, TileLayer, ZoomControl, useMap, useMapEvents } from 'react-leaflet';
 
 import { fetchObstacleDetail, fetchObstacles, searchLocations, type Obstacle, type ObstacleDetail } from '../../api/map';
+import { calculateRoute, type GuestPreferences, type RouteResult } from '../../api/routes';
+import { isLoggedIn } from '../../services/auth';
 import { COLORS } from '../../constants/theme';
 
 // Fix default Leaflet marker icons (broken in bundler environments)
@@ -21,8 +23,9 @@ L.Icon.Default.mergeOptions({
 
 const BOUN_CENTER: [number, number] = [41.0847, 29.0503];
 const DEFAULT_ZOOM = 16;
-// INDOOR obstacles are only shown above this zoom level
 const HIGH_DETAIL_ZOOM = 18;
+
+// ── Colors ───────────────────────────────────────────────────────────────────
 
 const CATEGORY_COLOR: Record<string, string> = {
   BROKEN_RAMP: COLORS.red500,
@@ -34,69 +37,96 @@ const CATEGORY_COLOR: Record<string, string> = {
 };
 
 const STATUS_LABEL: Record<string, string> = {
-  UNVERIFIED: 'Unverified',
-  PASSIVE: 'Passive',
-  VERIFIED: 'Verified',
-  RESOLVED_AWAITING_VALIDATION: 'Awaiting Validation',
-  CLOSED: 'Closed',
+  UNVERIFIED: 'Unverified', PASSIVE: 'Passive', VERIFIED: 'Verified',
+  RESOLVED_AWAITING_VALIDATION: 'Awaiting Validation', CLOSED: 'Closed',
 };
 
 const STATUS_COLOR: Record<string, string> = {
-  UNVERIFIED: COLORS.gray400,
-  PASSIVE: COLORS.gray400,
-  VERIFIED: COLORS.green500,
-  RESOLVED_AWAITING_VALIDATION: COLORS.blue500,
-  CLOSED: COLORS.gray500,
+  UNVERIFIED: COLORS.gray400, PASSIVE: COLORS.gray400,
+  VERIFIED: COLORS.green500, RESOLVED_AWAITING_VALIDATION: COLORS.blue500, CLOSED: COLORS.gray500,
 };
 
-// ── Sub-components (must live inside MapContainer) ──────────────────────────
+// ── Leaflet icon helpers ──────────────────────────────────────────────────────
 
-function BoundsWatcher({
-  onChange,
-}: {
-  onChange: (b: L.LatLngBounds, z: number) => void;
-}) {
+const makeCircleIcon = (color: string) =>
+  L.divIcon({
+    html: `<div style="width:14px;height:14px;border-radius:50%;background:${color};border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,0.35)"></div>`,
+    className: '', iconSize: [14, 14], iconAnchor: [7, 7],
+  });
+
+const ORIGIN_ICON = makeCircleIcon(COLORS.green700);
+const DEST_ICON   = makeCircleIcon(COLORS.red500);
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatDistance(m: number): string {
+  return m >= 1000 ? `${(m / 1000).toFixed(1)} km` : `${Math.round(m)} m`;
+}
+function formatTime(sec: number): string {
+  const mins = Math.round(sec / 60);
+  if (mins < 60) return `${mins} min`;
+  const h = Math.floor(mins / 60), rem = mins % 60;
+  return rem > 0 ? `${h}h ${rem}min` : `${h}h`;
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface MapPoint { lat: number; lng: number; label: string; }
+
+// ── Sub-components (must live inside MapContainer) ───────────────────────────
+
+function BoundsWatcher({ onChange }: { onChange: (b: L.LatLngBounds, z: number) => void }) {
   const map = useMapEvents({
     moveend: () => onChange(map.getBounds(), map.getZoom()),
     zoomend: () => onChange(map.getBounds(), map.getZoom()),
   });
+  useEffect(() => { onChange(map.getBounds(), map.getZoom()); }, []);
+  return null;
+}
+
+function PinDropper({ active, onDrop }: { active: boolean; onDrop: (ll: L.LatLng) => void }) {
+  useMapEvents({ click: (e) => { if (active) onDrop(e.latlng); } });
+  return null;
+}
+
+function FitBounds({ origin, dest }: { origin: [number, number] | null; dest: [number, number] | null }) {
+  const map = useMap();
+  const prevBothSet = useRef(false);
   useEffect(() => {
-    onChange(map.getBounds(), map.getZoom());
-  }, []);
+    const bothSet = origin !== null && dest !== null;
+    if (bothSet && !prevBothSet.current) {
+      map.fitBounds([origin, dest], { padding: [60, 60] });
+    }
+    prevBothSet.current = bothSet;
+  }, [origin, dest]);
   return null;
 }
 
-function PinDropper({ onDrop }: { onDrop: (ll: L.LatLng) => void }) {
-  useMapEvents({ click: (e) => onDrop(e.latlng) });
+function FlyToPoint({ point }: { point: [number, number] | null }) {
+  const map = useMap();
+  const prev = useRef<string>('');
+  useEffect(() => {
+    if (!point) return;
+    const key = `${point[0]},${point[1]}`;
+    if (key === prev.current) return;
+    prev.current = key;
+    map.flyTo(point, 17);
+  }, [point]);
   return null;
 }
 
-// ── Popup content ───────────────────────────────────────────────────────────
+// ── Obstacle popup ────────────────────────────────────────────────────────────
 
-function ObstaclePopup({
-  obs,
-  detail,
-  loading,
-}: {
-  obs: Obstacle;
-  detail: ObstacleDetail | undefined;
-  loading: boolean;
-}) {
+function ObstaclePopup({ obs, detail, loading }: { obs: Obstacle; detail: ObstacleDetail | undefined; loading: boolean }) {
   const color = CATEGORY_COLOR[obs.category] ?? COLORS.gray500;
   const statusColor = STATUS_COLOR[obs.status] ?? COLORS.gray400;
-
   return (
     <div style={{ minWidth: 200, maxWidth: 240, fontFamily: 'system-ui, sans-serif' }}>
       {detail?.photos?.[0] && (
-        <img
-          src={detail.photos[0].imageUrl}
-          alt="obstacle"
-          style={{ width: '100%', height: 110, objectFit: 'cover', borderRadius: 4, marginBottom: 8, display: 'block' }}
-        />
+        <img src={detail.photos[0].imageUrl} alt="obstacle"
+          style={{ width: '100%', height: 110, objectFit: 'cover', borderRadius: 4, marginBottom: 8, display: 'block' }} />
       )}
-
       <strong style={{ fontSize: 13, display: 'block', marginBottom: 6 }}>{obs.title}</strong>
-
       <div style={{ display: 'flex', gap: 5, flexWrap: 'wrap', marginBottom: 6 }}>
         <span style={{ background: color, color: '#fff', borderRadius: 4, padding: '2px 7px', fontSize: 11, fontWeight: 600 }}>
           {obs.category.replace(/_/g, ' ')}
@@ -105,14 +135,8 @@ function ObstaclePopup({
           {STATUS_LABEL[obs.status] ?? obs.status}
         </span>
       </div>
-
-      {obs.description ? (
-        <p style={{ margin: '0 0 6px', fontSize: 12, color: '#444', lineHeight: 1.4 }}>{obs.description}</p>
-      ) : null}
-
-      {loading && (
-        <div style={{ color: '#888', fontSize: 11, marginTop: 4 }}>Loading details…</div>
-      )}
+      {obs.description ? <p style={{ margin: '0 0 6px', fontSize: 12, color: '#444', lineHeight: 1.4 }}>{obs.description}</p> : null}
+      {loading && <div style={{ color: '#888', fontSize: 11, marginTop: 4 }}>Loading details…</div>}
       {!loading && detail && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#555', fontSize: 12, marginTop: 4, borderTop: '1px solid #eee', paddingTop: 6 }}>
           <span>👍 {detail.upvoteCount ?? 0} upvote{detail.upvoteCount !== 1 ? 's' : ''}</span>
@@ -122,122 +146,172 @@ function ObstaclePopup({
   );
 }
 
-// ── Main component ──────────────────────────────────────────────────────────
+// ── Main component ────────────────────────────────────────────────────────────
 
 export default function MapView() {
   const mapRef = useRef<L.Map | null>(null);
 
-  const [obstacles, setObstacles] = useState<Obstacle[]>([]);
-  const [loading, setLoading] = useState(false);
+  // Obstacle state
+  const [obstacles, setObstacles]   = useState<Obstacle[]>([]);
   const [showPassive, setShowPassive] = useState(false);
-  const [currentBounds, setCurrentBounds] = useState<L.LatLngBounds | null>(null);
-  const [zoom, setZoom] = useState(DEFAULT_ZOOM);
+  const [zoom, setZoom]               = useState(DEFAULT_ZOOM);
+  const [boundsKey, setBoundsKey]     = useState('');
+  const [detailMap, setDetailMap]     = useState<Record<string, ObstacleDetail | 'loading'>>({});
 
-  const [droppedPin, setDroppedPin] = useState<L.LatLng | null>(null);
-  const [query, setQuery] = useState('');
-  const [searchLoading, setSearchLoading] = useState(false);
-  const [boundsKey, setBoundsKey] = useState('');
+  // Search / route state
+  const [searchExpanded, setSearchExpanded] = useState(false);
+  const [originQ, setOriginQ] = useState('');
+  const [destQ,   setDestQ]   = useState('');
+  const [origin, setOrigin]   = useState<MapPoint | null>(null);
+  const [dest,   setDest]     = useState<MapPoint | null>(null);
+  const [pinMode, setPinMode] = useState<'origin' | 'dest' | null>(null);
+  const [flyTarget, setFlyTarget] = useState<[number, number] | null>(null);
 
-  // Detail cache stored in state so updates trigger re-renders
-  const [detailMap, setDetailMap] = useState<Record<string, ObstacleDetail | 'loading'>>({});
+  const [route,        setRoute]        = useState<RouteResult | null>(null);
+  const [routeLoading, setRouteLoading] = useState(false);
+  const [routeError,   setRouteError]   = useState<string | null>(null);
+  const [showPrefs,    setShowPrefs]    = useState(false);
+  const [prefs, setPrefs] = useState<GuestPreferences>({
+    avoidStairs: true, avoidSteepSlopes: false, maxSlopeGradient: 8,
+  });
+  const [locLoading, setLocLoading] = useState(false);
 
-  // Re-fetch whenever viewport or passive toggle changes
+  // ── Obstacles ──────────────────────────────────────────────────────────────
+
   useEffect(() => {
-    if (!currentBounds) return;
+    if (!boundsKey) return;
+    // boundsKey encodes north,south,east,west
+    const [north, south, east, west] = boundsKey.split(',').map(Number);
     let cancelled = false;
-    setLoading(true);
-    fetchObstacles(
-      {
-        north: currentBounds.getNorth(),
-        south: currentBounds.getSouth(),
-        east: currentBounds.getEast(),
-        west: currentBounds.getWest(),
-      },
-      showPassive,
-    ).then((data) => {
-      if (!cancelled) {
-        setObstacles(data);
-        setLoading(false);
-      }
+    fetchObstacles({ north, south, east, west }, showPassive).then(data => {
+      if (!cancelled) setObstacles(data);
     });
     return () => { cancelled = true; };
   }, [boundsKey, showPassive]);
 
   const handleBoundsChange = useCallback((b: L.LatLngBounds, z: number) => {
-    setCurrentBounds(b);
     setZoom(z);
-    const key = `${b.getNorth().toFixed(4)},${b.getSouth().toFixed(4)},${b.getEast().toFixed(4)},${b.getWest().toFixed(4)}`;
-    setBoundsKey(key);
+    setBoundsKey(`${b.getNorth().toFixed(4)},${b.getSouth().toFixed(4)},${b.getEast().toFixed(4)},${b.getWest().toFixed(4)}`);
   }, []);
 
   const handlePinClick = useCallback(async (id: string) => {
-    setDetailMap((prev: Record<string, ObstacleDetail | 'loading'>) => {
-      if (prev[id]) return prev; // already loading or cached
+    setDetailMap(prev => {
+      if (prev[id]) return prev;
       return { ...prev, [id]: 'loading' };
     });
-
     const detail = await fetchObstacleDetail(id);
-    setDetailMap((prev: Record<string, ObstacleDetail | 'loading'>) => {
-      if (!detail) {
-        // allow retry: remove the loading entry
-        const next = { ...prev };
-        delete next[id];
-        return next;
-      }
+    setDetailMap(prev => {
+      if (!detail) { const next = { ...prev }; delete next[id]; return next; }
       return { ...prev, [id]: detail };
     });
   }, []);
 
-  const handleSearch = async () => {
-    const q = query.trim();
-    if (!q) return;
-    setSearchLoading(true);
+  // ── Search ─────────────────────────────────────────────────────────────────
+
+  const searchAndSet = useCallback(async (q: string, kind: 'origin' | 'dest') => {
+    if (!q.trim()) return;
+    const results = await searchLocations(q.trim());
+    if (!results.length) return;
+    const r = results[0];
+    const point: MapPoint = { lat: r.latitude, lng: r.longitude, label: r.name };
+    if (kind === 'origin') { setOrigin(point); setOriginQ(r.name); }
+    else                   { setDest(point);   setDestQ(r.name);   }
+    setFlyTarget([r.latitude, r.longitude]);
+    setRouteError(null);
+  }, []);
+
+  // ── GPS / current location (web: browser geolocation) ─────────────────────
+
+  const handleUseCurrentLocation = useCallback(() => {
+    if (!navigator.geolocation) { setRouteError('Geolocation not supported by your browser.'); return; }
+    setLocLoading(true);
+    setRouteError(null);
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        const { latitude, longitude } = pos.coords;
+        const label = `${latitude.toFixed(5)}, ${longitude.toFixed(5)}`;
+        setOrigin({ lat: latitude, lng: longitude, label });
+        setOriginQ(label);
+        setFlyTarget([latitude, longitude]);
+        try {
+          const res = await fetch(
+            `https://nominatim.openstreetmap.org/reverse?lat=${latitude}&lon=${longitude}&format=json&accept-language=en`,
+            { headers: { 'User-Agent': 'AccessMap/1.0' } },
+          );
+          if (res.ok) {
+            const data = await res.json();
+            const short = ((data.display_name ?? label) as string).split(',').slice(0, 3).join(',').trim();
+            setOrigin({ lat: latitude, lng: longitude, label: short });
+            setOriginQ(short);
+          }
+        } catch {}
+        setLocLoading(false);
+      },
+      () => { setRouteError('Could not get your location.'); setLocLoading(false); },
+      { enableHighAccuracy: true, timeout: 10000 },
+    );
+  }, []);
+
+  // ── Pin drop ───────────────────────────────────────────────────────────────
+
+  const handleMapClick = useCallback(async (ll: L.LatLng) => {
+    const coordLabel = `${ll.lat.toFixed(5)}, ${ll.lng.toFixed(5)}`;
+    const point: MapPoint = { lat: ll.lat, lng: ll.lng, label: coordLabel };
+    if (pinMode === 'origin') { setOrigin(point); setOriginQ(coordLabel); }
+    else                       { setDest(point);   setDestQ(coordLabel);   }
+    setPinMode(null);
+    setRouteError(null);
     try {
-      const results = await searchLocations(q);
-      if (results.length > 0 && mapRef.current) {
-        mapRef.current.flyTo([results[0].latitude, results[0].longitude], 18);
+      const res = await fetch(
+        `https://nominatim.openstreetmap.org/reverse?lat=${ll.lat}&lon=${ll.lng}&format=json&accept-language=en`,
+        { headers: { 'User-Agent': 'AccessMap/1.0' } },
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const short = ((data.display_name ?? coordLabel) as string).split(',').slice(0, 3).join(',').trim();
+        const named: MapPoint = { lat: ll.lat, lng: ll.lng, label: short };
+        if (pinMode === 'origin') { setOrigin(named); setOriginQ(short); }
+        else                       { setDest(named);   setDestQ(short);   }
       }
-    } finally {
-      setSearchLoading(false);
-    }
-  };
+    } catch {}
+  }, [pinMode]);
+
+  // ── Route calculation ──────────────────────────────────────────────────────
+
+  const doCalculate = useCallback(async (guestPrefs?: GuestPreferences) => {
+    if (!origin || !dest) return;
+    setShowPrefs(false);
+    setRouteLoading(true);
+    setRouteError(null);
+    setRoute(null);
+    const result = await calculateRoute({
+      originLat: origin.lat, originLng: origin.lng,
+      destinationLat: dest.lat, destinationLng: dest.lng,
+      preferences: guestPrefs,
+    });
+    setRouteLoading(false);
+    if (result) setRoute(result);
+    else        setRouteError('Could not calculate route. Please try again.');
+  }, [origin, dest]);
+
+  const handleGetRoute = useCallback(() => {
+    if (!origin || !dest) { setRouteError('Please set both origin and destination.'); return; }
+    if (isLoggedIn()) doCalculate();
+    else setShowPrefs(true);
+  }, [origin, dest, doCalculate]);
+
+  // ── Derived values ─────────────────────────────────────────────────────────
+
+  const originLL: [number, number] | null = origin ? [origin.lat, origin.lng] : null;
+  const destLL:   [number, number] | null = dest   ? [dest.lat,   dest.lng]   : null;
+
+  // ── Render ─────────────────────────────────────────────────────────────────
 
   return (
     <View style={s.container}>
 
-      {/* ── Toolbar: search + passive filter ── */}
-      <View style={s.toolbar}>
-        <View style={s.searchWrap}>
-          <Ionicons name="search-outline" size={16} color={COLORS.gray400} />
-          <TextInput
-            style={s.searchInput}
-            placeholder="Search campus locations…"
-            placeholderTextColor={COLORS.gray400}
-            value={query}
-            onChangeText={setQuery}
-            onSubmitEditing={handleSearch}
-            returnKeyType="search"
-          />
-          {searchLoading ? (
-            <ActivityIndicator size="small" color={COLORS.green600} />
-          ) : query.length > 0 ? (
-            <TouchableOpacity onPress={handleSearch} style={s.searchGoBtn}>
-              <Ionicons name="arrow-forward-circle" size={28} color={COLORS.green700} />
-            </TouchableOpacity>
-          ) : null}
-        </View>
-
-        <TouchableOpacity
-          style={[s.passiveChip, showPassive && s.passiveChipActive]}
-          onPress={() => setShowPassive((v: boolean) => !v)}
-        >
-          <View style={[s.chipDot, showPassive && s.chipDotActive]} />
-          <Text style={[s.chipText, showPassive && s.chipTextActive]}>Passive</Text>
-        </TouchableOpacity>
-      </View>
-
-      {/* ── Map ── */}
-      <View style={s.mapWrapper}>
+      {/* ── Full-screen map ── */}
+      <View style={StyleSheet.absoluteFill}>
         <MapContainer
           center={BOUN_CENTER}
           zoom={DEFAULT_ZOOM}
@@ -250,37 +324,38 @@ export default function MapView() {
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
           />
           <ZoomControl position="bottomright" />
-
           <BoundsWatcher onChange={handleBoundsChange} />
-          <PinDropper onDrop={setDroppedPin} />
+          <PinDropper active={!!pinMode} onDrop={handleMapClick} />
+          <FitBounds origin={originLL} dest={destLL} />
+          <FlyToPoint point={flyTarget} />
 
-          {droppedPin && (
-            <Marker position={droppedPin}>
-              <Popup>
-                <strong>Dropped Pin</strong>
-                <br />
-                {droppedPin.lat.toFixed(6)}, {droppedPin.lng.toFixed(6)}
-              </Popup>
-            </Marker>
+          {/* Origin / destination markers */}
+          {originLL && <Marker position={originLL} icon={ORIGIN_ICON} />}
+          {destLL   && <Marker position={destLL}   icon={DEST_ICON}   />}
+
+          {/* Route polyline */}
+          {route && route.waypoints.length > 1 && (
+            <Polyline
+              positions={route.waypoints}
+              pathOptions={{ color: COLORS.blue500, weight: 5, opacity: 0.85, lineJoin: 'round' }}
+            />
           )}
 
+          {/* Obstacle markers */}
           {obstacles.map((obs) => {
             if (obs.isIndoor && zoom < HIGH_DETAIL_ZOOM) return null;
-
             const isPassive = obs.status === 'PASSIVE';
             const color = CATEGORY_COLOR[obs.category] ?? COLORS.gray500;
             const cached = detailMap[obs.id];
             const detail = cached && cached !== 'loading' ? (cached as ObstacleDetail) : undefined;
             const detailLoading = cached === 'loading';
-
             return (
               <CircleMarker
                 key={obs.id}
                 center={[obs.latitude, obs.longitude]}
                 radius={10}
                 pathOptions={{
-                  color,
-                  fillColor: color,
+                  color, fillColor: color,
                   fillOpacity: isPassive ? 0.4 : 0.85,
                   weight: isPassive ? 1 : 2,
                   opacity: isPassive ? 0.5 : 1,
@@ -295,77 +370,374 @@ export default function MapView() {
           })}
         </MapContainer>
       </View>
+
+      {/* ── Search overlay ── */}
+      <View style={s.searchOverlay} pointerEvents="box-none">
+        {!searchExpanded ? (
+
+          /* Collapsed state */
+          <View style={s.collapsedRow} pointerEvents="box-none">
+            <TouchableOpacity
+              style={s.searchBarCollapsed}
+              onPress={() => setSearchExpanded(true)}
+              activeOpacity={0.9}
+            >
+              <Ionicons name="search-outline" size={16} color={COLORS.gray400} />
+              <Text style={s.searchPlaceholder}>Search for a location</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={[s.passiveChip, showPassive && s.passiveChipActive]}
+              onPress={() => setShowPassive(v => !v)}
+            >
+              <View style={[s.chipDot, showPassive && s.chipDotActive]} />
+              <Text style={[s.chipText, showPassive && s.chipTextActive]}>Passive</Text>
+            </TouchableOpacity>
+          </View>
+
+        ) : (
+
+          /* Expanded state */
+          <View style={s.expandedCard}>
+            <View style={s.expandedHeader}>
+              <Ionicons name="navigate-circle-outline" size={18} color={COLORS.green600} />
+              <Text style={s.expandedTitle}>Plan Route</Text>
+              <TouchableOpacity style={s.collapseBtn} onPress={() => setSearchExpanded(false)}>
+                <Ionicons name="chevron-up-outline" size={20} color={COLORS.gray500} />
+              </TouchableOpacity>
+            </View>
+
+            {/* Origin row */}
+            <View style={s.inputRow}>
+              <View style={[s.dot, s.dotOrigin]} />
+              <TextInput
+                style={s.input}
+                placeholder="Origin"
+                placeholderTextColor={COLORS.gray400}
+                value={originQ}
+                onChangeText={t => { setOriginQ(t); setRouteError(null); }}
+                onSubmitEditing={() => searchAndSet(originQ, 'origin')}
+                returnKeyType="search"
+              />
+              {locLoading ? (
+                <ActivityIndicator size="small" color={COLORS.blue600} style={s.iconBtn} />
+              ) : (
+                <TouchableOpacity style={s.iconBtn} onPress={handleUseCurrentLocation}>
+                  <Ionicons name="locate-outline" size={19} color={COLORS.blue600} />
+                </TouchableOpacity>
+              )}
+              <TouchableOpacity
+                style={[s.pinBtn, pinMode === 'origin' && s.pinBtnActive]}
+                onPress={() => setPinMode(pinMode === 'origin' ? null : 'origin')}
+              >
+                <Ionicons name="location-outline" size={18} color={pinMode === 'origin' ? COLORS.green700 : COLORS.gray400} />
+              </TouchableOpacity>
+            </View>
+
+            <View style={s.connector}><View style={s.connectorLine} /></View>
+
+            {/* Destination row */}
+            <View style={s.inputRow}>
+              <View style={[s.dot, s.dotDest]} />
+              <TextInput
+                style={s.input}
+                placeholder="Destination"
+                placeholderTextColor={COLORS.gray400}
+                value={destQ}
+                onChangeText={t => { setDestQ(t); setRouteError(null); }}
+                onSubmitEditing={() => searchAndSet(destQ, 'dest')}
+                returnKeyType="search"
+              />
+              <TouchableOpacity
+                style={[s.pinBtn, pinMode === 'dest' && s.pinBtnActive]}
+                onPress={() => setPinMode(pinMode === 'dest' ? null : 'dest')}
+              >
+                <Ionicons name="location-outline" size={18} color={pinMode === 'dest' ? COLORS.red500 : COLORS.gray400} />
+              </TouchableOpacity>
+            </View>
+
+            {/* Pin mode hint */}
+            {pinMode && (
+              <View style={s.pinHintRow}>
+                <Ionicons name="finger-print-outline" size={13} color={COLORS.green700} />
+                <Text style={s.pinHintText}>Click map to set {pinMode === 'origin' ? 'origin' : 'destination'}</Text>
+                <TouchableOpacity onPress={() => setPinMode(null)}>
+                  <Ionicons name="close-outline" size={16} color={COLORS.gray400} />
+                </TouchableOpacity>
+              </View>
+            )}
+
+            {/* Get Route button */}
+            <TouchableOpacity
+              style={[s.routeBtn, (!origin || !dest) && s.routeBtnDisabled]}
+              onPress={handleGetRoute}
+              disabled={routeLoading}
+              activeOpacity={0.8}
+            >
+              {routeLoading ? (
+                <ActivityIndicator size="small" color={COLORS.white} />
+              ) : (
+                <>
+                  <Ionicons name="navigate-outline" size={16} color={COLORS.white} />
+                  <Text style={s.routeBtnText}>Get Route</Text>
+                </>
+              )}
+            </TouchableOpacity>
+
+            {routeError && (
+              <View style={s.errorRow}>
+                <Ionicons name="alert-circle-outline" size={14} color={COLORS.red500} />
+                <Text style={s.errorText}>{routeError}</Text>
+              </View>
+            )}
+
+            {/* Passive toggle */}
+            <TouchableOpacity
+              style={s.passiveRow}
+              onPress={() => setShowPassive(v => !v)}
+              activeOpacity={0.8}
+            >
+              <View style={[s.chipDot, showPassive && s.chipDotActive]} />
+              <Text style={[s.chipText, showPassive && s.chipTextActive]}>Show passive obstacles</Text>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+
+      {/* ── Route summary (bottom card) ── */}
+      {route && !showPrefs && (
+        <View style={s.summaryCard}>
+          <View style={s.summaryRow}>
+            <View style={s.summaryItem}>
+              <Ionicons name="walk-outline" size={18} color={COLORS.green700} />
+              <Text style={s.summaryValue}>{formatDistance(route.distanceMeters)}</Text>
+              <Text style={s.summaryLabel}>Distance</Text>
+            </View>
+            <View style={s.summaryDivider} />
+            <View style={s.summaryItem}>
+              <Ionicons name="time-outline" size={18} color={COLORS.green700} />
+              <Text style={s.summaryValue}>{formatTime(route.estimatedTimeSeconds)}</Text>
+              <Text style={s.summaryLabel}>Est. time</Text>
+            </View>
+            <View style={s.summaryDivider} />
+            <View style={s.summaryItem}>
+              <Ionicons name="shield-checkmark-outline" size={18} color={COLORS.green700} />
+              <Text style={s.summaryValue}>{route.avoidedObstaclesCount ?? 0}</Text>
+              <Text style={s.summaryLabel}>Avoided</Text>
+            </View>
+          </View>
+          {route.warnings && route.warnings.length > 0 && (
+            <View style={s.warningsBox}>
+              {route.warnings.map((w, i) => (
+                <View key={i} style={s.warningRow}>
+                  <Ionicons name="warning-outline" size={13} color={COLORS.orange500} />
+                  <Text style={s.warningText}>{w}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* ── Guest preferences overlay ── */}
+      {showPrefs && (
+        <View style={s.overlay}>
+          <View style={s.prefsCard}>
+            <Text style={s.prefsTitle}>Route Preferences</Text>
+            <Text style={s.prefsSubtitle}>
+              Sign in to save your profile. For now, set your preferences below.
+            </Text>
+            <View style={s.prefRow}>
+              <View style={s.prefLabel}>
+                <Ionicons name="footsteps-outline" size={16} color={COLORS.gray700} />
+                <Text style={s.prefLabelText}>Avoid stairs</Text>
+              </View>
+              <Switch
+                value={prefs.avoidStairs}
+                onValueChange={v => setPrefs(p => ({ ...p, avoidStairs: v }))}
+                trackColor={{ false: COLORS.gray200, true: COLORS.green400 }}
+                thumbColor={COLORS.white}
+              />
+            </View>
+            <View style={s.prefRow}>
+              <View style={s.prefLabel}>
+                <Ionicons name="trending-up-outline" size={16} color={COLORS.gray700} />
+                <Text style={s.prefLabelText}>Avoid steep slopes</Text>
+              </View>
+              <Switch
+                value={prefs.avoidSteepSlopes}
+                onValueChange={v => setPrefs(p => ({ ...p, avoidSteepSlopes: v }))}
+                trackColor={{ false: COLORS.gray200, true: COLORS.green400 }}
+                thumbColor={COLORS.white}
+              />
+            </View>
+            <View style={s.prefRow}>
+              <View style={s.prefLabel}>
+                <Ionicons name="speedometer-outline" size={16} color={COLORS.gray700} />
+                <Text style={s.prefLabelText}>Max slope gradient (%)</Text>
+              </View>
+              <TextInput
+                style={s.slopeInput}
+                keyboardType="numeric"
+                value={String(prefs.maxSlopeGradient)}
+                onChangeText={v => {
+                  const n = parseInt(v, 10);
+                  if (!isNaN(n) && n >= 1 && n <= 30) setPrefs(p => ({ ...p, maxSlopeGradient: n }));
+                }}
+              />
+            </View>
+            <TouchableOpacity style={s.prefsCalcBtn} onPress={() => doCalculate(prefs)}>
+              <Ionicons name="navigate-outline" size={16} color={COLORS.white} />
+              <Text style={s.prefsCalcBtnText}>Calculate Route</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={s.prefsCancelBtn} onPress={() => setShowPrefs(false)}>
+              <Text style={s.prefsCancelText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
     </View>
   );
 }
 
+// ── Styles ────────────────────────────────────────────────────────────────────
+
 const s = StyleSheet.create({
   container: { flex: 1, backgroundColor: COLORS.white },
 
-  // ── Toolbar ───────────────────────────────────────────────────────────────
-  toolbar: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 10,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
-    backgroundColor: COLORS.white,
-    borderBottomWidth: 1,
-    borderBottomColor: COLORS.gray200,
+  // Search overlay
+  searchOverlay: {
+    position: 'absolute', top: 12, left: 12, right: 12, zIndex: 1000,
   },
-  searchWrap: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    height: 42,
-    backgroundColor: COLORS.gray100,
-    borderRadius: 10,
-    paddingHorizontal: 12,
-    borderWidth: 1,
-    borderColor: COLORS.gray200,
+  collapsedRow: { flexDirection: 'row', gap: 8, alignItems: 'center' },
+  searchBarCollapsed: {
+    flex: 1, flexDirection: 'row', alignItems: 'center', gap: 8,
+    height: 44, backgroundColor: COLORS.white, borderRadius: 12,
+    paddingHorizontal: 14, borderWidth: 1, borderColor: COLORS.gray200,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1, shadowRadius: 6, elevation: 4,
   },
-  searchInput: {
-    flex: 1,
-    height: 42,
-    fontSize: 14,
-    color: COLORS.gray800,
-    paddingHorizontal: 4,
-  },
-  searchGoBtn: { padding: 2 },
+  searchPlaceholder: { flex: 1, fontSize: 14, color: COLORS.gray400 },
 
-  // ── Passive chip ──────────────────────────────────────────────────────────
+  // Expanded card
+  expandedCard: {
+    backgroundColor: COLORS.white, borderRadius: 14, padding: 14,
+    borderWidth: 1, borderColor: COLORS.gray200,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.12, shadowRadius: 8, elevation: 6,
+    gap: 4,
+  },
+  expandedHeader: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 },
+  expandedTitle: { flex: 1, fontSize: 14, fontWeight: '700', color: COLORS.gray800 },
+  collapseBtn: { padding: 2 },
+
+  // Input rows
+  inputRow: { flexDirection: 'row', alignItems: 'center', height: 44, gap: 8 },
+  dot: {
+    width: 11, height: 11, borderRadius: 6, borderWidth: 2.5, borderColor: COLORS.white,
+    flexShrink: 0, shadowColor: '#000', shadowOpacity: 0.2, shadowRadius: 2, elevation: 2,
+  },
+  dotOrigin: { backgroundColor: COLORS.green700 },
+  dotDest:   { backgroundColor: COLORS.red500 },
+  connector: { paddingLeft: 4, height: 8, justifyContent: 'center' },
+  connectorLine: { width: 1, height: 8, backgroundColor: COLORS.gray300, marginLeft: 4 },
+  input: {
+    flex: 1, height: 40, backgroundColor: COLORS.gray100,
+    borderRadius: 9, paddingHorizontal: 12, fontSize: 14,
+    color: COLORS.gray800, borderWidth: 1, borderColor: COLORS.gray200,
+  },
+  iconBtn: { width: 36, height: 36, alignItems: 'center', justifyContent: 'center' },
+  pinBtn: {
+    width: 36, height: 36, borderRadius: 9, borderWidth: 1,
+    borderColor: COLORS.gray200, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: COLORS.white, flexShrink: 0,
+  },
+  pinBtnActive: { borderColor: COLORS.green500, backgroundColor: COLORS.green50 },
+
+  // Pin hint
+  pinHintRow: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    backgroundColor: COLORS.green50, borderRadius: 8,
+    paddingHorizontal: 10, paddingVertical: 6,
+  },
+  pinHintText: { flex: 1, fontSize: 12, color: COLORS.green700, fontWeight: '500' },
+
+  // Route button
+  routeBtn: {
+    marginTop: 4, height: 44, borderRadius: 11, backgroundColor: COLORS.green700,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
+  },
+  routeBtnDisabled: { backgroundColor: COLORS.gray300 },
+  routeBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
+  errorRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  errorText: { fontSize: 12, color: COLORS.red500, flex: 1 },
+
+  // Passive toggle (in expanded card)
+  passiveRow: { flexDirection: 'row', alignItems: 'center', gap: 7, paddingVertical: 7, paddingHorizontal: 4 },
+
+  // Passive chip (collapsed)
   passiveChip: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 6,
-    height: 42,
-    paddingHorizontal: 14,
-    borderRadius: 10,
-    borderWidth: 1.5,
-    borderColor: COLORS.gray200,
-    backgroundColor: COLORS.white,
+    flexDirection: 'row', alignItems: 'center', gap: 6, height: 44,
+    paddingHorizontal: 12, borderRadius: 12, borderWidth: 1.5,
+    borderColor: COLORS.gray200, backgroundColor: COLORS.white,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1, shadowRadius: 6, elevation: 4,
   },
-  passiveChipActive: {
-    borderColor: COLORS.green500,
-    backgroundColor: COLORS.green50,
-  },
-  chipDot: {
-    width: 7,
-    height: 7,
-    borderRadius: 4,
-    backgroundColor: COLORS.gray300,
-  },
+  passiveChipActive: { borderColor: COLORS.green500, backgroundColor: COLORS.green50 },
+  chipDot: { width: 7, height: 7, borderRadius: 4, backgroundColor: COLORS.gray300 },
   chipDotActive: { backgroundColor: COLORS.green500 },
   chipText: { fontSize: 12, fontWeight: '600', color: COLORS.gray500 },
   chipTextActive: { color: COLORS.green700 },
 
-  // ── Map wrapper ───────────────────────────────────────────────────────────
-  mapWrapper: { flex: 1 },
-
-  // ── Loading bar ───────────────────────────────────────────────────────────
-  loadingBar: {
-    height: 3,
-    backgroundColor: COLORS.green500,
+  // Route summary card
+  summaryCard: {
+    position: 'absolute', bottom: 0, left: 0, right: 0,
+    backgroundColor: COLORS.white, borderTopWidth: 1, borderTopColor: COLORS.gray200,
+    paddingHorizontal: 16, paddingVertical: 14,
+    shadowColor: '#000', shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.08, shadowRadius: 8, elevation: 6,
   },
+  summaryRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around' },
+  summaryItem: { alignItems: 'center', gap: 3, flex: 1 },
+  summaryDivider: { width: 1, height: 36, backgroundColor: COLORS.gray200 },
+  summaryValue: { fontSize: 16, fontWeight: '700', color: COLORS.gray800 },
+  summaryLabel: { fontSize: 11, color: COLORS.gray400, fontWeight: '500' },
+  warningsBox: {
+    marginTop: 10, backgroundColor: COLORS.orange100,
+    borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8, gap: 4,
+  },
+  warningRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 6 },
+  warningText: { flex: 1, fontSize: 12, color: COLORS.gray700, lineHeight: 17 },
+
+  // Guest prefs overlay
+  overlay: {
+    position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+    alignItems: 'center', justifyContent: 'center', zIndex: 2000,
+  },
+  prefsCard: {
+    width: '90%', maxWidth: 400, backgroundColor: COLORS.white,
+    borderRadius: 16, padding: 24, gap: 16,
+    shadowColor: '#000', shadowOpacity: 0.25, shadowRadius: 16, elevation: 10,
+  },
+  prefsTitle: { fontSize: 18, fontWeight: '700', color: COLORS.gray800 },
+  prefsSubtitle: { fontSize: 13, color: COLORS.gray500, lineHeight: 18, marginTop: -8 },
+  prefRow: {
+    flexDirection: 'row', alignItems: 'center',
+    justifyContent: 'space-between', paddingVertical: 4,
+  },
+  prefLabel: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  prefLabelText: { fontSize: 14, color: COLORS.gray700, fontWeight: '500' },
+  slopeInput: {
+    width: 56, height: 36, borderRadius: 8,
+    borderWidth: 1.5, borderColor: COLORS.gray300,
+    textAlign: 'center', fontSize: 15, fontWeight: '600', color: COLORS.gray800,
+  },
+  prefsCalcBtn: {
+    height: 46, borderRadius: 11, backgroundColor: COLORS.green700,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center',
+    gap: 8, marginTop: 4,
+  },
+  prefsCalcBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
+  prefsCancelBtn: { alignItems: 'center', paddingVertical: 4 },
+  prefsCancelText: { fontSize: 14, color: COLORS.gray400 },
 });


### PR DESCRIPTION
## Description
Redesigns the map screen to follow a Google Maps-style layout. Route planning is merged into the map screen — no separate Plan tab needed.

## Type of Change
- [x] `feat` — new feature

## Changes
- Removed "Plan" tab from bottom tab navigator
- Merged route planning UI into map screen as a floating overlay
- Collapsed state: single pill search bar "Search for a location" floating over the map
- Expanded state: origin + destination fields with GPS current location button and pin-drop mode
- Route drawn directly on the map when both fields are set
- Map pans and drops pin when a location is searched
- "Campus Map" → "Access Map"
- "Search campus location" → "Search for a location"
- Web version uses browser geolocation API, native uses expo-location

## How to Test
1. Open the map tab — should show single search bar over the map
2. Tap the search bar — should expand to origin/destination fields
3. Tap "Use current location" on origin — should fill with GPS coords
4. Search a destination — map should pan and drop a pin
5. Tap "Get Route" — route should appear on the map
6. Confirm "Plan" tab is gone from bottom bar

## Related Issue
- Closes #[issue number]