### PR TITLE
feat(users): implement GET/POST/PUT /users/me/mobility-profile endpoint

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -131,3 +131,37 @@ class UserProfileUpdateSerializer(serializers.Serializer):
         instance.birth_date = validated_data.get('birth_date', instance.birth_date)
         instance.save(update_fields=['full_name', 'birth_date'])
         return instance
+
+
+class MobilityProfileInputSerializer(serializers.Serializer):
+    """Accepts the frontend's MobilityProfilePayload shape."""
+    mobilityAid = serializers.ChoiceField(
+        choices=MobilityAidType.choices,
+        source='mobility_aid_type',
+    )
+    avoidStairs = serializers.BooleanField(
+        source='avoid_stairs',
+        required=False,
+        default=False,
+    )
+    avoidSteepSlopes = serializers.BooleanField(
+        source='avoid_steep_slopes',
+        required=False,
+        default=False,
+    )
+    maxSlopeGradient = serializers.FloatField(
+        source='max_slope_gradient',
+        required=False,
+        default=None,
+        allow_null=True,
+    )
+
+
+class MobilityProfileOutputSerializer(serializers.Serializer):
+    """Returns the frontend's MobilityProfile shape."""
+    profileId = serializers.UUIDField(source='id')
+    mobilityAid = serializers.CharField(source='mobility_aid_type')
+    avoidStairs = serializers.BooleanField(source='avoid_stairs')
+    avoidSteepSlopes = serializers.BooleanField(source='avoid_steep_slopes')
+    maxSlopeGradient = serializers.FloatField(source='max_slope_gradient')
+    createdAt = serializers.DateTimeField(source='created_at')

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -83,3 +83,79 @@ class RegisterViewTest(TestCase):
         hasher = identify_hasher(user.password)
         self.assertEqual(hasher.algorithm, 'bcrypt_sha256')
         self.assertTrue(check_password('SecureP@ss123', user.password))
