### PR TITLE
feat(map): add reporterId, userUpvoted, userFlagged to obstacle detail

### DIFF
--- a/backend/apps/map/selectors.py
+++ b/backend/apps/map/selectors.py
@@ -27,7 +27,7 @@ def get_obstacles_in_bbox(sw_lat, sw_lng, ne_lat, ne_lng, include_passive=False,
 def get_obstacle_detail(report_id):
     try:
         return (
-            Report.objects.prefetch_related(
+            Report.objects.select_related("reporter").prefetch_related(
                 "photos",
                 "interactions",
                 "status_changes",

--- a/backend/apps/map/serializers.py
+++ b/backend/apps/map/serializers.py
@@ -50,6 +50,7 @@ class StatusHistorySerializer(serializers.Serializer):
 
 class ObstacleDetailSerializer(serializers.Serializer):
     reportId = serializers.UUIDField(source="id")
+    reporterId = serializers.UUIDField(source="reporter.id")
     location = serializers.SerializerMethodField()
     category = serializers.CharField()
     context = serializers.CharField()
@@ -57,6 +58,8 @@ class ObstacleDetailSerializer(serializers.Serializer):
     description = serializers.CharField()
     upvoteCount = serializers.SerializerMethodField()
     flagCount = serializers.SerializerMethodField()
+    userUpvoted = serializers.SerializerMethodField()
+    userFlagged = serializers.SerializerMethodField()
     photos = PhotoSerializer(many=True)
     statusHistory = StatusHistorySerializer(many=True, source="status_changes")
     createdAt = serializers.DateTimeField(source="created_at")
@@ -69,6 +72,22 @@ class ObstacleDetailSerializer(serializers.Serializer):
 
     def get_flagCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.FLAG)
+
+    def _user_has_interaction(self, obj, interaction_type):
+        request = self.context.get("request")
+        if request is None or not request.user.is_authenticated:
+            return False
+        user_id = request.user.id
+        return any(
+            i.user_id == user_id and i.interaction_type == interaction_type
+            for i in obj.interactions.all()
+        )
+
+    def get_userUpvoted(self, obj):
+        return self._user_has_interaction(obj, InteractionType.UPVOTE)
+
+    def get_userFlagged(self, obj):
+        return self._user_has_interaction(obj, InteractionType.FLAG)
 
 
 class CampusLocationSerializer(serializers.Serializer):

--- a/backend/apps/map/tests.py
+++ b/backend/apps/map/tests.py
@@ -283,6 +283,67 @@ class ObstacleDetailViewTest(TestCase):
 
 
 # ---------------------------------------------------------------------------
+# View: GET /api/map/obstacles/<id>/ — auth-aware fields (reporterId, userUpvoted, userFlagged)
+# ---------------------------------------------------------------------------
+
+class ObstacleDetailUserFieldsTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.reporter = make_user("reporter@test.com")
+        self.report = make_report(self.reporter, report_status=ReportStatus.VERIFIED)
+
+    def _url(self, report_id):
+        return f"/api/map/obstacles/{report_id}/"
+
+    def test_anonymous_user_fields(self):
+        response = self.client.get(self._url(self.report.pk))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["reporterId"], str(self.reporter.id))
+        self.assertFalse(data["userUpvoted"])
+        self.assertFalse(data["userFlagged"])
+
+    def test_reporter_id_for_own_report(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.get(self._url(self.report.pk))
+        self.assertEqual(response.json()["reporterId"], str(self.reporter.id))
+
+    def test_user_upvoted_true_when_upvoted(self):
+        voter = make_user("voter@test.com")
+        Interaction.objects.create(
+            report=self.report, user=voter, interaction_type=InteractionType.UPVOTE,
+        )
+        self.client.force_authenticate(user=voter)
+        response = self.client.get(self._url(self.report.pk))
+        data = response.json()
+        self.assertTrue(data["userUpvoted"])
+        self.assertFalse(data["userFlagged"])
+
+    def test_user_flagged_true_when_flagged(self):
+        flagger = make_user("flagger@test.com")
+        Interaction.objects.create(
+            report=self.report, user=flagger, interaction_type=InteractionType.FLAG,
+        )
+        self.client.force_authenticate(user=flagger)
+        response = self.client.get(self._url(self.report.pk))
+        data = response.json()
+        self.assertTrue(data["userFlagged"])
+        self.assertFalse(data["userUpvoted"])
+
+    def test_user_fields_isolated_per_user(self):
+        voter = make_user("voter@test.com")
+        bystander = make_user("bystander@test.com")
+        Interaction.objects.create(
+            report=self.report, user=voter, interaction_type=InteractionType.UPVOTE,
+        )
+        self.client.force_authenticate(user=bystander)
+        response = self.client.get(self._url(self.report.pk))
+        data = response.json()
+        self.assertFalse(data["userUpvoted"])
+        self.assertFalse(data["userFlagged"])
+
+
+# ---------------------------------------------------------------------------
 # View: GET /api/map/search?q=...
 # ---------------------------------------------------------------------------
 

--- a/backend/apps/map/views.py
+++ b/backend/apps/map/views.py
@@ -53,7 +53,7 @@ class ObstacleDetailView(APIView):
         if obstacle is None:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
 
-        serializer = ObstacleDetailSerializer(obstacle)
+        serializer = ObstacleDetailSerializer(obstacle, context={"request": request})
         return Response(serializer.data)
 
 


### PR DESCRIPTION
## Summary
Extends `GET /api/map/obstacles/{id}/` with `reporterId`, `userUpvoted`, and `userFlagged`. These unblock own-report detection and already-upvoted state restoration in the obstacle detail UI from PR #190.

Closes #196

## Changes
- `ObstacleDetailSerializer` returns `reporterId` (reporter UUID).
- Returns `userUpvoted` / `userFlagged` reflecting the requesting user's interactions; `false` for anonymous users.
- View passes `request` into serializer context (without it, the auth-aware fields would always be false).
- Selector adds `select_related("reporter")` to avoid an extra query for the reporter id.
- 5 new tests in `ObstacleDetailUserFieldsTest` covering anonymous, own-report, upvoted, flagged, and per-user isolation cases.

## Test plan
- [x] `pytest apps/map/tests.py -v` — all 46 tests pass (41 existing + 5 new).
- [x] Anonymous GET returns both flags false and `reporterId` matches the reporter.
- [x] Authenticated GET returns true flags after upvote/flag.
- [x] Per-user isolation verified (one user's upvote does not leak into another user's response).