### PR TITLE
feat: admin endpoint to delete reports as malicious

### DIFF
--- a/backend/apps/admin/services.py
+++ b/backend/apps/admin/services.py
@@ -1,0 +1,18 @@
+from django.db import transaction
+
+from apps.reports.models import Report
+from apps.trust_scores.services import apply_malicious_deletion_delta
+
+
+@transaction.atomic
+def delete_report_as_malicious(report_id):
+    """Delete a report flagged as malicious and penalize the reporter's trust score.
+
+    Decrement and deletion run in one transaction so they succeed or roll back together.
+    Raises Report.DoesNotExist if the id is unknown.
+    """
+    report = Report.objects.select_related('reporter').get(pk=report_id)
+    reporter = report.reporter
+    new_score = apply_malicious_deletion_delta(reporter)
+    report.delete()
+    return {'reporter_id': reporter.pk, 'trust_score': new_score}

--- a/backend/apps/admin/tests.py
+++ b/backend/apps/admin/tests.py
@@ -1,0 +1,148 @@
+from unittest.mock import patch
+from uuid import uuid4
+
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.reports.models import (
+    ObstacleCategory,
+    Report,
+    ReportContext,
+    ReportStatus,
+)
+from apps.users.models import User, UserRole
+
+
+def make_admin(email="admin@test.com"):
+    return User.objects.create_user(
+        email=email,
+        full_name="Admin",
+        password="pass",
+        role=UserRole.ADMINISTRATOR,
+    )
+
+
+def make_reporter(email="reporter@test.com", points=0):
+    user = User.objects.create_user(
+        email=email, full_name="Reporter", password="pass",
+    )
+    if points:
+        user.reputation_points = points
+        user.save(update_fields=['reputation_points'])
+    return user
+
+
+def make_report(reporter):
+    return Report.objects.create(
+        reporter=reporter,
+        title="Broken Ramp",
+        description="The ramp is broken.",
+        category=ObstacleCategory.BROKEN_RAMP,
+        context=ReportContext.OUTDOOR,
+        status=ReportStatus.VERIFIED,
+        latitude="41.083700",
+        longitude="29.051000",
+    )
+
+
+# ---------------------------------------------------------------------------
+# View: DELETE /api/admin/reports/<uuid>/
+# ---------------------------------------------------------------------------
+
+@override_settings(TRUST_SCORE_MALICIOUS_DELTA=4)
+class DeleteReportAsMaliciousViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.admin = make_admin()
+        self.reporter = make_reporter(points=10)
+        self.report = make_report(self.reporter)
+        self.url = f"/api/admin/reports/{self.report.id}/"
+
+    def test_admin_deletes_and_decrements_score(self):
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Report.objects.filter(pk=self.report.id).exists())
+        self.reporter.refresh_from_db()
+        self.assertEqual(self.reporter.reputation_points, 6)
+        self.assertEqual(response.json()['trust_score'], 6)
+
+    def test_non_admin_gets_403(self):
+        other = User.objects.create_user(
+            email="other@test.com", full_name="Other", password="pass",
+        )
+        self.client.force_authenticate(user=other)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(Report.objects.filter(pk=self.report.id).exists())
+        self.reporter.refresh_from_db()
+        self.assertEqual(self.reporter.reputation_points, 10)
+
+    def test_anonymous_gets_401(self):
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertTrue(Report.objects.filter(pk=self.report.id).exists())
+
+    def test_unknown_report_returns_404(self):
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.delete(f"/api/admin/reports/{uuid4()}/")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_decrement_floors_at_zero(self):
+        self.reporter.reputation_points = 2
+        self.reporter.save(update_fields=['reputation_points'])
+        self.client.force_authenticate(user=self.admin)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.reporter.refresh_from_db()
+        self.assertEqual(self.reporter.reputation_points, 0)
+        self.assertEqual(response.json()['trust_score'], 0)
+
+
+# ---------------------------------------------------------------------------
+# Service: delete_report_as_malicious
+# ---------------------------------------------------------------------------
+
+@override_settings(TRUST_SCORE_MALICIOUS_DELTA=4)
+class DeleteReportAsMaliciousServiceTest(TestCase):
+    def setUp(self):
+        self.reporter = make_reporter(points=10)
+        self.report = make_report(self.reporter)
+
+    def test_deletes_and_decrements(self):
+        from apps.admin.services import delete_report_as_malicious
+
+        result = delete_report_as_malicious(self.report.id)
+
+        self.assertEqual(result['trust_score'], 6)
+        self.assertEqual(result['reporter_id'], self.reporter.pk)
+        self.assertFalse(Report.objects.filter(pk=self.report.id).exists())
+        self.reporter.refresh_from_db()
+        self.assertEqual(self.reporter.reputation_points, 6)
+
+    def test_unknown_raises_does_not_exist(self):
+        from apps.admin.services import delete_report_as_malicious
+
+        with self.assertRaises(Report.DoesNotExist):
+            delete_report_as_malicious(uuid4())
+
+    def test_rollback_on_delete_failure(self):
+        from apps.admin.services import delete_report_as_malicious
+
+        with patch.object(Report, 'delete', side_effect=Exception("boom")):
+            with self.assertRaises(Exception):
+                delete_report_as_malicious(self.report.id)
+
+        self.reporter.refresh_from_db()
+        self.assertEqual(self.reporter.reputation_points, 10)
+        self.assertTrue(Report.objects.filter(pk=self.report.id).exists())

