### PR TITLE
feat: implement POST /api/reports/{id}/upvote endpoint

### DIFF
--- a/backend/apps/interactions/serializers.py
+++ b/backend/apps/interactions/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+
+
+class UpvoteResponseSerializer(serializers.Serializer):
+    reportId = serializers.UUIDField()
+    upvoteCount = serializers.IntegerField()
+    status = serializers.CharField()

--- a/backend/apps/interactions/services.py
+++ b/backend/apps/interactions/services.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.db import transaction
+from rest_framework.exceptions import NotFound, PermissionDenied
+
+from apps.reports.models import Interaction, InteractionType, Report, ReportStatus
+
+
+def upvote_report(user, report_id) -> dict:
+    try:
+        report = Report.objects.get(pk=report_id)
+    except Report.DoesNotExist:
+        raise NotFound("Report not found.")
+
+    if report.reporter_id == user.pk:
+        raise PermissionDenied("Cannot upvote your own report.")
+
+    with transaction.atomic():
+        _, created = Interaction.objects.get_or_create(
+            report=report,
+            user=user,
+            interaction_type=InteractionType.UPVOTE,
+        )
+
+        upvote_count = report.interactions.filter(
+            interaction_type=InteractionType.UPVOTE
+        ).count()
+
+        if created and upvote_count >= settings.UPVOTE_THRESHOLD:
+            report.status = ReportStatus.CONFIRMED
+            report.save(update_fields=["status", "updated_at"])
+
+    return {
+        "reportId": report.id,
+        "upvoteCount": upvote_count,
+        "status": report.status,
+    }

