### PR TITLE
Feature/saved places

### DIFF
--- a/frontend/app/tabs/profile.tsx
+++ b/frontend/app/tabs/profile.tsx
@@ -104,18 +104,19 @@ export default function ProfileScreen() {
           <Text style={s.cardTitle}>Saved Places</Text>
         </View>
         {savedPlaces.length === 0 ? (
-          <View style={s.stub}>
+          <View testID="saved-places-empty" style={s.stub}>
             <Text style={s.stubP}>No saved places yet. Save frequent destinations from the route planning screen.</Text>
           </View>
         ) : (
           savedPlaces.map((place) => (
-            <View key={place.id} style={s.placeRow}>
+            <View key={place.id} testID={`saved-place-${place.id}`} style={s.placeRow}>
               <Ionicons name="location-outline" size={16} color={COLORS.green600} style={{ marginTop: 1 }} />
               <View style={{ flex: 1, minWidth: 0 }}>
                 <Text style={s.placeLabel}>{place.label}</Text>
                 {!!place.address && <Text style={s.placeAddress} numberOfLines={1}>{place.address}</Text>}
               </View>
               <TouchableOpacity
+                testID={`delete-place-${place.id}`}
                 onPress={() => handleDeletePlace(place.id)}
                 disabled={deletingId === place.id}
                 style={s.deleteBtn}

--- a/frontend/app/tabs/profile.tsx
+++ b/frontend/app/tabs/profile.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../src/constants/theme';
 import { getMe, updateMe, clearTokens, isLoggedIn, parseDRFError, UserProfile } from '../../src/services/auth';
 import { MobilityProfileCard } from '../../src/components/profile/MobilityProfileCard';
+import { getSavedPlaces, deleteSavedPlace, SavedPlace } from '../../src/api/savedPlaces';
 
 function getInitials(name: string): string {
   if (!name) return '?';
@@ -22,6 +23,9 @@ export default function ProfileScreen() {
   const [editError, setEditError] = useState('');
   const [successMsg, setSuccessMsg] = useState('');
 
+  const [savedPlaces, setSavedPlaces] = useState<SavedPlace[]>([]);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
   const loadProfile = useCallback(async () => {
     if (!isLoggedIn()) { router.replace('/auth/login'); return; }
     setLoadingPage(true);
@@ -34,6 +38,17 @@ export default function ProfileScreen() {
   }, [router]);
 
   useEffect(() => { loadProfile(); }, [loadProfile]);
+
+  useEffect(() => {
+    getSavedPlaces().then(setSavedPlaces);
+  }, []);
+
+  async function handleDeletePlace(id: string) {
+    setDeletingId(id);
+    const ok = await deleteSavedPlace(id);
+    if (ok) setSavedPlaces((prev) => prev.filter((p) => p.id !== id));
+    setDeletingId(null);
+  }
 
   async function handleSave() {
     if (!editName.trim()) { setEditError('Name cannot be empty.'); return; }
@@ -83,6 +98,37 @@ export default function ProfileScreen() {
 
       <MobilityProfileCard />
 
+      <View style={s.card}>
+        <View style={s.cardTitleRow}>
+          <Ionicons name="bookmark-outline" size={16} color={COLORS.green600} />
+          <Text style={s.cardTitle}>Saved Places</Text>
+        </View>
+        {savedPlaces.length === 0 ? (
+          <View style={s.stub}>
+            <Text style={s.stubP}>No saved places yet. Save frequent destinations from the route planning screen.</Text>
+          </View>
+        ) : (
+          savedPlaces.map((place) => (
+            <View key={place.id} style={s.placeRow}>
+              <Ionicons name="location-outline" size={16} color={COLORS.green600} style={{ marginTop: 1 }} />
+              <View style={{ flex: 1, minWidth: 0 }}>
+                <Text style={s.placeLabel}>{place.label}</Text>
+                {!!place.address && <Text style={s.placeAddress} numberOfLines={1}>{place.address}</Text>}
+              </View>
+              <TouchableOpacity
+                onPress={() => handleDeletePlace(place.id)}
+                disabled={deletingId === place.id}
+                style={s.deleteBtn}
+              >
+                {deletingId === place.id
+                  ? <ActivityIndicator size="small" color={COLORS.gray400} />
+                  : <Ionicons name="trash-outline" size={16} color={COLORS.red500} />}
+              </TouchableOpacity>
+            </View>
+          ))
+        )}
+      </View>
+
       <View style={[s.card, { marginBottom: 20 }]}>
         <View style={s.cardTitleRow}><Ionicons name="ribbon-outline" size={16} color={COLORS.green600} /><Text style={s.cardTitle}>Badges</Text></View>
         <View style={s.stub}><View style={s.stubTag}><Text style={s.stubTagText}>MILESTONE 2</Text></View><Text style={s.stubP}>Earned badges from contributions and community activity.</Text></View>
@@ -127,6 +173,10 @@ const s = StyleSheet.create({
   stubTag: { backgroundColor: COLORS.orange100, paddingHorizontal: 8, paddingVertical: 3, borderRadius: 100, marginBottom: 6 },
   stubTagText: { fontSize: 10, fontWeight: '800', color: COLORS.orange500, letterSpacing: 0.5 },
   stubP: { fontSize: 13, color: COLORS.gray400, textAlign: 'center', lineHeight: 20 },
+  placeRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, paddingVertical: 10, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: COLORS.gray200 },
+  placeLabel: { fontSize: 14, fontWeight: '600', color: COLORS.gray800 },
+  placeAddress: { fontSize: 12, color: COLORS.gray400, marginTop: 1 },
+  deleteBtn: { width: 32, height: 32, alignItems: 'center', justifyContent: 'center' },
   logoutBtn: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, marginHorizontal: 14, paddingVertical: 14, borderRadius: 10, backgroundColor: COLORS.white, borderWidth: 1, borderColor: COLORS.gray200 },
   logoutText: { fontSize: 14, fontWeight: '600', color: COLORS.red600 },
 });

--- a/frontend/src/__tests__/ProfileSavedPlaces.test.tsx
+++ b/frontend/src/__tests__/ProfileSavedPlaces.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import ProfileScreen from '../../app/tabs/profile';
+import * as auth from '../services/auth';
+import * as savedPlacesApi from '../api/savedPlaces';
+
+jest.mock('../services/auth');
+jest.mock('../api/savedPlaces');
+jest.mock('../components/profile/MobilityProfileCard', () => ({
+  MobilityProfileCard: () => null,
+}));
+const mockRouter = { replace: jest.fn(), push: jest.fn() };
+jest.mock('expo-router', () => ({
+  useRouter: () => mockRouter,
+}));
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+const mockIsLoggedIn = auth.isLoggedIn as jest.MockedFunction<typeof auth.isLoggedIn>;
+const mockGetMe = auth.getMe as jest.MockedFunction<typeof auth.getMe>;
+const mockGetSavedPlaces = savedPlacesApi.getSavedPlaces as jest.MockedFunction<typeof savedPlacesApi.getSavedPlaces>;
+const mockDeleteSavedPlace = savedPlacesApi.deleteSavedPlace as jest.MockedFunction<typeof savedPlacesApi.deleteSavedPlace>;
+
+const MOCK_USER = {
+  userId: 'u1',
+  email: 'test@example.com',
+  fullName: 'Test User',
+  status: 'ACTIVE',
+  trustScore: 10,
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+const MOCK_PLACES = [
+  { id: 'p1', label: 'Home', latitude: 41.0, longitude: 29.0, address: '123 Main St', createdAt: '2026-01-01T00:00:00Z' },
+  { id: 'p2', label: 'Work', latitude: 41.1, longitude: 29.1, address: undefined, createdAt: '2026-01-02T00:00:00Z' },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsLoggedIn.mockReturnValue(true);
+  mockGetMe.mockResolvedValue({ ok: true, status: 200, data: MOCK_USER });
+  mockGetSavedPlaces.mockResolvedValue([]);
+  mockDeleteSavedPlace.mockResolvedValue(true);
+});
+
+it('shows empty state when there are no saved places', async () => {
+  mockGetSavedPlaces.mockResolvedValue([]);
+  const { getByTestId } = render(<ProfileScreen />);
+
+  await waitFor(() => expect(getByTestId('saved-places-empty')).toBeTruthy());
+});
+
+it('renders saved place items with their labels', async () => {
+  mockGetSavedPlaces.mockResolvedValue(MOCK_PLACES);
+  const { getByTestId, getByText } = render(<ProfileScreen />);
+
+  await waitFor(() => {
+    expect(getByTestId('saved-place-p1')).toBeTruthy();
+    expect(getByTestId('saved-place-p2')).toBeTruthy();
+    expect(getByText('Home')).toBeTruthy();
+    expect(getByText('Work')).toBeTruthy();
+  });
+});
+
+it('renders the address when present', async () => {
+  mockGetSavedPlaces.mockResolvedValue(MOCK_PLACES);
+  const { getByText } = render(<ProfileScreen />);
+
+  await waitFor(() => expect(getByText('123 Main St')).toBeTruthy());
+});
+
+it('calls deleteSavedPlace and removes item when delete is pressed', async () => {
+  mockGetSavedPlaces.mockResolvedValue(MOCK_PLACES);
+  const { getByTestId, queryByTestId } = render(<ProfileScreen />);
+
+  await waitFor(() => expect(getByTestId('delete-place-p1')).toBeTruthy());
+
+  await act(async () => {
+    fireEvent.press(getByTestId('delete-place-p1'));
+  });
+
+  expect(mockDeleteSavedPlace).toHaveBeenCalledWith('p1');
+  expect(queryByTestId('saved-place-p1')).toBeNull();
+});
+
+it('keeps the item if deletion fails', async () => {
+  mockDeleteSavedPlace.mockResolvedValue(false);
+  mockGetSavedPlaces.mockResolvedValue(MOCK_PLACES);
+  const { getByTestId } = render(<ProfileScreen />);
+
+  await waitFor(() => expect(getByTestId('delete-place-p1')).toBeTruthy());
+
+  await act(async () => {
+    fireEvent.press(getByTestId('delete-place-p1'));
+  });
+
+  expect(mockDeleteSavedPlace).toHaveBeenCalledWith('p1');
+  expect(getByTestId('saved-place-p1')).toBeTruthy();
+});

--- a/frontend/src/__tests__/SavePlaceModal.test.tsx
+++ b/frontend/src/__tests__/SavePlaceModal.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import SavePlaceModal from '../components/map/SavePlaceModal';
+
+const baseProps = {
+  label: '',
+  onLabelChange: jest.fn(),
+  saving: false,
+  error: '',
+  onSave: jest.fn(),
+  onCancel: jest.fn(),
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+it('renders Home and Work preset chips', () => {
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} />);
+  expect(getByTestId('preset-chip-home')).toBeTruthy();
+  expect(getByTestId('preset-chip-work')).toBeTruthy();
+});
+
+it('pressing a preset chip calls onLabelChange with that preset', () => {
+  const onLabelChange = jest.fn();
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} onLabelChange={onLabelChange} />);
+
+  fireEvent.press(getByTestId('preset-chip-home'));
+
+  expect(onLabelChange).toHaveBeenCalledWith('Home');
+});
+
+it('pressing Work preset chip calls onLabelChange with "Work"', () => {
+  const onLabelChange = jest.fn();
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} onLabelChange={onLabelChange} />);
+
+  fireEvent.press(getByTestId('preset-chip-work'));
+
+  expect(onLabelChange).toHaveBeenCalledWith('Work');
+});
+
+it('save button is disabled when label is empty', () => {
+  const onSave = jest.fn();
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} label="" onSave={onSave} />);
+
+  fireEvent.press(getByTestId('save-btn'));
+
+  expect(onSave).not.toHaveBeenCalled();
+});
+
+it('save button is disabled while saving is true', () => {
+  const onSave = jest.fn();
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} label="Home" saving={true} onSave={onSave} />);
+
+  fireEvent.press(getByTestId('save-btn'));
+
+  expect(onSave).not.toHaveBeenCalled();
+});
+
+it('calls onSave when label is set and save button is pressed', () => {
+  const onSave = jest.fn();
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} label="Home" onSave={onSave} />);
+
+  fireEvent.press(getByTestId('save-btn'));
+
+  expect(onSave).toHaveBeenCalledTimes(1);
+});
+
+it('does not show error banner when error is empty', () => {
+  const { queryByTestId } = render(<SavePlaceModal {...baseProps} error="" />);
+  expect(queryByTestId('save-error-banner')).toBeNull();
+});
+
+it('shows error banner with message when error is set', () => {
+  const { getByTestId, getByText } = render(
+    <SavePlaceModal {...baseProps} error="Failed to save place. Please try again." />,
+  );
+  expect(getByTestId('save-error-banner')).toBeTruthy();
+  expect(getByText('Failed to save place. Please try again.')).toBeTruthy();
+});
+
+it('calls onCancel when cancel button is pressed', () => {
+  const onCancel = jest.fn();
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} onCancel={onCancel} />);
+
+  fireEvent.press(getByTestId('cancel-btn'));
+
+  expect(onCancel).toHaveBeenCalledTimes(1);
+});
+
+it('typing in the label input calls onLabelChange', () => {
+  const onLabelChange = jest.fn();
+  const { getByTestId } = render(<SavePlaceModal {...baseProps} onLabelChange={onLabelChange} />);
+
+  fireEvent.changeText(getByTestId('save-label-input'), 'Gym');
+
+  expect(onLabelChange).toHaveBeenCalledWith('Gym');
+});