--- a/backend/apps/admin/urls.py
+++ b/backend/apps/admin/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import DeleteReportView
+
+app_name = 'admin_api'
+
+urlpatterns = [
+    path('reports/<uuid:report_id>/', DeleteReportView.as_view(), name='delete-report'),
+]

--- a/backend/apps/admin/views.py
+++ b/backend/apps/admin/views.py
@@ -1,0 +1,22 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.permissions import IsAdmin
+from apps.reports.models import Report
+
+from .services import delete_report_as_malicious
+
+
+class DeleteReportView(APIView):
+    permission_classes = [IsAdmin]
+
+    def delete(self, request, report_id):
+        try:
+            result = delete_report_as_malicious(report_id)
+        except Report.DoesNotExist:
+            return Response(
+                {'detail': 'Report not found.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        return Response(result, status=status.HTTP_200_OK)

--- a/backend/apps/notifications/models.py
+++ b/backend/apps/notifications/models.py
@@ -1,36 +1,42 @@
-from django.conf import settings
-from django.db import models
+# Notifications are not part of the current milestone. The Notification model
+# below was added ahead of schedule and has never been migrated to Supabase;
+# its related_report FK to Report breaks report deletion via cascade. Keep it
+# commented out until notifications are actually implemented and a migration
+# is applied.
 
-
-class NotificationType(models.TextChoices):
-    REGISTRATION_COMPLETE = 'REGISTRATION_COMPLETE', 'Registration Complete'
-    REPORT_VERIFIED = 'REPORT_VERIFIED', 'Report Verified'
-    REPORT_RESOLVED = 'REPORT_RESOLVED', 'Report Resolved'
-    SPAM_WARNING = 'SPAM_WARNING', 'Spam Warning'
-    STATUS_CHANGE = 'STATUS_CHANGE', 'Status Change'
-
-
-class Notification(models.Model):
-    user = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
-        on_delete=models.CASCADE,
-        related_name='notifications',
-    )
-    notification_type = models.CharField(max_length=25, choices=NotificationType.choices)
-    title = models.CharField(max_length=255)
-    message = models.TextField()
-    is_read = models.BooleanField(default=False)
-    related_report = models.ForeignKey(
-        'reports.Report',
-        on_delete=models.SET_NULL,
-        null=True,
-        blank=True,
-        related_name='notifications',
-    )
-    created_at = models.DateTimeField(auto_now_add=True)
-
-    class Meta:
-        db_table = 'notifications'
-
-    def __str__(self):
-        return f'{self.notification_type} for {self.user.email}'
+# from django.conf import settings
+# from django.db import models
+#
+#
+# class NotificationType(models.TextChoices):
+#     REGISTRATION_COMPLETE = 'REGISTRATION_COMPLETE', 'Registration Complete'
+#     REPORT_VERIFIED = 'REPORT_VERIFIED', 'Report Verified'
+#     REPORT_RESOLVED = 'REPORT_RESOLVED', 'Report Resolved'
+#     SPAM_WARNING = 'SPAM_WARNING', 'Spam Warning'
+#     STATUS_CHANGE = 'STATUS_CHANGE', 'Status Change'
+#
+#
+# class Notification(models.Model):
+#     user = models.ForeignKey(
+#         settings.AUTH_USER_MODEL,
+#         on_delete=models.CASCADE,
+#         related_name='notifications',
+#     )
+#     notification_type = models.CharField(max_length=25, choices=NotificationType.choices)
+#     title = models.CharField(max_length=255)
+#     message = models.TextField()
+#     is_read = models.BooleanField(default=False)
+#     related_report = models.ForeignKey(
+#         'reports.Report',
+#         on_delete=models.SET_NULL,
+#         null=True,
+#         blank=True,
+#         related_name='notifications',
+#     )
+#     created_at = models.DateTimeField(auto_now_add=True)
+#
+#     class Meta:
+#         db_table = 'notifications'
+#
+#     def __str__(self):
+#         return f'{self.notification_type} for {self.user.email}'

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     path('api/routes/', include('apps.routing.urls')),
     path('api/reports/', include('apps.reports.urls')),
     path('api/map/', include('apps.map.urls')),
+    path('api/admin/', include('apps.admin.urls')),
 ]