--- a/backend/apps/interactions/tests.py
+++ b/backend/apps/interactions/tests.py
@@ -1,0 +1,182 @@
+import uuid
+
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.test import APIClient
+
+from apps.reports.models import (
+    Interaction,
+    InteractionType,
+    ObstacleCategory,
+    Report,
+    ReportContext,
+    ReportStatus,
+)
+from apps.users.models import User
+
+
+def make_user(email="user@test.com", **kwargs):
+    return User.objects.create_user(
+        email=email, full_name="Test User", password="pass", **kwargs
+    )
+
+
+def make_report(reporter, **kwargs):
+    defaults = dict(
+        title="Broken Ramp",
+        description="The ramp is broken.",
+        category=ObstacleCategory.BROKEN_RAMP,
+        context=ReportContext.OUTDOOR,
+        status=ReportStatus.VERIFIED,
+        latitude="41.083700",
+        longitude="29.051000",
+    )
+    defaults.update(kwargs)
+    return Report.objects.create(reporter=reporter, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# Service: upvote_report
+# ---------------------------------------------------------------------------
+
+
+class UpvoteReportServiceTest(TestCase):
+    def setUp(self):
+        self.reporter = make_user(email="reporter@test.com")
+        self.voter = make_user(email="voter@test.com")
+        self.report = make_report(self.reporter)
+
+    def test_upvote_creates_interaction(self):
+        from apps.interactions.services import upvote_report
+
+        result = upvote_report(self.voter, self.report.pk)
+
+        self.assertEqual(result["upvoteCount"], 1)
+        self.assertTrue(
+            Interaction.objects.filter(
+                report=self.report,
+                user=self.voter,
+                interaction_type=InteractionType.UPVOTE,
+            ).exists()
+        )
+
+    def test_upvote_idempotent_no_double_count(self):
+        from apps.interactions.services import upvote_report
+
+        upvote_report(self.voter, self.report.pk)
+        result = upvote_report(self.voter, self.report.pk)
+
+        self.assertEqual(result["upvoteCount"], 1)
+        self.assertEqual(
+            Interaction.objects.filter(
+                report=self.report, interaction_type=InteractionType.UPVOTE
+            ).count(),
+            1,
+        )
+
+    def test_cannot_upvote_own_report(self):
+        from apps.interactions.services import upvote_report
+
+        with self.assertRaises(PermissionDenied):
+            upvote_report(self.reporter, self.report.pk)
+
+    def test_upvote_count_increments_per_distinct_user(self):
+        from apps.interactions.services import upvote_report
+
+        voter2 = make_user(email="voter2@test.com")
+        upvote_report(self.voter, self.report.pk)
+        result = upvote_report(voter2, self.report.pk)
+
+        self.assertEqual(result["upvoteCount"], 2)
+
+    def test_nonexistent_report_raises_not_found(self):
+        from apps.interactions.services import upvote_report
+
+        with self.assertRaises(NotFound):
+            upvote_report(self.voter, uuid.uuid4())
+
+    @override_settings(UPVOTE_THRESHOLD=3)
+    def test_confirmed_transition_at_threshold(self):
+        from apps.interactions.services import upvote_report
+
+        voters = [make_user(email=f"v{i}@test.com") for i in range(3)]
+
+        for voter in voters[:2]:
+            result = upvote_report(voter, self.report.pk)
+            self.assertNotEqual(result["status"], ReportStatus.CONFIRMED)
+
+        result = upvote_report(voters[2], self.report.pk)
+        self.assertEqual(result["status"], ReportStatus.CONFIRMED)
+
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, ReportStatus.CONFIRMED)
+
+    @override_settings(UPVOTE_THRESHOLD=3)
+    def test_no_double_transition_on_idempotent_upvote(self):
+        from apps.interactions.services import upvote_report
+
+        voters = [make_user(email=f"v{i}@test.com") for i in range(3)]
+        for voter in voters:
+            upvote_report(voter, self.report.pk)
+
+        self.report.status = ReportStatus.VERIFIED
+        self.report.save()
+
+        result = upvote_report(voters[0], self.report.pk)
+        self.assertEqual(result["status"], ReportStatus.VERIFIED)
+
+
+# ---------------------------------------------------------------------------
+# View: POST /api/reports/{id}/upvote/
+# ---------------------------------------------------------------------------
+
+
+class ReportUpvoteViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.reporter = make_user(email="reporter@test.com")
+        self.voter = make_user(email="voter@test.com")
+        self.report = make_report(self.reporter)
+        self.url = f"/api/reports/{self.report.pk}/upvote/"
+
+    def test_upvote_returns_200_with_expected_fields(self):
+        self.client.force_authenticate(user=self.voter)
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("reportId", data)
+        self.assertIn("upvoteCount", data)
+        self.assertIn("status", data)
+        self.assertEqual(data["upvoteCount"], 1)
+
+    def test_unauthenticated_returns_401(self):
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_own_report_returns_403(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_idempotent_upvote_returns_200(self):
+        self.client.force_authenticate(user=self.voter)
+        self.client.post(self.url)
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["upvoteCount"], 1)
+
+    def test_nonexistent_report_returns_404(self):
+        self.client.force_authenticate(user=self.voter)
+        response = self.client.post(f"/api/reports/{uuid.uuid4()}/upvote/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @override_settings(UPVOTE_THRESHOLD=1)
+    def test_upvote_triggers_confirmed_status(self):
+        self.client.force_authenticate(user=self.voter)
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], ReportStatus.CONFIRMED)

--- a/backend/apps/interactions/urls.py
+++ b/backend/apps/interactions/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import ReportUpvoteView
+
+app_name = "interactions"
+
+urlpatterns = [
+    path("<uuid:report_id>/upvote/", ReportUpvoteView.as_view(), name="report-upvote"),
+]

--- a/backend/apps/interactions/views.py
+++ b/backend/apps/interactions/views.py
@@ -1,0 +1,16 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.permissions import IsUser
+
+from .serializers import UpvoteResponseSerializer
+from .services import upvote_report
+
+
+class ReportUpvoteView(APIView):
+    permission_classes = [IsUser]
+
+    def post(self, request, report_id):
+        result = upvote_report(request.user, report_id)
+        return Response(UpvoteResponseSerializer(result).data, status=status.HTTP_200_OK)

--- a/backend/apps/reports/models.py
+++ b/backend/apps/reports/models.py
@@ -8,6 +8,7 @@ class ReportStatus(models.TextChoices):
     UNVERIFIED = "UNVERIFIED", "Unverified"
     PASSIVE = "PASSIVE", "Passive"
     VERIFIED = "VERIFIED", "Verified"
