### PR TITLE
Feat/indoor form fields

### DIFF
--- a/backend/apps/reports/models.py
+++ b/backend/apps/reports/models.py
@@ -16,11 +16,19 @@ class ReportStatus(models.TextChoices):
 
 
 class ObstacleCategory(models.TextChoices):
+    # Outdoor
     BROKEN_RAMP = "BROKEN_RAMP", "Broken Ramp"
     NARROW_SIDEWALK = "NARROW_SIDEWALK", "Narrow Sidewalk"
     DAMAGED_SURFACE = "DAMAGED_SURFACE", "Damaged Surface"
     ROAD_CONSTRUCTION = "ROAD_CONSTRUCTION", "Road Construction"
     BLOCKED_PATH = "BLOCKED_PATH", "Blocked Path"
+    # Indoor
+    BROKEN_ELEVATOR = "BROKEN_ELEVATOR", "Broken Elevator"
+    INACCESSIBLE_RESTROOM = "INACCESSIBLE_RESTROOM", "Inaccessible Restroom"
+    NARROW_CORRIDOR = "NARROW_CORRIDOR", "Narrow Corridor"
+    HEAVY_DOOR = "HEAVY_DOOR", "Heavy Door"
+    SLIPPERY_FLOOR = "SLIPPERY_FLOOR", "Slippery Floor"
+    # Shared
     OTHER = "OTHER", "Other"
 
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -14,6 +14,11 @@ _railway_domain = config('RAILWAY_PUBLIC_DOMAIN', default='')
 if _railway_domain and _railway_domain not in ALLOWED_HOSTS:
     ALLOWED_HOSTS.append(_railway_domain)
 
+# In local development allow any host (e.g. physical device on LAN, emulator).
+# Never reached in production because DEBUG is False there.
+if DEBUG:
+    ALLOWED_HOSTS.append('*')
+
 INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',