--- a/frontend/src/api/savedPlaces.ts
+++ b/frontend/src/api/savedPlaces.ts
@@ -1,0 +1,63 @@
+import { API_BASE } from '../constants/theme';
+import { getAccessToken } from '../services/auth';
+
+export interface SavedPlace {
+  id: string;
+  label: string;
+  latitude: number;
+  longitude: number;
+  address?: string;
+  createdAt: string;
+}
+
+export interface SavedPlacePayload {
+  label: string;
+  latitude: number;
+  longitude: number;
+  address?: string;
+}
+
+function authHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = getAccessToken();
+  if (token) h['Authorization'] = `Bearer ${token}`;
+  return h;
+}
+
+export async function getSavedPlaces(): Promise<SavedPlace[]> {
+  try {
+    const res = await fetch(`${API_BASE}/api/users/me/saved-places/`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
+export async function createSavedPlace(payload: SavedPlacePayload): Promise<SavedPlace | null> {
+  try {
+    const res = await fetch(`${API_BASE}/api/users/me/saved-places/`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteSavedPlace(id: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/users/me/saved-places/${id}/`, {
+      method: 'DELETE',
+      headers: authHeaders(),
+    });
+    return res.ok || res.status === 204;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  ActivityIndicator, FlatList, Keyboard, StyleSheet, Switch,
+  ActivityIndicator, FlatList, Keyboard, ScrollView, StyleSheet, Switch,
   Text, TextInput, TouchableOpacity, View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -8,6 +8,7 @@ import WebView from 'react-native-webview';
 
 import { fetchObstacles, searchLocations, type Obstacle, type SearchResult } from '../../api/map';
 import { calculateRoute, type GuestPreferences, type RouteResult } from '../../api/routes';
+import { getSavedPlaces, createSavedPlace, type SavedPlace } from '../../api/savedPlaces';
 import { isLoggedIn } from '../../services/auth';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
@@ -252,6 +253,12 @@ export default function MapView() {
     maxSlopeGradient: 8,
   });
 
+  // Saved places state
+  const [savedPlaces, setSavedPlaces] = useState<SavedPlace[]>([]);
+  const [saveTarget, setSaveTarget] = useState<{ kind: 'origin' | 'dest'; lat: number; lng: number; address: string } | null>(null);
+  const [saveLabel, setSaveLabel] = useState('');
+  const [savingPlace, setSavingPlace] = useState(false);
+
   // Origin autocomplete state
   const [originSuggestions, setOriginSuggestions] = useState<SearchResult[]>([]);
   const [destSuggestions, setDestSuggestions] = useState<SearchResult[]>([]);
@@ -266,6 +273,34 @@ export default function MapView() {
   const prefetchedRef = useRef<Obstacle[] | null>(null);
 
   const { location: currentLocation } = useLocation();
+
+  // ── Saved places ─────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (isLoggedIn()) getSavedPlaces().then(setSavedPlaces);
+  }, []);
+
+  const handleSavePlace = useCallback(async () => {
+    if (!saveTarget || !saveLabel.trim()) return;
+    setSavingPlace(true);
+    const result = await createSavedPlace({
+      label: saveLabel.trim(),
+      latitude: saveTarget.lat,
+      longitude: saveTarget.lng,
+      address: saveTarget.address || undefined,
+    });
+    setSavingPlace(false);
+    if (result) setSavedPlaces((prev) => [...prev, result]);
+    setSaveTarget(null);
+    setSaveLabel('');
+  }, [saveTarget, saveLabel]);
+
+  const openSaveModal = (kind: 'origin' | 'dest') => {
+    const point = kind === 'origin' ? origin : dest;
+    if (!point) return;
+    setSaveTarget({ kind, lat: point.lat, lng: point.lng, address: point.label });
+    setSaveLabel('');
+  };
 
   // ── Obstacle loading ─────────────────────────────────────────────────────
 
@@ -589,6 +624,18 @@ export default function MapView() {
                 </TouchableOpacity>
               </View>
 
+              {/* Saved places quick-select for origin */}
+              {originFocused && savedPlaces.length > 0 && originQ.length === 0 && (
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.savedChips} keyboardShouldPersistTaps="handled">
+                  {savedPlaces.map((p) => (
+                    <TouchableOpacity key={p.id} style={s.savedChip} onPress={() => selectOriginSuggestion({ id: p.id, name: p.label, latitude: p.latitude, longitude: p.longitude })}>
+                      <Ionicons name="bookmark" size={11} color={COLORS.green700} />
+                      <Text style={s.savedChipText}>{p.label}</Text>
+                    </TouchableOpacity>
+                  ))}
+                </ScrollView>
+              )}
+
               {/* Origin row */}
               <View style={s.inputRow}>
                 <View style={[s.dot, s.dotOrigin]} />
@@ -629,6 +676,11 @@ export default function MapView() {
                   <Ionicons name="location-outline" size={18}
                     color={pinMode === 'origin' ? COLORS.green700 : COLORS.gray400} />
                 </TouchableOpacity>
+                {origin && isLoggedIn() && (
+                  <TouchableOpacity style={s.bookmarkBtn} onPress={() => openSaveModal('origin')}>
+                    <Ionicons name="bookmark-outline" size={16} color={COLORS.green700} />
+                  </TouchableOpacity>
+                )}
               </View>
 
               {/* Use current location button */}
@@ -638,6 +690,18 @@ export default function MapView() {
               </TouchableOpacity>
 
               <View style={s.connector}><View style={s.connectorLine} /></View>
+
+              {/* Saved places quick-select for destination */}
+              {destFocused && savedPlaces.length > 0 && destQ.length === 0 && (
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.savedChips} keyboardShouldPersistTaps="handled">
+                  {savedPlaces.map((p) => (
+                    <TouchableOpacity key={p.id} style={s.savedChip} onPress={() => selectDestSuggestion({ id: p.id, name: p.label, latitude: p.latitude, longitude: p.longitude })}>
+                      <Ionicons name="bookmark" size={11} color={COLORS.green700} />
+                      <Text style={s.savedChipText}>{p.label}</Text>
+                    </TouchableOpacity>
+                  ))}
+                </ScrollView>
+              )}
 
               {/* Destination row */}
               <View style={s.inputRow}>
@@ -679,6 +743,11 @@ export default function MapView() {
                   <Ionicons name="location-outline" size={18}
                     color={pinMode === 'dest' ? COLORS.red500 : COLORS.gray400} />
                 </TouchableOpacity>
+                {dest && isLoggedIn() && (
+                  <TouchableOpacity style={s.bookmarkBtn} onPress={() => openSaveModal('dest')}>
+                    <Ionicons name="bookmark-outline" size={16} color={COLORS.green700} />
+                  </TouchableOpacity>
+                )}
               </View>
 
               {/* Get Route button */}
@@ -745,6 +814,47 @@ export default function MapView() {
         )}
 
       </View>
+
+      {/* Save place modal */}
+      {saveTarget && (
+        <View style={s.prefsOverlay}>
+          <View style={s.prefsCard}>
+            <Text style={s.prefsTitle}>Save Location</Text>
+            <Text style={s.prefsSubtitle}>Choose a label for this place.</Text>
+            <View style={s.presetRow}>
+              {['Home', 'Work'].map((preset) => (
+                <TouchableOpacity
+                  key={preset}
+                  style={[s.presetChip, saveLabel === preset && s.presetChipActive]}
+                  onPress={() => setSaveLabel(preset)}
+                >
+                  <Text style={[s.presetChipText, saveLabel === preset && s.presetChipTextActive]}>{preset}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <TextInput
+              style={[s.slopeInput, { width: '100%', textAlign: 'left', paddingHorizontal: 12 }]}
+              placeholder="Custom label"
+              placeholderTextColor={COLORS.gray400}
+              value={saveLabel}
+              onChangeText={setSaveLabel}
+              maxLength={50}
+            />
+            <TouchableOpacity
+              style={[s.prefsCalcBtn, (!saveLabel.trim() || savingPlace) && { backgroundColor: COLORS.gray300 }]}
+              onPress={handleSavePlace}
+              disabled={!saveLabel.trim() || savingPlace}
+            >
+              {savingPlace
+                ? <ActivityIndicator size="small" color={COLORS.white} />
+                : <><Ionicons name="bookmark-outline" size={16} color={COLORS.white} /><Text style={s.prefsCalcBtnText}>Save</Text></>}
+            </TouchableOpacity>
+            <TouchableOpacity style={s.prefsCancelBtn} onPress={() => setSaveTarget(null)}>
+              <Text style={s.prefsCancelText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
 
       {/* Guest preferences overlay */}
       {showPrefs && (
@@ -935,7 +1045,30 @@ const s = StyleSheet.create({
   errorRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 6 },
   errorText: { fontSize: 12, color: COLORS.red500 },
 
-  // ── Route summary ─────────────────────────────────────────────────────────
+  // ── Saved places ──────────────────────────────────────────────────────────
+  savedChips: { flexDirection: 'row', paddingVertical: 6, gap: 6 },
+  savedChip: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: 10, paddingVertical: 5,
+    backgroundColor: COLORS.green50, borderRadius: 100,
+    borderWidth: 1, borderColor: COLORS.green200,
+  },
+  savedChipText: { fontSize: 12, fontWeight: '600', color: COLORS.green700 },
+  bookmarkBtn: {
+    width: 36, height: 36, borderRadius: 9, borderWidth: 1,
+    borderColor: COLORS.green200, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: COLORS.green50, flexShrink: 0,
+  },
+  presetRow: { flexDirection: 'row', gap: 8, marginBottom: 8 },
+  presetChip: {
+    flex: 1, paddingVertical: 8, borderRadius: 9, alignItems: 'center',
+    borderWidth: 1.5, borderColor: COLORS.gray300, backgroundColor: COLORS.white,
+  },
+  presetChipActive: { borderColor: COLORS.green600, backgroundColor: COLORS.green50 },
+  presetChipText: { fontSize: 14, fontWeight: '600', color: COLORS.gray600 },
+  presetChipTextActive: { color: COLORS.green700 },
+
+  // ── Route summary ──────────────────────────────────────────────────────────
   summaryCard: {
     marginTop: 10,
     backgroundColor: COLORS.green50,

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -10,6 +10,7 @@ import { fetchObstacles, searchLocations, type Obstacle, type SearchResult } fro
 import { calculateRoute, type GuestPreferences, type RouteResult } from '../../api/routes';
 import { getSavedPlaces, createSavedPlace, type SavedPlace } from '../../api/savedPlaces';
 import { isLoggedIn } from '../../services/auth';
+import SavePlaceModal from './SavePlaceModal';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
 import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
@@ -258,6 +259,7 @@ export default function MapView() {
   const [saveTarget, setSaveTarget] = useState<{ kind: 'origin' | 'dest'; lat: number; lng: number; address: string } | null>(null);
   const [saveLabel, setSaveLabel] = useState('');
   const [savingPlace, setSavingPlace] = useState(false);
+  const [saveError, setSaveError] = useState('');
 
   // Origin autocomplete state
   const [originSuggestions, setOriginSuggestions] = useState<SearchResult[]>([]);
@@ -283,6 +285,7 @@ export default function MapView() {
   const handleSavePlace = useCallback(async () => {
     if (!saveTarget || !saveLabel.trim()) return;
     setSavingPlace(true);
+    setSaveError('');
     const result = await createSavedPlace({
       label: saveLabel.trim(),
       latitude: saveTarget.lat,
@@ -290,9 +293,13 @@ export default function MapView() {
       address: saveTarget.address || undefined,
     });
     setSavingPlace(false);
-    if (result) setSavedPlaces((prev) => [...prev, result]);
-    setSaveTarget(null);
-    setSaveLabel('');
+    if (result) {
+      setSavedPlaces((prev) => [...prev, result]);
+      setSaveTarget(null);
+      setSaveLabel('');
+    } else {
+      setSaveError('Failed to save place. Please try again.');
+    }
   }, [saveTarget, saveLabel]);
 
   const openSaveModal = (kind: 'origin' | 'dest') => {
@@ -300,6 +307,7 @@ export default function MapView() {
     if (!point) return;
     setSaveTarget({ kind, lat: point.lat, lng: point.lng, address: point.label });
     setSaveLabel('');
+    setSaveError('');
   };
 
   // ── Obstacle loading ─────────────────────────────────────────────────────
@@ -817,43 +825,14 @@ export default function MapView() {
 
       {/* Save place modal */}
       {saveTarget && (
-        <View style={s.prefsOverlay}>
-          <View style={s.prefsCard}>
-            <Text style={s.prefsTitle}>Save Location</Text>
-            <Text style={s.prefsSubtitle}>Choose a label for this place.</Text>
-            <View style={s.presetRow}>
-              {['Home', 'Work'].map((preset) => (
-                <TouchableOpacity
-                  key={preset}
-                  style={[s.presetChip, saveLabel === preset && s.presetChipActive]}
-                  onPress={() => setSaveLabel(preset)}
-                >
-                  <Text style={[s.presetChipText, saveLabel === preset && s.presetChipTextActive]}>{preset}</Text>
-                </TouchableOpacity>
-              ))}
-            </View>
-            <TextInput
-              style={[s.slopeInput, { width: '100%', textAlign: 'left', paddingHorizontal: 12 }]}
-              placeholder="Custom label"
-              placeholderTextColor={COLORS.gray400}
-              value={saveLabel}
-              onChangeText={setSaveLabel}
-              maxLength={50}
-            />
-            <TouchableOpacity
-              style={[s.prefsCalcBtn, (!saveLabel.trim() || savingPlace) && { backgroundColor: COLORS.gray300 }]}
-              onPress={handleSavePlace}
-              disabled={!saveLabel.trim() || savingPlace}
-            >
-              {savingPlace
-                ? <ActivityIndicator size="small" color={COLORS.white} />
-                : <><Ionicons name="bookmark-outline" size={16} color={COLORS.white} /><Text style={s.prefsCalcBtnText}>Save</Text></>}
-            </TouchableOpacity>
-            <TouchableOpacity style={s.prefsCancelBtn} onPress={() => setSaveTarget(null)}>
-              <Text style={s.prefsCancelText}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
+        <SavePlaceModal
+          label={saveLabel}
+          onLabelChange={(t) => { setSaveLabel(t); setSaveError(''); }}
+          saving={savingPlace}
+          error={saveError}
+          onSave={handleSavePlace}
+          onCancel={() => { setSaveTarget(null); setSaveError(''); }}
+        />
       )}
 
       {/* Guest preferences overlay */}

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -14,6 +14,19 @@ import { COLORS } from '../../constants/theme';
 import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
 import { useRouter } from 'expo-router';
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function formatDistance(m: number): string {
+  return m >= 1000 ? `${(m / 1000).toFixed(1)} km` : `${Math.round(m)} m`;
+}
+
+function formatTime(sec: number): string {
+  const mins = Math.round(sec / 60);
+  if (mins < 60) return `${mins} min`;
+  const h = Math.floor(mins / 60), rem = mins % 60;
+  return rem > 0 ? `${h}h ${rem}min` : `${h}h`;
+}
+
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const BOUN_CENTER = { lat: 41.0847, lng: 29.0503 };
@@ -690,6 +703,30 @@ export default function MapView() {
                   <Text style={s.errorText}>{routeError}</Text>
                 </View>
               )}
+
+              {route && (
+                <View style={s.summaryCard}>
+                  <View style={s.summaryRow}>
+                    <View style={s.summaryItem}>
+                      <Ionicons name="walk-outline" size={16} color={COLORS.green700} />
+                      <Text style={s.summaryValue}>{formatDistance(route.distanceMeters)}</Text>
+                      <Text style={s.summaryLabel}>Distance</Text>
+                    </View>
+                    <View style={s.summaryDivider} />
+                    <View style={s.summaryItem}>
+                      <Ionicons name="time-outline" size={16} color={COLORS.green700} />
+                      <Text style={s.summaryValue}>{formatTime(route.estimatedTimeSeconds)}</Text>
+                      <Text style={s.summaryLabel}>Est. time</Text>
+                    </View>
+                    <View style={s.summaryDivider} />
+                    <View style={s.summaryItem}>
+                      <Ionicons name="shield-checkmark-outline" size={16} color={COLORS.green700} />
+                      <Text style={s.summaryValue}>{route.avoidedObstaclesCount ?? 0}</Text>
+                      <Text style={s.summaryLabel}>Avoided</Text>
+                    </View>
+                  </View>
+                </View>
+              )}
             </View>
           )}
         </View>
@@ -897,6 +934,22 @@ const s = StyleSheet.create({
   routeBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
   errorRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 6 },
   errorText: { fontSize: 12, color: COLORS.red500 },
+
+  // ── Route summary ─────────────────────────────────────────────────────────
+  summaryCard: {
+    marginTop: 10,
+    backgroundColor: COLORS.green50,
+    borderRadius: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: COLORS.green200,
+  },
+  summaryRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around' },
+  summaryItem: { alignItems: 'center', gap: 2, flex: 1 },
+  summaryDivider: { width: 1, height: 32, backgroundColor: COLORS.green200 },
+  summaryValue: { fontSize: 14, fontWeight: '700', color: COLORS.gray800 },
+  summaryLabel: { fontSize: 10, color: COLORS.gray400, fontWeight: '500' },
 
   // ── Pin mode banner ────────────────────────────────────────────────────────
   pinBanner: {

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -21,6 +21,7 @@ import {
 import { calculateRoute, type GuestPreferences, type RouteResult } from '../../api/routes';
 import { getSavedPlaces, createSavedPlace, type SavedPlace } from '../../api/savedPlaces';
 import { isLoggedIn } from '../../services/auth';
+import SavePlaceModal from './SavePlaceModal';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
 import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
@@ -239,6 +240,7 @@ export default function MapView() {
   const [saveTarget, setSaveTarget] = useState<{ kind: 'origin' | 'dest'; lat: number; lng: number; address: string } | null>(null);
   const [saveLabel, setSaveLabel] = useState('');
   const [savingPlace, setSavingPlace] = useState(false);
+  const [saveError, setSaveError] = useState('');
 
   // Origin/Dest autocomplete state
   const [originSuggestions, setOriginSuggestions] = useState<SearchResult[]>([]);
@@ -259,6 +261,7 @@ export default function MapView() {
   const handleSavePlace = useCallback(async () => {
     if (!saveTarget || !saveLabel.trim()) return;
     setSavingPlace(true);
+    setSaveError('');
     const result = await createSavedPlace({
       label: saveLabel.trim(),
       latitude: saveTarget.lat,
@@ -266,9 +269,13 @@ export default function MapView() {
       address: saveTarget.address || undefined,
     });
     setSavingPlace(false);
-    if (result) setSavedPlaces((prev) => [...prev, result]);
-    setSaveTarget(null);
-    setSaveLabel('');
+    if (result) {
+      setSavedPlaces((prev) => [...prev, result]);
+      setSaveTarget(null);
+      setSaveLabel('');
+    } else {
+      setSaveError('Failed to save place. Please try again.');
+    }
   }, [saveTarget, saveLabel]);
 
   const openSaveModal = (kind: 'origin' | 'dest') => {
@@ -276,6 +283,7 @@ export default function MapView() {
     if (!point) return;
     setSaveTarget({ kind, lat: point.lat, lng: point.lng, address: point.label });
     setSaveLabel('');
+    setSaveError('');
   };
 
   // ── Obstacle loading ─────────────────────────────────────────────────────
@@ -839,43 +847,14 @@ export default function MapView() {
 
       {/* Save place modal */}
       {saveTarget && (
-        <View style={s.prefsOverlay}>
-          <View style={s.prefsCard}>
-            <Text style={s.prefsTitle}>Save Location</Text>
-            <Text style={s.prefsSubtitle}>Choose a label for this place.</Text>
-            <View style={s.presetRow}>
-              {['Home', 'Work'].map((preset) => (
-                <TouchableOpacity
-                  key={preset}
-                  style={[s.presetChip, saveLabel === preset && s.presetChipActive]}
-                  onPress={() => setSaveLabel(preset)}
-                >
-                  <Text style={[s.presetChipText, saveLabel === preset && s.presetChipTextActive]}>{preset}</Text>
-                </TouchableOpacity>
-              ))}
-            </View>
-            <TextInput
-              style={[s.slopeInput, { width: '100%', textAlign: 'left', paddingHorizontal: 12 }]}
-              placeholder="Custom label"
-              placeholderTextColor={COLORS.gray400}
-              value={saveLabel}
-              onChangeText={setSaveLabel}
-              maxLength={50}
-            />
-            <TouchableOpacity
-              style={[s.prefsCalcBtn, (!saveLabel.trim() || savingPlace) && { backgroundColor: COLORS.gray300 }]}
-              onPress={handleSavePlace}
-              disabled={!saveLabel.trim() || savingPlace}
-            >
-              {savingPlace
-                ? <ActivityIndicator size="small" color={COLORS.white} />
-                : <><Ionicons name="bookmark-outline" size={16} color={COLORS.white} /><Text style={s.prefsCalcBtnText}>Save</Text></>}
-            </TouchableOpacity>
-            <TouchableOpacity style={s.prefsCancelBtn} onPress={() => setSaveTarget(null)}>
-              <Text style={s.prefsCancelText}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
+        <SavePlaceModal
+          label={saveLabel}
+          onLabelChange={(t) => { setSaveLabel(t); setSaveError(''); }}
+          saving={savingPlace}
+          error={saveError}
+          onSave={handleSavePlace}
+          onCancel={() => { setSaveTarget(null); setSaveError(''); }}
+        />
       )}
 
       {/* Guest preferences overlay */}

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -25,6 +25,19 @@ import { COLORS } from '../../constants/theme';
 import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
 import { useRouter } from 'expo-router';
 
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatDistance(m: number): string {
+  return m >= 1000 ? `${(m / 1000).toFixed(1)} km` : `${Math.round(m)} m`;
+}
+
+function formatTime(sec: number): string {
+  const mins = Math.round(sec / 60);
+  if (mins < 60) return `${mins} min`;
+  const h = Math.floor(mins / 60), rem = mins % 60;
+  return rem > 0 ? `${h}h ${rem}min` : `${h}h`;
+}
+
 // ── Leaflet icon setup ──────────────────────────────────────────────────────
 
 delete (L.Icon.Default.prototype as any)._getIconUrl;
@@ -712,6 +725,30 @@ export default function MapView() {
                   <Text style={s.errorText}>{routeError}</Text>
                 </View>
               )}
+
+              {route && (
+                <View style={s.summaryCard}>
+                  <View style={s.summaryRow}>
+                    <View style={s.summaryItem}>
+                      <Ionicons name="walk-outline" size={16} color={COLORS.green700} />
+                      <Text style={s.summaryValue}>{formatDistance(route.distanceMeters)}</Text>
+                      <Text style={s.summaryLabel}>Distance</Text>
+                    </View>
+                    <View style={s.summaryDivider} />
+                    <View style={s.summaryItem}>
+                      <Ionicons name="time-outline" size={16} color={COLORS.green700} />
+                      <Text style={s.summaryValue}>{formatTime(route.estimatedTimeSeconds)}</Text>
+                      <Text style={s.summaryLabel}>Est. time</Text>
+                    </View>
+                    <View style={s.summaryDivider} />
+                    <View style={s.summaryItem}>
+                      <Ionicons name="shield-checkmark-outline" size={16} color={COLORS.green700} />
+                      <Text style={s.summaryValue}>{route.avoidedObstaclesCount ?? 0}</Text>
+                      <Text style={s.summaryLabel}>Avoided</Text>
+                    </View>
+                  </View>
+                </View>
+              )}
             </View>
           )}
         </View>
@@ -911,6 +948,22 @@ const s = StyleSheet.create({
   routeBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
   errorRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 6 },
   errorText: { fontSize: 12, color: COLORS.red500 },
+
+  // ── Route summary ────────────────────────────────────────────────────────
+  summaryCard: {
+    marginTop: 10,
+    backgroundColor: COLORS.green50,
+    borderRadius: 10,
+    paddingHorizontal: 8,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: COLORS.green200,
+  },
+  summaryRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-around' },
+  summaryItem: { alignItems: 'center', gap: 2, flex: 1 },
+  summaryDivider: { width: 1, height: 32, backgroundColor: COLORS.green200 },
+  summaryValue: { fontSize: 14, fontWeight: '700', color: COLORS.gray800 },
+  summaryLabel: { fontSize: 10, color: COLORS.gray400, fontWeight: '500' },
 
   // ── Pin mode banner ──────────────────────────────────────────────────────
   pinBanner: {

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -5,7 +5,7 @@ import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  ActivityIndicator, FlatList, StyleSheet, Switch,
+  ActivityIndicator, FlatList, ScrollView, StyleSheet, Switch,
   Text, TextInput, TouchableOpacity, View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
@@ -19,6 +19,7 @@ import {
   type Obstacle, type ObstacleDetail, type SearchResult,
 } from '../../api/map';
 import { calculateRoute, type GuestPreferences, type RouteResult } from '../../api/routes';
+import { getSavedPlaces, createSavedPlace, type SavedPlace } from '../../api/savedPlaces';
 import { isLoggedIn } from '../../services/auth';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
@@ -233,6 +234,12 @@ export default function MapView() {
     maxSlopeGradient: 8,
   });
 
+  // Saved places state
+  const [savedPlaces, setSavedPlaces] = useState<SavedPlace[]>([]);
+  const [saveTarget, setSaveTarget] = useState<{ kind: 'origin' | 'dest'; lat: number; lng: number; address: string } | null>(null);
+  const [saveLabel, setSaveLabel] = useState('');
+  const [savingPlace, setSavingPlace] = useState(false);
+
   // Origin/Dest autocomplete state
   const [originSuggestions, setOriginSuggestions] = useState<SearchResult[]>([]);
   const [destSuggestions, setDestSuggestions] = useState<SearchResult[]>([]);
@@ -242,6 +249,34 @@ export default function MapView() {
   const [destFocused, setDestFocused] = useState(false);
 
   const { location: currentLocation } = useLocation();
+
+  // ── Saved places ─────────────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (isLoggedIn()) getSavedPlaces().then(setSavedPlaces);
+  }, []);
+
+  const handleSavePlace = useCallback(async () => {
+    if (!saveTarget || !saveLabel.trim()) return;
+    setSavingPlace(true);
+    const result = await createSavedPlace({
+      label: saveLabel.trim(),
+      latitude: saveTarget.lat,
+      longitude: saveTarget.lng,
+      address: saveTarget.address || undefined,
+    });
+    setSavingPlace(false);
+    if (result) setSavedPlaces((prev) => [...prev, result]);
+    setSaveTarget(null);
+    setSaveLabel('');
+  }, [saveTarget, saveLabel]);
+
+  const openSaveModal = (kind: 'origin' | 'dest') => {
+    const point = kind === 'origin' ? origin : dest;
+    if (!point) return;
+    setSaveTarget({ kind, lat: point.lat, lng: point.lng, address: point.label });
+    setSaveLabel('');
+  };
 
   // ── Obstacle loading ─────────────────────────────────────────────────────
 
@@ -611,6 +646,18 @@ export default function MapView() {
                 </TouchableOpacity>
               </View>
 
+              {/* Saved places quick-select for origin */}
+              {originFocused && savedPlaces.length > 0 && originQ.length === 0 && (
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.savedChips} keyboardShouldPersistTaps="handled">
+                  {savedPlaces.map((p) => (
+                    <TouchableOpacity key={p.id} style={s.savedChip} onPress={() => selectOriginSuggestion({ id: p.id, name: p.label, latitude: p.latitude, longitude: p.longitude })}>
+                      <Ionicons name="bookmark" size={11} color={COLORS.green700} />
+                      <Text style={s.savedChipText}>{p.label}</Text>
+                    </TouchableOpacity>
+                  ))}
+                </ScrollView>
+              )}
+
               {/* Origin row */}
               <View style={s.inputRow}>
                 <View style={[s.dot, s.dotOrigin]} />
@@ -651,6 +698,11 @@ export default function MapView() {
                   <Ionicons name="location-outline" size={20}
                     color={pinMode === 'origin' ? COLORS.green700 : COLORS.gray400} />
                 </TouchableOpacity>
+                {origin && isLoggedIn() && (
+                  <TouchableOpacity style={s.bookmarkBtn} onPress={() => openSaveModal('origin')}>
+                    <Ionicons name="bookmark-outline" size={16} color={COLORS.green700} />
+                  </TouchableOpacity>
+                )}
               </View>
 
               {/* Use current location */}
@@ -660,6 +712,18 @@ export default function MapView() {
               </TouchableOpacity>
 
               <View style={s.connector}><View style={s.connectorLine} /></View>
+
+              {/* Saved places quick-select for destination */}
+              {destFocused && savedPlaces.length > 0 && destQ.length === 0 && (
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.savedChips} keyboardShouldPersistTaps="handled">
+                  {savedPlaces.map((p) => (
+                    <TouchableOpacity key={p.id} style={s.savedChip} onPress={() => selectDestSuggestion({ id: p.id, name: p.label, latitude: p.latitude, longitude: p.longitude })}>
+                      <Ionicons name="bookmark" size={11} color={COLORS.green700} />
+                      <Text style={s.savedChipText}>{p.label}</Text>
+                    </TouchableOpacity>
+                  ))}
+                </ScrollView>
+              )}
 
               {/* Destination row */}
               <View style={s.inputRow}>
@@ -701,6 +765,11 @@ export default function MapView() {
                   <Ionicons name="location-outline" size={20}
                     color={pinMode === 'dest' ? COLORS.red500 : COLORS.gray400} />
                 </TouchableOpacity>
+                {dest && isLoggedIn() && (
+                  <TouchableOpacity style={s.bookmarkBtn} onPress={() => openSaveModal('dest')}>
+                    <Ionicons name="bookmark-outline" size={16} color={COLORS.green700} />
+                  </TouchableOpacity>
+                )}
               </View>
 
               {/* Get Route button */}
@@ -767,6 +836,47 @@ export default function MapView() {
         )}
 
       </View>
+
+      {/* Save place modal */}
+      {saveTarget && (
+        <View style={s.prefsOverlay}>
+          <View style={s.prefsCard}>
+            <Text style={s.prefsTitle}>Save Location</Text>
+            <Text style={s.prefsSubtitle}>Choose a label for this place.</Text>
+            <View style={s.presetRow}>
+              {['Home', 'Work'].map((preset) => (
+                <TouchableOpacity
+                  key={preset}
+                  style={[s.presetChip, saveLabel === preset && s.presetChipActive]}
+                  onPress={() => setSaveLabel(preset)}
+                >
+                  <Text style={[s.presetChipText, saveLabel === preset && s.presetChipTextActive]}>{preset}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <TextInput
+              style={[s.slopeInput, { width: '100%', textAlign: 'left', paddingHorizontal: 12 }]}
+              placeholder="Custom label"
+              placeholderTextColor={COLORS.gray400}
+              value={saveLabel}
+              onChangeText={setSaveLabel}
+              maxLength={50}
+            />
+            <TouchableOpacity
+              style={[s.prefsCalcBtn, (!saveLabel.trim() || savingPlace) && { backgroundColor: COLORS.gray300 }]}
+              onPress={handleSavePlace}
+              disabled={!saveLabel.trim() || savingPlace}
+            >
+              {savingPlace
+                ? <ActivityIndicator size="small" color={COLORS.white} />
+                : <><Ionicons name="bookmark-outline" size={16} color={COLORS.white} /><Text style={s.prefsCalcBtnText}>Save</Text></>}
+            </TouchableOpacity>
+            <TouchableOpacity style={s.prefsCancelBtn} onPress={() => setSaveTarget(null)}>
+              <Text style={s.prefsCancelText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      )}
 
       {/* Guest preferences overlay */}
       {showPrefs && (
@@ -948,6 +1058,29 @@ const s = StyleSheet.create({
   routeBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
   errorRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 6 },
   errorText: { fontSize: 12, color: COLORS.red500 },
+
+  // ── Saved places ─────────────────────────────────────────────────────────
+  savedChips: { flexDirection: 'row', paddingVertical: 6, gap: 6 },
+  savedChip: {
+    flexDirection: 'row', alignItems: 'center', gap: 4,
+    paddingHorizontal: 10, paddingVertical: 5,
+    backgroundColor: COLORS.green50, borderRadius: 100,
+    borderWidth: 1, borderColor: COLORS.green200,
+  },
+  savedChipText: { fontSize: 12, fontWeight: '600', color: COLORS.green700 },
+  bookmarkBtn: {
+    width: 44, height: 44, borderRadius: 10, borderWidth: 1,
+    borderColor: COLORS.green200, alignItems: 'center', justifyContent: 'center',
+    backgroundColor: COLORS.green50, flexShrink: 0,
+  },
+  presetRow: { flexDirection: 'row', gap: 8, marginBottom: 8 },
+  presetChip: {
+    flex: 1, paddingVertical: 8, borderRadius: 9, alignItems: 'center',
+    borderWidth: 1.5, borderColor: COLORS.gray300, backgroundColor: COLORS.white,
+  },
+  presetChipActive: { borderColor: COLORS.green600, backgroundColor: COLORS.green50 },
+  presetChipText: { fontSize: 14, fontWeight: '600', color: COLORS.gray600 },
+  presetChipTextActive: { color: COLORS.green700 },
 
   // ── Route summary ────────────────────────────────────────────────────────
   summaryCard: {

--- a/frontend/src/components/map/SavePlaceModal.tsx
+++ b/frontend/src/components/map/SavePlaceModal.tsx
@@ -1,0 +1,84 @@
+import { View, Text, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../constants/theme';
+
+type Props = {
+  label: string;
+  onLabelChange: (text: string) => void;
+  saving: boolean;
+  error: string;
+  onSave: () => void;
+  onCancel: () => void;
+};
+
+const PRESETS = ['Home', 'Work'];
+
+export default function SavePlaceModal({ label, onLabelChange, saving, error, onSave, onCancel }: Props) {
+  return (
+    <View style={s.overlay}>
+      <View style={s.card}>
+        <Text style={s.title}>Save Location</Text>
+        <Text style={s.subtitle}>Choose a label for this place.</Text>
+        <View style={s.presetRow}>
+          {PRESETS.map((preset) => (
+            <TouchableOpacity
+              key={preset}
+              testID={`preset-chip-${preset.toLowerCase()}`}
+              style={[s.presetChip, label === preset && s.presetChipActive]}
+              onPress={() => onLabelChange(preset)}
+            >
+              <Text style={[s.presetChipText, label === preset && s.presetChipTextActive]}>{preset}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+        <TextInput
+          testID="save-label-input"
+          style={s.input}
+          placeholder="Custom label"
+          placeholderTextColor={COLORS.gray400}
+          value={label}
+          onChangeText={onLabelChange}
+          maxLength={50}
+        />
+        {!!error && (
+          <View testID="save-error-banner" style={s.errorBanner}>
+            <Ionicons name="close-circle" size={14} color={COLORS.red600} />
+            <Text style={s.errorText}>{error}</Text>
+          </View>
+        )}
+        <TouchableOpacity
+          testID="save-btn"
+          style={[s.saveBtn, (!label.trim() || saving) && { backgroundColor: COLORS.gray300 }]}
+          onPress={onSave}
+          disabled={!label.trim() || saving}
+        >
+          {saving
+            ? <ActivityIndicator size="small" color={COLORS.white} />
+            : <><Ionicons name="bookmark-outline" size={16} color={COLORS.white} /><Text style={s.saveBtnText}>Save</Text></>}
+        </TouchableOpacity>
+        <TouchableOpacity testID="cancel-btn" style={s.cancelBtn} onPress={onCancel}>
+          <Text style={s.cancelText}>Cancel</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  overlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(0,0,0,0.45)', alignItems: 'center', justifyContent: 'flex-end', zIndex: 30 },
+  card: { width: '100%', backgroundColor: COLORS.white, borderTopLeftRadius: 20, borderTopRightRadius: 20, padding: 24, gap: 12 },
+  title: { fontSize: 17, fontWeight: '800', color: COLORS.gray900 },
+  subtitle: { fontSize: 13, color: COLORS.gray500 },
+  presetRow: { flexDirection: 'row', gap: 10 },
+  presetChip: { paddingHorizontal: 18, paddingVertical: 9, borderRadius: 100, borderWidth: 1.5, borderColor: COLORS.gray300, backgroundColor: COLORS.white },
+  presetChipActive: { borderColor: COLORS.green600, backgroundColor: COLORS.green50 },
+  presetChipText: { fontSize: 14, fontWeight: '600', color: COLORS.gray600 },
+  presetChipTextActive: { color: COLORS.green700 },
+  input: { borderWidth: 1.5, borderColor: COLORS.gray300, borderRadius: 10, paddingHorizontal: 12, paddingVertical: 11, fontSize: 15, color: COLORS.gray900, backgroundColor: COLORS.white },
+  errorBanner: { flexDirection: 'row', alignItems: 'center', gap: 6, backgroundColor: COLORS.red50, padding: 8, borderRadius: 8, borderWidth: 1, borderColor: 'rgba(239,68,68,0.2)' },
+  errorText: { fontSize: 12, color: COLORS.red600, fontWeight: '500', flex: 1 },
+  saveBtn: { backgroundColor: COLORS.green700, paddingVertical: 13, borderRadius: 12, alignItems: 'center', flexDirection: 'row', justifyContent: 'center', gap: 8 },
+  saveBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
+  cancelBtn: { alignItems: 'center', paddingVertical: 4 },
+  cancelText: { fontSize: 14, color: COLORS.gray400 },
+});


### PR DESCRIPTION
## Description
Registered users can now save frequent destinations (e.g. "Home", "Work") from the
route planning screen and view or delete them from their profile. Saved places appear
as quick-select chips when focusing the origin or destination fields.

## Type of Change
- [x] `feat` — new feature

## Changes
- Added `src/api/savedPlaces.ts` with `getSavedPlaces`, `createSavedPlace`,
  `deleteSavedPlace` wired to `GET/POST/DELETE /api/users/me/saved-places/`
- Added "Saved Places" card to the Profile tab — lists all saved places with label,
  address, and a delete button
- Added horizontal quick-select chips above origin/destination fields in `MapView.tsx`
  (native) and `MapView.web.tsx` (web) — visible when the field is focused and no
  query is typed
- Added a bookmark button next to each input row (visible only for logged-in users
  when a point is set) that opens a save modal with "Home" / "Work" presets and a
  custom label input

## How to Test
1. Log in and open the map route planning panel
2. Set an origin — verify the bookmark icon appears next to the input
3. Tap the bookmark icon, select "Home" or type a custom label, tap Save
4. Focus the origin field again with no text — verify the saved chip appears
5. Tap the chip — verify it fills the origin field
6. Open the Profile tab — verify the Saved Places card shows the saved entry
7. Delete the saved place from profile — verify it disappears
8. Repeat steps 2–7 while not logged in — verify no bookmark button appears

## Screenshots (if applicable)
N/A

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch (`feature/route-summary-panel`)
- [ ] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #198

## Notes
Backend endpoints (`GET/POST/DELETE /api/users/me/saved-places/`) are tracked in a
separate backend issue and will be implemented by another team member. The frontend
will silently show an empty list until the backend is deployed — no mock mode needed.
This PR is branched off `feature/route-summary-panel`; set that as the base branch
or retarget to `main` once that PR is merged.