+    CONFIRMED = "CONFIRMED", "Confirmed"
     RESOLVED_AWAITING_VALIDATION = (
         "RESOLVED_AWAITING_VALIDATION",
         "Resolved Awaiting Validation",

--- a/backend/apps/reports/urls.py
+++ b/backend/apps/reports/urls.py
@@ -1,8 +1,10 @@
-from django.urls import path
+from django.urls import include, path
+
 from apps.reports import views
 
 app_name = 'reports'
 
 urlpatterns = [
     path('', views.ReportCreateView.as_view(), name='report-create'),
+    path('', include('apps.interactions.urls')),
 ]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -129,6 +129,7 @@ SUPABASE_PHOTOS_BUCKET = config('SUPABASE_PHOTOS_BUCKET', default='report-photos
 
 TRUST_SCORE_VERIFIED_DELTA = config('TRUST_SCORE_VERIFIED_DELTA', default=5, cast=int)
 TRUST_SCORE_MALICIOUS_DELTA = config('TRUST_SCORE_MALICIOUS_DELTA', default=10, cast=int)
+UPVOTE_THRESHOLD = config('UPVOTE_THRESHOLD', default=5, cast=int)
 
 STATIC_URL = '/static/'
 STATIC_ROOT = BASE_DIR / 'staticfiles'


### PR DESCRIPTION
## Description

Implements `POST /api/reports/{id}/upvote` as specified in issue #174.

Authenticated users can upvote a report to signal it is a real obstacle. The endpoint is idempotent — calling it twice records only one vote. When the upvote count reaches the configurable threshold (`UPVOTE_THRESHOLD`, default 5), the report's status transitions to `CONFIRMED`.

## Type of Change
- [x] `feat` — new feature

## Changes

- `apps/reports/models.py` — added `CONFIRMED` to `ReportStatus` choices
- `apps/interactions/services.py` — `upvote_report(user, report_id)`: checks ownership, idempotently creates an `Interaction(type=UPVOTE)`, counts upvotes, transitions to `CONFIRMED` when threshold is reached — all inside a single atomic transaction
- `apps/interactions/serializers.py` — `UpvoteResponseSerializer` returning `reportId`, `upvoteCount`, `status`
- `apps/interactions/views.py` — `ReportUpvoteView` (POST, `IsUser` permission)
- `apps/interactions/urls.py` — route declaration
- `apps/reports/urls.py` — includes the interactions URLs so the full path resolves to `/api/reports/{id}/upvote/`
- `config/settings.py` — `UPVOTE_THRESHOLD` env-configurable setting (default 5)
- `apps/interactions/tests.py` — 12 tests covering service and view behaviours

**No DB migration needed.** `CONFIRMED` is a new `TextChoices` member: Django does not add database-level `CHECK` constraints for `CharField` choices, so the existing `status` column already accepts this value. Upvote counts are computed dynamically from the existing `Interaction` table (which has `unique_together = ("report", "user", "interaction_type")` to prevent double-counting), avoiding any schema change.

## How to Test

1. Create a report as user A
2. `POST /api/reports/{id}/upvote/` as user B → 200, `upvoteCount: 1`
3. Repeat step 2 as user B → 200, `upvoteCount: 1` (idempotent)
4. `POST /api/reports/{id}/upvote/` as user A → 403
5. `POST /api/reports/{unknown-uuid}/upvote/` → 404
6. Set `UPVOTE_THRESHOLD=1` and upvote as user B → `status` becomes `CONFIRMED`

Run tests: `python manage.py test apps.interactions`

## Screenshots (if applicable)

N/A

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #174

## Notes
- `UPVOTE_THRESHOLD` is env-configurable (same pattern as `TRUST_SCORE_VERIFIED_DELTA` and `TRUST_SCORE_MALICIOUS_DELTA`)
- The threshold check is guarded by `if created` so a repeated call by an already-upvoted user can never re-trigger the transition
- The `interactions` app was scaffolded in an earlier PR; this fills in its service/view/serializer/urls