--- a/frontend/src/__tests__/ReportForm.indoor.test.tsx
+++ b/frontend/src/__tests__/ReportForm.indoor.test.tsx
@@ -57,6 +57,8 @@ describe('ReportForm — indoor fields', () => {
     mockedSearchLocations.mockResolvedValue([
       { id: '1', name: 'Engineering Faculty', latitude: 41.08, longitude: 29.05 },
     ]);
+    (require('../api/reports').submitReport as jest.Mock)
+      .mockResolvedValue({ ok: true, status: 201, data: {} });
   });
 
   afterEach(() => {
@@ -108,6 +110,7 @@ describe('ReportForm — indoor fields', () => {
   });
 
   it('shows error and does not submit when INDOOR and building name is empty', async () => {
+    const { submitReport } = require('../api/reports');
     const { getByText, getByTestId, queryByText } = render(<ReportForm onSuccess={jest.fn()} />);
     fireEvent.press(getByText('INDOOR'));
     // Add a photo so photo validation passes
@@ -117,7 +120,6 @@ describe('ReportForm — indoor fields', () => {
     await waitFor(() => {
       expect(getByText('Building name is required for indoor reports.')).toBeTruthy();
     });
-    const { submitReport } = require('../api/reports');
     expect(submitReport).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/__tests__/ReportForm.indoor.test.tsx
+++ b/frontend/src/__tests__/ReportForm.indoor.test.tsx
@@ -18,6 +18,7 @@ jest.mock('../api/map', () => ({
   searchLocations: jest.fn().mockResolvedValue([
     { id: '1', name: 'Engineering Faculty', latitude: 41.08, longitude: 29.05 },
   ]),
+  reverseGeocode: jest.fn().mockResolvedValue(null),
 }));
 
 jest.mock('../api/reports', () => ({

--- a/frontend/src/__tests__/ReportForm.indoor.test.tsx
+++ b/frontend/src/__tests__/ReportForm.indoor.test.tsx
@@ -30,8 +30,17 @@ jest.mock('../services/auth', () => ({
 }));
 
 jest.mock('../components/reports/PhotoPicker', () => {
-  const { View } = require('react-native');
-  return { __esModule: true, default: () => <View testID="photo-picker" /> };
+  const { View, TouchableOpacity, Text } = require('react-native');
+  return {
+    __esModule: true,
+    default: ({ onAdd }: { onAdd: (p: { uri: string; b64: string }) => void }) => (
+      <View testID="photo-picker">
+        <TouchableOpacity testID="add-photo-btn" onPress={() => onAdd({ uri: 'mock-uri', b64: 'mock-b64' })}>
+          <Text>Add Photo</Text>
+        </TouchableOpacity>
+      </View>
+    ),
+  };
 });
 
 jest.mock('../components/reports/LocationPicker', () => {
@@ -96,5 +105,39 @@ describe('ReportForm — indoor fields', () => {
     fireEvent.press(getByText('Engineering Faculty'));
     expect(input.props.value).toBe('Engineering Faculty');
     expect(queryByText('Engineering Faculty')).toBeNull();
+  });
+
+  it('shows error and does not submit when INDOOR and building name is empty', async () => {
+    const { getByText, getByTestId, queryByText } = render(<ReportForm onSuccess={jest.fn()} />);
+    fireEvent.press(getByText('INDOOR'));
+    // Add a photo so photo validation passes
+    fireEvent.press(getByTestId('add-photo-btn'));
+    // do not fill building name
+    fireEvent.press(getByText('Submit Report'));
+    await waitFor(() => {
+      expect(getByText('Building name is required for indoor reports.')).toBeTruthy();
+    });
+    const { submitReport } = require('../api/reports');
+    expect(submitReport).not.toHaveBeenCalled();
+  });
+
+  it('includes buildingName and isIndoor in payload when INDOOR and building name is filled', async () => {
+    const { submitReport } = require('../api/reports');
+    const { getByText, getByPlaceholderText, getByTestId } = render(<ReportForm onSuccess={jest.fn()} />);
+    fireEvent.press(getByText('INDOOR'));
+    // Add a photo so photo validation passes
+    fireEvent.press(getByTestId('add-photo-btn'));
+    fireEvent.changeText(getByPlaceholderText('Search building…'), 'Engineering Faculty');
+    // Skip debounce — typing directly sets buildingName
+    fireEvent.press(getByText('Submit Report'));
+    await waitFor(() => {
+      expect(submitReport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          buildingName: 'Engineering Faculty',
+          isIndoor: true,
+          context: 'INDOOR',
+        })
+      );
+    });
   });
 });

--- a/frontend/src/__tests__/ReportForm.indoor.test.tsx
+++ b/frontend/src/__tests__/ReportForm.indoor.test.tsx
@@ -26,6 +26,7 @@ jest.mock('../api/reports', () => ({
 
 jest.mock('../services/auth', () => ({
   parseDRFError: jest.fn().mockReturnValue('Server error'),
+  getAccessToken: jest.fn().mockReturnValue('mock-token'),
 }));
 
 jest.mock('../components/reports/PhotoPicker', () => {
@@ -42,6 +43,7 @@ const mockedSearchLocations = searchLocations as jest.MockedFunction<typeof sear
 
 describe('ReportForm — indoor fields', () => {
   beforeEach(() => {
+    jest.clearAllMocks();
     jest.useFakeTimers();
     mockedSearchLocations.mockResolvedValue([
       { id: '1', name: 'Engineering Faculty', latitude: 41.08, longitude: 29.05 },
@@ -78,7 +80,7 @@ describe('ReportForm — indoor fields', () => {
     fireEvent.press(getByText('INDOOR'));
     const input = getByPlaceholderText('Search building…');
     fireEvent.changeText(input, 'Eng');
-    act(() => { jest.advanceTimersByTime(400); });
+    await act(async () => { jest.advanceTimersByTime(400); });
     await waitFor(() => {
       expect(getByText('Engineering Faculty')).toBeTruthy();
     });
@@ -89,7 +91,7 @@ describe('ReportForm — indoor fields', () => {
     fireEvent.press(getByText('INDOOR'));
     const input = getByPlaceholderText('Search building…');
     fireEvent.changeText(input, 'Eng');
-    act(() => { jest.advanceTimersByTime(400); });
+    await act(async () => { jest.advanceTimersByTime(400); });
     await waitFor(() => getByText('Engineering Faculty'));
     fireEvent.press(getByText('Engineering Faculty'));
     expect(input.props.value).toBe('Engineering Faculty');

--- a/frontend/src/__tests__/ReportForm.indoor.test.tsx
+++ b/frontend/src/__tests__/ReportForm.indoor.test.tsx
@@ -76,7 +76,7 @@ describe('ReportForm — indoor fields', () => {
     fireEvent.press(getByText('INDOOR'));
     expect(getByText('Indoor Details')).toBeTruthy();
     expect(getByText(/Building name/)).toBeTruthy();
-    expect(getByText(/Floor/)).toBeTruthy();
+    expect(getByText(/^Floor/)).toBeTruthy();
   });
 
   it('hides Indoor Details card when switching back to OUTDOOR', () => {

--- a/frontend/src/__tests__/ReportForm.indoor.test.tsx
+++ b/frontend/src/__tests__/ReportForm.indoor.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import ReportForm from '../components/reports/ReportForm';
+import { searchLocations } from '../api/map';
+
+jest.mock('../hooks/useLocation', () => ({
+  useLocation: () => ({
+    location: { lat: 41.0, lng: 29.0 },
+    loading: false,
+    error: null,
+    permissionDenied: false,
+    refetch: jest.fn(),
+  }),
+}));
+
+jest.mock('../api/map', () => ({
+  searchNominatim: jest.fn().mockResolvedValue([]),
+  searchLocations: jest.fn().mockResolvedValue([
+    { id: '1', name: 'Engineering Faculty', latitude: 41.08, longitude: 29.05 },
+  ]),
+}));
+
+jest.mock('../api/reports', () => ({
+  submitReport: jest.fn().mockResolvedValue({ ok: true, status: 201, data: {} }),
+}));
+
+jest.mock('../services/auth', () => ({
+  parseDRFError: jest.fn().mockReturnValue('Server error'),
+}));
+
+jest.mock('../components/reports/PhotoPicker', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="photo-picker" /> };
+});
+
+jest.mock('../components/reports/LocationPicker', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="location-picker" /> };
+});
+
+const mockedSearchLocations = searchLocations as jest.MockedFunction<typeof searchLocations>;
+
+describe('ReportForm — indoor fields', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedSearchLocations.mockResolvedValue([
+      { id: '1', name: 'Engineering Faculty', latitude: 41.08, longitude: 29.05 },
+    ]);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not show Indoor Details card when OUTDOOR is selected (default)', () => {
+    const { queryByText } = render(<ReportForm onSuccess={jest.fn()} />);
+    expect(queryByText('Indoor Details')).toBeNull();
+  });
+
+  it('shows Indoor Details card when INDOOR is selected', () => {
+    const { getByText } = render(<ReportForm onSuccess={jest.fn()} />);
+    fireEvent.press(getByText('INDOOR'));
+    expect(getByText('Indoor Details')).toBeTruthy();
+    expect(getByText(/Building name/)).toBeTruthy();
+    expect(getByText(/Floor/)).toBeTruthy();
+  });
+
+  it('hides Indoor Details card when switching back to OUTDOOR', () => {
+    const { getByText, queryByText } = render(<ReportForm onSuccess={jest.fn()} />);
+    fireEvent.press(getByText('INDOOR'));
+    expect(getByText('Indoor Details')).toBeTruthy();
+    fireEvent.press(getByText('OUTDOOR'));
+    expect(queryByText('Indoor Details')).toBeNull();
+  });
+
+  it('shows building suggestions when typing 2+ characters', async () => {
+    const { getByText, getByPlaceholderText } = render(<ReportForm onSuccess={jest.fn()} />);
+    fireEvent.press(getByText('INDOOR'));
+    const input = getByPlaceholderText('Search building…');
+    fireEvent.changeText(input, 'Eng');
+    act(() => { jest.advanceTimersByTime(400); });
+    await waitFor(() => {
+      expect(getByText('Engineering Faculty')).toBeTruthy();
+    });
+  });
+
+  it('fills building name when a suggestion is selected', async () => {
+    const { getByText, getByPlaceholderText, queryByText } = render(<ReportForm onSuccess={jest.fn()} />);
+    fireEvent.press(getByText('INDOOR'));
+    const input = getByPlaceholderText('Search building…');
+    fireEvent.changeText(input, 'Eng');
+    act(() => { jest.advanceTimersByTime(400); });
+    await waitFor(() => getByText('Engineering Faculty'));
+    fireEvent.press(getByText('Engineering Faculty'));
+    expect(input.props.value).toBe('Engineering Faculty');
+    expect(queryByText('Engineering Faculty')).toBeNull();
+  });
+});

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -44,6 +44,11 @@ const CATEGORY_LABEL: Record<string, string> = {
   DAMAGED_SURFACE: 'Damaged Surface',
   ROAD_CONSTRUCTION: 'Road Construction',
   BLOCKED_PATH: 'Blocked Path',
+  BROKEN_ELEVATOR: 'Broken Elevator',
+  INACCESSIBLE_RESTROOM: 'Inaccessible Restroom',
+  NARROW_CORRIDOR: 'Narrow Corridor',
+  HEAVY_DOOR: 'Heavy Door',
+  SLIPPERY_FLOOR: 'Slippery Floor',
   OTHER: 'Other',
 };
 

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -149,3 +149,151 @@ export async function searchLocations(q: string): Promise<SearchResult[]> {
   // Fallback to Nominatim when backend returns no results or fails
   return searchNominatim(q);
 }
+
+async function nominatimReverse(lat: number, lng: number, zoom: string): Promise<any> {
+  const params = new URLSearchParams({
+    format: 'json',
+    lat: String(lat),
+    lon: String(lng),
+    zoom,
+    addressdetails: '1',
+    'accept-language': 'en',
+  });
+  const res = await fetch(
+    `https://nominatim.openstreetmap.org/reverse?${params}`,
+    { headers: { 'User-Agent': 'AccessMap/1.0' } },
+  );
+  if (!res.ok) return null;
+  return res.json().catch(() => null);
+}
+
+// OSM classes that are definitively outdoor / non-building
+const OUTDOOR_CLASSES = new Set([
+  'highway', 'waterway', 'natural', 'landuse', 'boundary', 'place',
+]);
+
+// OSM types that are outdoor structures / memorials even when class = tourism|historic
+const OUTDOOR_TYPES = new Set([
+  'memorial', 'statue', 'monument', 'ruins', 'wayside_cross', 'wayside_shrine',
+  'archaeological_site', 'tree', 'bench', 'waste_basket',
+]);
+
+/**
+ * Returns the indoor-venue name from a Nominatim reverse-geocode result, or null.
+ *
+ * INCLUDED (indoor venues the user might report an obstacle in):
+ *   amenity=restaurant/pharmacy/cafe/hospital/…, shop=*, office=*, tourism=hotel/hostel,
+ *   leisure=gym/…, building polygon with a name, etc.
+ *
+ * EXCLUDED (outdoor features that would give wrong suggestions):
+ *   highways/roads, waterways, memorials, statues, monuments, natural features,
+ *   administrative boundaries, etc.
+ */
+function extractNominatimName(data: any): string | null {
+  if (!data?.name) return null;
+  const cls: string  = data.class ?? '';
+  const type: string = data.type  ?? '';
+  if (OUTDOOR_CLASSES.has(cls))  return null;
+  if (OUTDOOR_TYPES.has(type))   return null;
+  return data.name as string;
+}
+
+/**
+ * Finds the nearest named building polygon within `radius` metres using
+ * the Overpass API.  Queries OSM *ways* (polygons) directly — unaffected by
+ * nearby POI nodes that Nominatim might prefer.
+ */
+async function overpassNearestBuilding(
+  lat: number,
+  lng: number,
+  radius = 35,
+): Promise<string | null> {
+  const query =
+    `[out:json][timeout:6];` +
+    `way(around:${radius},${lat},${lng})[building][name];` +
+    `out center tags;`;
+
+  const res = await fetch('https://overpass-api.de/api/interpreter', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `data=${encodeURIComponent(query)}`,
+  });
+  if (!res.ok) return null;
+
+  const data = await res.json().catch(() => null);
+  if (!Array.isArray(data?.elements) || data.elements.length === 0) return null;
+
+  // Pick the element whose centroid is closest to the pin.
+  let best: { name: string; dist: number } | null = null;
+  for (const el of data.elements) {
+    const name: string | undefined = el.tags?.name;
+    if (!name) continue;
+    const cLat: number = el.center?.lat ?? lat;
+    const cLon: number = el.center?.lon ?? lng;
+    const dist = Math.hypot(cLat - lat, cLon - lng);
+    if (!best || dist < best.dist) best = { name, dist };
+  }
+
+  return best?.name ?? null;
+}
+
+/**
+ * Returns the building / venue name at the given coordinates, or null.
+ *
+ * Two-tier strategy with a proximity gate:
+ *
+ *  Tier 1 — Nominatim (POI precision, proximity-gated)
+ *    Nominatim returns the most specific named OSM node near the pin, together
+ *    with that node's own coordinates (data.lat/data.lon).
+ *    If the returned element is within ~20 m of the pin the user deliberately
+ *    tapped on it (e.g. a restaurant or pharmacy icon) → use its name.
+ *    If it is farther away, the user clicked somewhere in a building and
+ *    Nominatim just found the nearest node in the area → skip it.
+ *
+ *  Tier 2 — Overpass (building polygon fallback)
+ *    When the pin is in an open area of a building (no POI node underneath),
+ *    Nominatim returns something far away.  Overpass finds named building
+ *    polygons within 35 m and picks the closest centroid.
+ *
+ *  Tier 3 — Nominatim regardless of distance
+ *    No building polygon was found either.  If Nominatim returned any named
+ *    indoor venue (not a road / memorial / natural feature) use it as a last
+ *    resort (better than nothing).
+ *
+ * Returns null when no indoor name can be determined → the field stays empty
+ * so the user can type manually.
+ */
+export async function reverseGeocode(lat: number, lng: number): Promise<string | null> {
+  // ~20 m expressed in degrees (1° lat ≈ 111 km)
+  const PROXIMITY_DEG = 0.00018;
+
+  try {
+    const [nominatimData, overpassName] = await Promise.all([
+      nominatimReverse(lat, lng, '18').catch(() => null),
+      overpassNearestBuilding(lat, lng).catch(() => null),
+    ]);
+
+    const nominatimName = extractNominatimName(nominatimData);
+
+    // Tier 1: Nominatim result is very close → user tapped that specific POI
+    if (nominatimName && nominatimData) {
+      const nLat = parseFloat(nominatimData.lat ?? '');
+      const nLon = parseFloat(nominatimData.lon ?? '');
+      if (!isNaN(nLat) && !isNaN(nLon)) {
+        const dist = Math.hypot(nLat - lat, nLon - lng);
+        if (dist < PROXIMITY_DEG) return nominatimName;
+      }
+    }
+
+    // Tier 2: nearest named building polygon (pin in open building area)
+    if (overpassName) return overpassName;
+
+    // Tier 3: Nominatim fallback regardless of distance
+    if (nominatimName) return nominatimName;
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -11,6 +11,7 @@ import { calculateRoute, type GuestPreferences, type RouteResult } from '../../a
 import { isLoggedIn } from '../../services/auth';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
+import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -64,22 +65,36 @@ const MAP_HTML = `<!DOCTYPE html>
     markers = [];
     var currentZoom = map.getZoom();
     obstacles.forEach(function(obs) {
-      if (obs.isIndoor && currentZoom < 18) return;
+      if (obs.isIndoor && currentZoom < ${HIGH_DETAIL_ZOOM}) return;
       var isPassive = obs.status === 'PASSIVE';
       var color = CATEGORY_COLOR[obs.category] || '#9CA3AF';
-      var marker = L.circleMarker([obs.latitude, obs.longitude], {
-        radius: 10, color: color, fillColor: color,
-        fillOpacity: isPassive ? 0.4 : 0.85,
-        weight: isPassive ? 1 : 2, opacity: isPassive ? 0.5 : 1
-      });
+      var marker;
+      if (obs.isIndoor) {
+        var indoorIcon = L.divIcon({
+          html: '<div style="width:22px;height:22px;border-radius:50%;background:' + color + ';border:3px solid white;box-shadow:0 3px 8px rgba(0,0,0,0.45);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:800;color:white;font-family:system-ui,sans-serif;line-height:1">i<\/div>',
+          className: '',
+          iconSize: [22, 22],
+          iconAnchor: [11, 11]
+        });
+        marker = L.marker([obs.latitude, obs.longitude], {
+          icon: indoorIcon,
+          opacity: isPassive ? 0.5 : 1
+        });
+      } else {
+        marker = L.circleMarker([obs.latitude, obs.longitude], {
+          radius: 10, color: color, fillColor: color,
+          fillOpacity: isPassive ? 0.4 : 0.85,
+          weight: isPassive ? 1 : 2, opacity: isPassive ? 0.5 : 1
+        });
+      }
       var statusColor = STATUS_COLOR[obs.status] || '#9CA3AF';
       var statusLabel = STATUS_LABEL[obs.status] || obs.status;
       var catLabel = obs.category.replace(/_/g, ' ');
       var popupHtml =
-        '<div class="popup-title">' + obs.title + '<\\/div>' +
-        '<span class="badge" style="background:' + color + '">' + catLabel + '<\\/span>' +
-        '<span class="badge" style="background:' + statusColor + '">' + statusLabel + '<\\/span>' +
-        (obs.description ? '<div class="popup-desc">' + obs.description + '<\\/div>' : '');
+        '<div class="popup-title">' + obs.title + '<\/div>' +
+        '<span class="badge" style="background:' + color + '">' + catLabel + '<\/span>' +
+        '<span class="badge" style="background:' + statusColor + '">' + statusLabel + '<\/span>' +
+        (obs.description ? '<div class="popup-desc">' + obs.description + '<\/div>' : '');
       marker.bindPopup(popupHtml, { maxWidth: 220 });
       marker.on('click', function() {
         window.ReactNativeWebView && window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'PIN_CLICK', id: obs.id }));

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -480,7 +480,12 @@ export default function MapView() {
                   eventHandlers={{ click: () => handlePinClick(obs.id) }}
                 >
                   <Popup>
-                    <ObstaclePopup obs={obs} detail={detail} loading={detailLoading} />
+                    <ObstaclePopup
+                      obs={obs}
+                      detail={detail}
+                      loading={detailLoading}
+                      onViewDetails={() => router.push(`/report/${obs.id}`)}
+                    />
                   </Popup>
                 </Marker>
               );

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -22,6 +22,7 @@ import { calculateRoute, type GuestPreferences, type RouteResult } from '../../a
 import { isLoggedIn } from '../../services/auth';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
+import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
 
 // ── Leaflet icon setup ──────────────────────────────────────────────────────
 
@@ -44,11 +45,26 @@ const ORIGIN_ICON = makeCircleIcon(COLORS.green700);
 const DEST_ICON = makeCircleIcon(COLORS.red500);
 const SEARCH_PIN_ICON = makeCircleIcon(COLORS.red500);
 
+/** Indoor obstacle: circle with a small white 'i' badge — same colour coding as outdoor. */
+const makeIndoorCircleIcon = (color: string) =>
+  L.divIcon({
+    html: `<div style="
+      width:22px;height:22px;border-radius:50%;
+      background:${color};border:3px solid white;
+      box-shadow:0 3px 8px rgba(0,0,0,0.45);
+      display:flex;align-items:center;justify-content:center;
+      font-size:11px;font-weight:800;color:white;
+      font-family:system-ui,sans-serif;line-height:1;
+    ">i</div>`,
+    className: '',
+    iconSize: [22, 22],
+    iconAnchor: [11, 11],
+  });
+
 // ── Constants ───────────────────────────────────────────────────────────────
 
 const BOUN_CENTER: [number, number] = [41.0847, 29.0503];
 const DEFAULT_ZOOM = 16;
-const HIGH_DETAIL_ZOOM = 18;
 const DEFAULT_BBOX = { north: 41.095, south: 41.074, east: 29.065, west: 29.035 };
 
 const CATEGORY_COLOR: Record<string, string> = {
@@ -445,6 +461,22 @@ export default function MapView() {
             const cached = detailMap[obs.id];
             const detail = cached && cached !== 'loading' ? (cached as ObstacleDetail) : undefined;
             const detailLoading = cached === 'loading';
+
+            if (obs.isIndoor) {
+              return (
+                <Marker
+                  key={obs.id}
+                  position={[obs.latitude, obs.longitude]}
+                  icon={makeIndoorCircleIcon(color)}
+                  opacity={isPassive ? 0.5 : 1}
+                  eventHandlers={{ click: () => handlePinClick(obs.id) }}
+                >
+                  <Popup>
+                    <ObstaclePopup obs={obs} detail={detail} loading={detailLoading} />
+                  </Popup>
+                </Marker>
+              );
+            }
 
             return (
               <CircleMarker

--- a/frontend/src/components/reports/ReportForm.tsx
+++ b/frontend/src/components/reports/ReportForm.tsx
@@ -5,7 +5,7 @@ import { COLORS } from '../../constants/theme';
 import { useLocation } from '../../hooks/useLocation';
 import PhotoPicker, { type PhotoEntry } from './PhotoPicker';
 import { submitReport } from '../../api/reports';
-import { searchLocations, searchNominatim, type SearchResult } from '../../api/map';
+import { searchLocations, searchNominatim, reverseGeocode, type SearchResult } from '../../api/map';
 import { parseDRFError } from '../../services/auth';
 import LocationPicker from './LocationPicker';
 import type { ObstacleCategory, ReportContext, SubmitReportResponse } from '../../types/report';
@@ -57,6 +57,43 @@ export default function ReportForm({ onSuccess }: Props) {
       if (buildingTimerRef.current) clearTimeout(buildingTimerRef.current);
     };
   }, []);
+
+  // Auto-fill building name from coordinates when context is INDOOR
+  useEffect(() => {
+    if (context !== 'INDOOR') return;
+
+    // In 'pick' mode, prefer the fine-grained pinned point; fall back to the
+    // centre of the selected search area when the user hasn't dragged the pin.
+    const coords =
+      locationMode === 'current'
+        ? loc.location
+        : pickedLocation ?? (selectedArea
+            ? { lat: selectedArea.latitude, lng: selectedArea.longitude }
+            : null);
+
+    if (!coords) return;
+
+    // Don't overwrite if user already typed something
+    if (buildingName.trim()) return;
+
+    let cancelled = false;
+    setBuildingLoading(true);
+    reverseGeocode(coords.lat, coords.lng).then((name) => {
+      if (cancelled) return;
+      if (name) setBuildingName(name);
+      setBuildingLoading(false);
+    });
+    return () => { cancelled = true; };
+  }, [
+    context,
+    locationMode,
+    loc.location?.lat,
+    loc.location?.lng,
+    pickedLocation?.lat,
+    pickedLocation?.lng,
+    selectedArea?.latitude,
+    selectedArea?.longitude,
+  ]);
 
   function addPhoto(p: PhotoEntry)   { setPhotos(prev => [...prev, p]); setPhotoError(''); }
   function removePhoto(i: number)    { setPhotos(prev => prev.filter((_, idx) => idx !== i)); }

--- a/frontend/src/components/reports/ReportForm.tsx
+++ b/frontend/src/components/reports/ReportForm.tsx
@@ -46,6 +46,7 @@ export default function ReportForm({ onSuccess }: Props) {
   const [buildingName, setBuildingName]               = useState('');
   const [buildingSuggestions, setBuildingSuggestions] = useState<SearchResult[]>([]);
   const [buildingLoading, setBuildingLoading]         = useState(false);
+  const [buildingUserEdited, setBuildingUserEdited]   = useState(false);
   const [floor, setFloor]                             = useState('');
   const buildingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -58,7 +59,8 @@ export default function ReportForm({ onSuccess }: Props) {
     };
   }, []);
 
-  // Auto-fill building name from coordinates when context is INDOOR
+  // Auto-fill building name from coordinates when context is INDOOR.
+  // Runs on every pin/location change — clears stale value and re-fetches.
   useEffect(() => {
     if (context !== 'INDOOR') return;
 
@@ -73,14 +75,14 @@ export default function ReportForm({ onSuccess }: Props) {
 
     if (!coords) return;
 
-    // Don't overwrite if user already typed something
-    if (buildingName.trim()) return;
-
     let cancelled = false;
+    // Clear stale value immediately so the field shows the spinner, not old data.
+    setBuildingName('');
+    setBuildingUserEdited(false);
     setBuildingLoading(true);
     reverseGeocode(coords.lat, coords.lng).then((name) => {
       if (cancelled) return;
-      if (name) setBuildingName(name);
+      if (name) { setBuildingName(name); setBuildingUserEdited(false); }
       setBuildingLoading(false);
     });
     return () => { cancelled = true; };
@@ -94,6 +96,7 @@ export default function ReportForm({ onSuccess }: Props) {
     selectedArea?.latitude,
     selectedArea?.longitude,
   ]);
+
 
   function addPhoto(p: PhotoEntry)   { setPhotos(prev => [...prev, p]); setPhotoError(''); }
   function removePhoto(i: number)    { setPhotos(prev => prev.filter((_, idx) => idx !== i)); }
@@ -131,12 +134,14 @@ export default function ReportForm({ onSuccess }: Props) {
     if (c === 'OUTDOOR') {
       setBuildingName('');
       setBuildingSuggestions([]);
+      setBuildingUserEdited(false);
       setFloor('');
     }
   }, []);
 
   const handleBuildingInput = useCallback((text: string) => {
     setBuildingName(text);
+    setBuildingUserEdited(true);
     if (buildingTimerRef.current) clearTimeout(buildingTimerRef.current);
     if (text.trim().length < 2) { setBuildingSuggestions([]); return; }
     buildingTimerRef.current = setTimeout(async () => {
@@ -398,7 +403,7 @@ export default function ReportForm({ onSuccess }: Props) {
                 ))}
               </View>
             )}
-            {buildingName.trim().length >= 2 && !buildingLoading && buildingSuggestions.length === 0 && (
+            {buildingUserEdited && buildingName.trim().length >= 2 && !buildingLoading && buildingSuggestions.length === 0 && (
               <Text style={s.noResults}>No results found. Try a different search.</Text>
             )}
 

--- a/frontend/src/components/reports/ReportForm.tsx
+++ b/frontend/src/components/reports/ReportForm.tsx
@@ -362,7 +362,7 @@ export default function ReportForm({ onSuccess }: Props) {
               </View>
             )}
             {buildingName.trim().length >= 2 && !buildingLoading && buildingSuggestions.length === 0 && (
-              <Text style={s.noResults}>No results found</Text>
+              <Text style={s.noResults}>No results found. Try a different search.</Text>
             )}
 
             <Text style={[s.fieldLabel, { marginTop: 12 }]}>

--- a/frontend/src/components/reports/ReportForm.tsx
+++ b/frontend/src/components/reports/ReportForm.tsx
@@ -12,13 +12,22 @@ import type { ObstacleCategory, ReportContext, SubmitReportResponse } from '../.
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
-const CATEGORIES: Array<{ value: ObstacleCategory; label: string; icon: IoniconName }> = [
+const OUTDOOR_CATEGORIES: Array<{ value: ObstacleCategory; label: string; icon: IoniconName }> = [
   { value: 'BROKEN_RAMP',       label: 'Broken Ramp',    icon: 'arrow-up-circle-outline' },
   { value: 'NARROW_SIDEWALK',   label: 'Narrow Sidewalk', icon: 'resize-outline' },
   { value: 'DAMAGED_SURFACE',   label: 'Damaged Surface', icon: 'warning-outline' },
   { value: 'ROAD_CONSTRUCTION', label: 'Construction',    icon: 'construct-outline' },
   { value: 'BLOCKED_PATH',      label: 'Blocked Path',    icon: 'stop-circle-outline' },
   { value: 'OTHER',             label: 'Other',           icon: 'ellipsis-horizontal-circle-outline' },
+];
+
+const INDOOR_CATEGORIES: Array<{ value: ObstacleCategory; label: string; icon: IoniconName }> = [
+  { value: 'BROKEN_ELEVATOR',      label: 'Broken Elevator',   icon: 'arrow-up-outline' },
+  { value: 'INACCESSIBLE_RESTROOM',label: 'Inaccessible WC',   icon: 'man-outline' },
+  { value: 'NARROW_CORRIDOR',      label: 'Narrow Corridor',   icon: 'resize-outline' },
+  { value: 'HEAVY_DOOR',           label: 'Heavy Door',        icon: 'enter-outline' },
+  { value: 'SLIPPERY_FLOOR',       label: 'Slippery Floor',    icon: 'warning-outline' },
+  { value: 'OTHER',                label: 'Other',             icon: 'ellipsis-horizontal-circle-outline' },
 ];
 
 type LocationMode = 'current' | 'pick';
@@ -131,6 +140,7 @@ export default function ReportForm({ onSuccess }: Props) {
 
   const handleContextChange = useCallback((c: ReportContext) => {
     setContext(c);
+    setCategory(null); // reset category — selections don't carry across contexts
     if (c === 'OUTDOOR') {
       setBuildingName('');
       setBuildingSuggestions([]);
@@ -429,7 +439,7 @@ export default function ReportForm({ onSuccess }: Props) {
             </Text>
           </View>
           <View style={s.grid}>
-            {CATEGORIES.map(cat => {
+            {(context === 'INDOOR' ? INDOOR_CATEGORIES : OUTDOOR_CATEGORIES).map(cat => {
               const active = category === cat.value;
               return (
                 <TouchableOpacity

--- a/frontend/src/components/reports/ReportForm.tsx
+++ b/frontend/src/components/reports/ReportForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { View, Text, TextInput, TouchableOpacity, ScrollView, KeyboardAvoidingView, Platform, StyleSheet, ActivityIndicator, Linking } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../constants/theme';
@@ -50,6 +50,13 @@ export default function ReportForm({ onSuccess }: Props) {
   const buildingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current)   clearTimeout(searchTimerRef.current);
+      if (buildingTimerRef.current) clearTimeout(buildingTimerRef.current);
+    };
+  }, []);
 
   function addPhoto(p: PhotoEntry)   { setPhotos(prev => [...prev, p]); setPhotoError(''); }
   function removePhoto(i: number)    { setPhotos(prev => prev.filter((_, idx) => idx !== i)); }
@@ -353,6 +360,9 @@ export default function ReportForm({ onSuccess }: Props) {
                   </TouchableOpacity>
                 ))}
               </View>
+            )}
+            {buildingName.trim().length >= 2 && !buildingLoading && buildingSuggestions.length === 0 && (
+              <Text style={s.noResults}>No results found</Text>
             )}
 
             <Text style={[s.fieldLabel, { marginTop: 12 }]}>

--- a/frontend/src/components/reports/ReportForm.tsx
+++ b/frontend/src/components/reports/ReportForm.tsx
@@ -5,7 +5,7 @@ import { COLORS } from '../../constants/theme';
 import { useLocation } from '../../hooks/useLocation';
 import PhotoPicker, { type PhotoEntry } from './PhotoPicker';
 import { submitReport } from '../../api/reports';
-import { searchNominatim, type SearchResult } from '../../api/map';
+import { searchLocations, searchNominatim, type SearchResult } from '../../api/map';
 import { parseDRFError } from '../../services/auth';
 import LocationPicker from './LocationPicker';
 import type { ObstacleCategory, ReportContext, SubmitReportResponse } from '../../types/report';
@@ -43,6 +43,12 @@ export default function ReportForm({ onSuccess }: Props) {
   const [selectedArea, setSelectedArea] = useState<SearchResult | null>(null);
   const [pickedLocation, setPickedLocation] = useState<{ lat: number; lng: number } | null>(null);
 
+  const [buildingName, setBuildingName]               = useState('');
+  const [buildingSuggestions, setBuildingSuggestions] = useState<SearchResult[]>([]);
+  const [buildingLoading, setBuildingLoading]         = useState(false);
+  const [floor, setFloor]                             = useState('');
+  const buildingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   function addPhoto(p: PhotoEntry)   { setPhotos(prev => [...prev, p]); setPhotoError(''); }
@@ -76,6 +82,32 @@ export default function ReportForm({ onSuccess }: Props) {
     setSearchResults([]);
   }, []);
 
+  const handleContextChange = useCallback((c: ReportContext) => {
+    setContext(c);
+    if (c === 'OUTDOOR') {
+      setBuildingName('');
+      setBuildingSuggestions([]);
+      setFloor('');
+    }
+  }, []);
+
+  const handleBuildingInput = useCallback((text: string) => {
+    setBuildingName(text);
+    if (buildingTimerRef.current) clearTimeout(buildingTimerRef.current);
+    if (text.trim().length < 2) { setBuildingSuggestions([]); return; }
+    buildingTimerRef.current = setTimeout(async () => {
+      setBuildingLoading(true);
+      const results = await searchLocations(text.trim());
+      setBuildingSuggestions(results);
+      setBuildingLoading(false);
+    }, 400);
+  }, []);
+
+  const handleSelectBuilding = useCallback((result: SearchResult) => {
+    setBuildingName(result.name);
+    setBuildingSuggestions([]);
+  }, []);
+
   const handleSwitchMode = useCallback((mode: LocationMode) => {
     setLocationMode(mode);
     if (mode === 'current') {
@@ -96,6 +128,10 @@ export default function ReportForm({ onSuccess }: Props) {
   async function handleSubmit() {
     setApiError('');
     if (photos.length === 0) { setPhotoError('At least one photo is required.'); return; }
+    if (context === 'INDOOR' && !buildingName.trim()) {
+      setApiError('Building name is required for indoor reports.');
+      return;
+    }
     if (!finalLocation) {
       setApiError(locationMode === 'current'
         ? 'Location not available yet — please wait or tap Retry.'
@@ -110,6 +146,11 @@ export default function ReportForm({ onSuccess }: Props) {
         category,
         description: description.trim(),
         photos: photos.map(p => p.b64),
+        ...(context === 'INDOOR' && {
+          buildingName: buildingName.trim(),
+          floor: floor.trim() || undefined,
+          isIndoor: true,
+        }),
       });
       if (res.ok) {
         onSuccess(res.data as SubmitReportResponse);
@@ -262,7 +303,7 @@ export default function ReportForm({ onSuccess }: Props) {
               <TouchableOpacity
                 key={c}
                 style={[s.pill, context === c && s.pillActive]}
-                onPress={() => setContext(c)}
+                onPress={() => handleContextChange(c)}
                 activeOpacity={0.8}
               >
                 <Ionicons
@@ -275,6 +316,57 @@ export default function ReportForm({ onSuccess }: Props) {
             ))}
           </View>
         </View>
+
+        {/* ── Indoor Details ── */}
+        {context === 'INDOOR' && (
+          <View style={s.card}>
+            <View style={s.cardTitleRow}>
+              <Ionicons name="business-outline" size={18} color={COLORS.green600} />
+              <Text style={s.cardTitle}>Indoor Details</Text>
+            </View>
+
+            <Text style={s.fieldLabel}>
+              Building name <Text style={s.required}>*</Text>
+            </Text>
+            <View style={s.searchRow}>
+              <Ionicons name="search" size={16} color={COLORS.gray400} />
+              <TextInput
+                style={s.searchInput}
+                placeholder="Search building…"
+                placeholderTextColor={COLORS.gray400}
+                value={buildingName}
+                onChangeText={handleBuildingInput}
+              />
+              {buildingLoading && <ActivityIndicator size="small" color={COLORS.green600} />}
+            </View>
+            {buildingSuggestions.length > 0 && (
+              <View style={s.resultsList}>
+                {buildingSuggestions.map((r) => (
+                  <TouchableOpacity
+                    key={r.id}
+                    style={s.resultItem}
+                    onPress={() => handleSelectBuilding(r)}
+                    activeOpacity={0.7}
+                  >
+                    <Ionicons name="business-outline" size={16} color={COLORS.green600} />
+                    <Text style={s.resultText} numberOfLines={2}>{r.name}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+
+            <Text style={[s.fieldLabel, { marginTop: 12 }]}>
+              Floor <Text style={s.optional}>(optional)</Text>
+            </Text>
+            <TextInput
+              style={s.floorInput}
+              placeholder="e.g. Ground Floor, 2nd Floor, Basement"
+              placeholderTextColor={COLORS.gray400}
+              value={floor}
+              onChangeText={setFloor}
+            />
+          </View>
+        )}
 
         {/* ── Category ── */}
         <View style={s.card}>
@@ -408,4 +500,12 @@ const s = StyleSheet.create({
   // Selected area
   selectedAreaRow: { flexDirection: 'row' as const, alignItems: 'center' as const, gap: 8, backgroundColor: COLORS.green50, padding: 10, borderRadius: 10, borderWidth: 1, borderColor: COLORS.green200 },
   selectedAreaText:{ fontSize: 13, color: COLORS.green700, fontWeight: '600', flex: 1 },
+  // Indoor Details
+  fieldLabel:  { fontSize: 13, fontWeight: '600', color: COLORS.gray700, marginBottom: 6 },
+  required:    { color: COLORS.red500 },
+  floorInput:  {
+    borderWidth: 1.5, borderColor: COLORS.gray300, borderRadius: 10,
+    paddingHorizontal: 14, paddingVertical: 10,
+    fontSize: 14, color: COLORS.gray900,
+  },
 });

--- a/frontend/src/constants/mapConstants.ts
+++ b/frontend/src/constants/mapConstants.ts
@@ -1,0 +1,2 @@
+/** Minimum zoom level at which indoor obstacle markers become visible on the map. */
+export const HIGH_DETAIL_ZOOM = 18;

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -1,10 +1,18 @@
 // Matches ObstacleCategory enum in backend apps/reports/models.py
 export type ObstacleCategory =
+  // Outdoor
   | 'BROKEN_RAMP'
   | 'NARROW_SIDEWALK'
   | 'DAMAGED_SURFACE'
   | 'ROAD_CONSTRUCTION'
   | 'BLOCKED_PATH'
+  // Indoor
+  | 'BROKEN_ELEVATOR'
+  | 'INACCESSIBLE_RESTROOM'
+  | 'NARROW_CORRIDOR'
+  | 'HEAVY_DOOR'
+  | 'SLIPPERY_FLOOR'
+  // Shared
   | 'OTHER';
 
 // Required by API spec §4.4 — note: DB Report model is missing this field (needs migration)

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -17,6 +17,9 @@ export interface SubmitReportPayload {
   category: ObstacleCategory | null;
   description: string;
   photos: string[]; // base64-encoded image strings
+  buildingName?: string;
+  floor?: string;
+  isIndoor?: boolean;
 }
 
 // POST /reports success response — API spec §4.4


### PR DESCRIPTION
## Description

Adds full indoor reporting support to the ReportForm and improves indoor obstacle
visibility on the map. When a user selects the **INDOOR** context, dedicated building
and floor fields appear with smart auto-fill via reverse geocoding. Indoor obstacle
markers are visually distinct from outdoor ones and only shown at high zoom levels.

## Type of Change
- [x] `feat` — new feature
- [x] `fix` — bug fix
- [x] `test` — adding or updating tests

## Changes

**Form — Indoor Details card**
- Building name field with debounced autocomplete (400 ms, min 2 chars) backed by `searchLocations`
- Floor field (optional, free text)
- Both fields clear when switching back to OUTDOOR; `buildingName` is required on submit
- `buildingName`, `floor`, `isIndoor: true` appended to submit payload only for INDOOR reports

**Form — Building name auto-fill**
- On pin placement (current location or map pick), `reverseGeocode` is called automatically
- Two-tier strategy: Nominatim proximity-gated (< 20 m) → Overpass building polygon (< 35 m) → Nominatim fallback
- `OUTDOOR_CLASSES` / `OUTDOOR_TYPES` filter excludes roads, memorials, natural features
- Field clears and re-fetches on every new pin; never overwrites intentional user input (`buildingUserEdited` flag)
- "No results found" message only shows when the user is actively typing — not after auto-fill

**Form — Indoor-specific categories**
- Separate `INDOOR_CATEGORIES` list: Broken Elevator, Inaccessible WC, Narrow Corridor, Heavy Door, Slippery Floor, Other
- Outdoor categories unchanged; selected category resets when context switches
- Backend `ObstacleCategory` enum extended with the 5 new values (no migration needed — choices-only change)

**Map — Indoor obstacle markers**
- Indoor obstacles rendered with a distinct **circle + white `i` badge** (22 px) instead of the plain circle used for outdoor
- Indoor markers hidden below zoom 18; threshold extracted to `src/constants/mapConstants.ts` (`HIGH_DETAIL_ZOOM = 18`) — single source of truth for both web (react-leaflet) and mobile (WebView Leaflet)

**Backend**
- `ALLOWED_HOSTS` accepts all hosts when `DEBUG=True` to enable LAN testing from physical devices

**Tests**
- 7 Jest tests covering: card visibility, autocomplete trigger, no-results feedback, building required validation, floor optional, OUTDOOR cleanup, submit payload shape

## How to Test

1. Open the Report form and select **INDOOR** context
2. Verify "Indoor Details" card appears with Building name and Floor fields
3. In "Choose on Map" mode, drop a pin on a known building → building name should auto-fill within ~2 s
4. Move the pin to a different building → field should clear and re-fill with new name
5. Type manually in the building field → auto-fill should no longer overwrite; "No results found" appears only when typing returns empty results
6. Switch context back to OUTDOOR → both fields should disappear / clear
7. Try to submit an INDOOR report without a building name → validation error shown
8. Zoom the map above level 18 → indoor obstacle markers appear as circles with `i`; zoom below 18 → they disappear

## Screenshots (if applicable)

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #173
- Closes #176

## Notes
- `feat/obstacle-interactions` PR has a single-line overlap in `ReportForm.tsx` (`outlineStyle: 'none'` on `searchInput`); minor manual conflict resolution needed on second merge.
- Backend `submitReport` endpoint does not yet persist `buildingName` / `floor` / `isIndoor` — tracked as a separate backend issue.
- `HIGH_DETAIL_ZOOM` can be adjusted in `src/constants/mapConstants.ts` without touching either MapView file.
