### PR TITLE
fix: use dynamic PORT for Railway nginx

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -8,6 +8,5 @@ RUN npx expo export --platform web
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-EXPOSE 80
+COPY nginx.conf /etc/nginx/templates/default.conf.template
 CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -10,7 +10,7 @@ types {
 }
 
 server {
-    listen 80;
+    listen ${PORT};
     root /usr/share/nginx/html;
     index index.html;
 


### PR DESCRIPTION
Railway sets PORT env var dynamically. Nginx must listen on it instead of hardcoded 80.