+
+
+# ---------------------------------------------------------------------------
+# View: GET/POST/PUT /users/me/mobility-profile
+# ---------------------------------------------------------------------------
+
+class MobilityProfileViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.url = '/users/me/mobility-profile'
+        self.user = User.objects.create_user(
+            email='mp@test.com', full_name='MP User', password='SecureP@ss123',
+        )
+        self.client.force_authenticate(user=self.user)
+        self.valid_payload = {
+            'mobilityAid': 'WHEELCHAIR',
+            'avoidStairs': True,
+            'avoidSteepSlopes': True,
+            'maxSlopeGradient': 8.0,
+        }
+
+    def test_get_returns_404_when_no_profile(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_profile(self):
+        response = self.client.post(self.url, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        self.assertEqual(data['mobilityAid'], 'WHEELCHAIR')
+        self.assertTrue(data['avoidStairs'])
+        self.assertTrue(data['avoidSteepSlopes'])
+        self.assertEqual(data['maxSlopeGradient'], 8.0)
+        self.assertIn('profileId', data)
+        self.assertIn('createdAt', data)
+
+    def test_get_returns_profile_after_create(self):
+        self.client.post(self.url, self.valid_payload, format='json')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data['mobilityAid'], 'WHEELCHAIR')
+
+    def test_create_duplicate_returns_409(self):
+        self.client.post(self.url, self.valid_payload, format='json')
+        response = self.client.post(self.url, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_update_profile(self):
+        self.client.post(self.url, self.valid_payload, format='json')
+        updated = {
+            'mobilityAid': 'CRUTCHES',
+            'avoidStairs': False,
+            'avoidSteepSlopes': False,
+            'maxSlopeGradient': None,
+        }
+        response = self.client.put(self.url, updated, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data['mobilityAid'], 'CRUTCHES')
+        self.assertFalse(data['avoidStairs'])
+        self.assertIsNone(data['maxSlopeGradient'])
+
+    def test_update_returns_404_when_no_profile(self):
+        response = self.client.put(self.url, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_unauthenticated_returns_401(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_mobility_aid_returns_400(self):
+        payload = {**self.valid_payload, 'mobilityAid': 'JETPACK'}
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -6,7 +6,9 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenRefreshView
 
 from apps.users.serializers import (LoginSerializer, TokenOutputSerializer, LogoutSerializer,
-                                    RegisterSerializer, UserProfileSerializer, UserProfileUpdateSerializer)
+                                    RegisterSerializer, UserProfileSerializer, UserProfileUpdateSerializer,
+                                    MobilityProfileInputSerializer, MobilityProfileOutputSerializer)
+from apps.users.models import MobilityProfile
 from apps.users.services import login_user, logout_user
 from apps.users.throttles import AuthRateThrottle
 
@@ -74,6 +76,50 @@ class MeView(APIView):
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
         return Response(UserProfileSerializer(user).data, status=status.HTTP_200_OK)
+
+
+class MobilityProfileView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        try:
+            profile = request.user.mobility_profile
+        except MobilityProfile.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        return Response(MobilityProfileOutputSerializer(profile).data)
+
+    def post(self, request):
+        try:
+            request.user.mobility_profile
+            return Response(
+                {'detail': 'Mobility profile already exists. Use PUT to update.'},
+                status=status.HTTP_409_CONFLICT,
+            )
+        except MobilityProfile.DoesNotExist:
+            pass
+
+        serializer = MobilityProfileInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        profile = MobilityProfile.objects.create(
+            user=request.user, **serializer.validated_data
+        )
+        return Response(
+            MobilityProfileOutputSerializer(profile).data,
+            status=status.HTTP_201_CREATED,
+        )
+
+    def put(self, request):
+        try:
+            profile = request.user.mobility_profile
+        except MobilityProfile.DoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+        serializer = MobilityProfileInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        for attr, value in serializer.validated_data.items():
+            setattr(profile, attr, value)
+        profile.save()
+        return Response(MobilityProfileOutputSerializer(profile).data)
 
 
 # For permission testing purposes

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -3,6 +3,8 @@ from django.db import connection
 from django.http import JsonResponse
 from django.urls import include, path
 
+from apps.users.views import MobilityProfileView
+
 
 def health(request):
     try:
@@ -21,4 +23,5 @@ urlpatterns = [
     path('api/routes/', include('apps.routing.urls')),
     path('api/reports/', include('apps.reports.urls')),
     path('api/map/', include('apps.map.urls')),
+    path('users/me/mobility-profile', MobilityProfileView.as_view(), name='mobility-profile'),
 ]

--- a/frontend/src/api/mobilityProfile.ts
+++ b/frontend/src/api/mobilityProfile.ts
@@ -6,7 +6,7 @@ import { MobilityProfile, MobilityProfilePayload } from '../types/mobilityProfil
  * Set MOCK = true while the backend endpoints are not yet implemented.
  * Flip to false once GET/POST/PUT /users/me/mobility-profile are live.
  */
-export const MOCK = true;
+export const MOCK = false;
 
 // ── In-memory mock store ───────────────────────────────────────────────────
 let _mockProfile: MobilityProfile | null = null;


### PR DESCRIPTION
## Description
Adds mobility profile support for authenticated users by implementing backend serializers, endpoint, and tests, and connecting the frontend to the real API. This enables users to create, retrieve, and update their mobility preferences.

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes
- Added `MobilityProfileInputSerializer` and `MobilityProfileOutputSerializer` aligned with frontend interfaces
- Implemented `GET/POST/PUT /users/me/mobility-profile` endpoint
- Registered route in `config/urls.py`
- Flipped `MOCK = false` in frontend mobilityProfile API
- Added 8 tests covering success cases and edge cases
- 
## Related Issue 
- Closes #143 
- 
## How to Test
1. Run backend tests:
   ```bash
   pytest
   # or
   python manage.py test