### PR DESCRIPTION
## Description

  Adds an admin-only endpoint for removing malicious reports. Deleting a report via this endpoint penalizes the reporter's trustScore
   through apply_malicious_deletion_delta (floored at 0) from the trust-score ticket, atomically with the deletion. Also comments out
   the unused Notification model because its unmigrated SET_NULL FK to Report was breaking cascade deletion against Supabase — it was
   added ahead of the milestone and nothing in the codebase or frontend references it.

##  Type of Change

  - feat — new feature
  - fix — bug fix
  - refactor — code refactor
  - docs — documentation
  - chore — maintenance / configuration
  - perf — performance improvement
  - test — adding or updating tests
  - style — formatting, missing semicolons, etc.

##  Changes

  - Added DELETE /api/admin/reports/<uuid>/ (service + view + URL) guarded by IsAdmin; returns 200 with the updated trust score, 401
  for anonymous, 403 for non-admin, 404 for unknown id.
  - delete_report_as_malicious runs inside @transaction.atomic so the decrement and delete succeed or roll back together.
  - Commented out the Notification model (no callers in backend or frontend, no migration, blocked cascade on report delete).
  - Added 8 tests in apps/admin/tests.py — 5 view-level (success + decrement, 403, 401, 404, floor-at-zero) and 3 service-level
  (success, unknown-id raises DoesNotExist, rollback on delete failure leaves trust score unchanged).

##  How to Test

  1. cd backend && source .venv/bin/activate
  2. pytest apps/admin/tests.py -v — all 8 tests should pass.
  3. Manual smoke (optional): register an admin via shell (User.role = ADMINISTRATOR), register a reporter, create a report, curl -X
  DELETE -H "Authorization: Bearer <admin-token>" http://localhost:8000/api/admin/reports/<uuid>/ → expect 200 with trust_score
  field, report gone, reporter's reputation_points decreased by TRUST_SCORE_MALICIOUS_DELTA.

##  Screenshots (if applicable)

  N/A — backend only, no UI.

##  Checklist

  - Commit messages follow <type>(<scope>): <subject> format
  - Branch is up to date with the target branch
  - No self-merge — at least 1 reviewer assigned
  - Conflicts resolved by PR author

##  Related Issue

  - Closes #187

##  Notes

  - PR base is feat/trust-score (the trust-score PR is open but not yet merged). Once trust-score merges into main, flip this PR's
  base to main — the trust-score commit will drop out of the diff automatically.
  - Follow-up tech debt: most apps (users, notifications, trust_scores, map, routing, etc.) have no migration files, so Supabase
  schema is hand-managed and drifts from model definitions. Worth a dedicated ticket to bring everything under Django migrations.
  - When notifications are actually implemented, restore the model from git history and ship it with a proper migration.