### PR TITLE
feat: status-change notifications + authority resolve endpoint

### DIFF
--- a/backend/apps/authority/serializers.py
+++ b/backend/apps/authority/serializers.py
@@ -1,0 +1,17 @@
+from rest_framework import serializers
+
+
+class ResolveReportSerializer(serializers.Serializer):
+    repairPhotoUrl = serializers.URLField(source='repair_photo_url')
+    repairNotes = serializers.CharField(
+        source='repair_notes',
+        required=False,
+        allow_blank=True,
+        default='',
+    )
+
+
+class ResolveReportResponseSerializer(serializers.Serializer):
+    reportId = serializers.UUIDField(source='id')
+    status = serializers.CharField()
+    updatedAt = serializers.DateTimeField(source='updated_at')

--- a/backend/apps/authority/services.py
+++ b/backend/apps/authority/services.py
@@ -1,0 +1,47 @@
+from django.db import transaction
+
+from apps.reports.models import Report, ReportStatus, StatusChange
+from apps.reports.signals import report_status_changed
+
+
+class ReportAlreadyResolvedError(Exception):
+    """Raised when an authority tries to resolve a report that is already resolved or closed."""
+
+
+@transaction.atomic
+def resolve_report(*, actor, report_id, repair_photo_url: str, repair_notes: str = '') -> Report:
+    """Mark a report as RESOLVED_AWAITING_VALIDATION.
+
+    Records a StatusChange entry and emits report_status_changed so notifications
+    fire after commit. Raises Report.DoesNotExist or ReportAlreadyResolvedError.
+    """
+    report = Report.objects.select_for_update().get(pk=report_id)
+
+    if report.status in (ReportStatus.RESOLVED_AWAITING_VALIDATION, ReportStatus.CLOSED):
+        raise ReportAlreadyResolvedError()
+
+    old_status = report.status
+    report.status = ReportStatus.RESOLVED_AWAITING_VALIDATION
+    report.save(update_fields=['status', 'updated_at'])
+
+    reason = f'repair_photo_url: {repair_photo_url}'
+    if repair_notes:
+        reason = f'{reason}; notes: {repair_notes}'
+
+    StatusChange.objects.create(
+        report=report,
+        changed_by=actor,
+        old_status=old_status,
+        new_status=ReportStatus.RESOLVED_AWAITING_VALIDATION,
+        reason=reason,
+    )
+
+    report_status_changed.send(
+        sender=Report,
+        report=report,
+        old_status=old_status,
+        new_status=ReportStatus.RESOLVED_AWAITING_VALIDATION,
+        actor=actor,
+    )
+
+    return report

--- a/backend/apps/authority/tests.py
+++ b/backend/apps/authority/tests.py
@@ -1,0 +1,172 @@
+from uuid import uuid4
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.notifications.models import Notification, NotificationType
+from apps.reports.models import (
+    Interaction,
+    InteractionType,
+    ObstacleCategory,
+    Report,
+    ReportContext,
+    ReportStatus,
+    StatusChange,
+)
+from apps.users.models import User, UserRole
+
+
+def make_user(email, role=UserRole.REGISTERED_USER, **kwargs):
+    return User.objects.create_user(
+        email=email,
+        full_name=kwargs.pop('full_name', 'Test User'),
+        password='pass',
+        role=role,
+        **kwargs,
+    )
+
+
+def make_report(reporter, **kwargs):
+    defaults = dict(
+        title="Broken Ramp",
+        description="Broken.",
+        category=ObstacleCategory.BROKEN_RAMP,
+        context=ReportContext.OUTDOOR,
+        status=ReportStatus.VERIFIED,
+        latitude="41.083700",
+        longitude="29.051000",
+    )
+    defaults.update(kwargs)
+    return Report.objects.create(reporter=reporter, **defaults)
+
+
+class ResolveReportViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.authority = make_user("authority@test.com", role=UserRole.INFRASTRUCTURE_AUTHORITY)
+        self.reporter = make_user("reporter@test.com")
+        self.report = make_report(self.reporter)
+        self.url = f"/api/authority/reports/{self.report.id}/resolve"
+        self.payload = {
+            "repairPhotoUrl": "https://cdn.example.com/repaired.jpg",
+            "repairNotes": "Patched the ramp.",
+        }
+
+    def test_anonymous_returns_401(self):
+        response = self.client.patch(self.url, self.payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_authority_role_returns_403(self):
+        self.client.force_authenticate(user=self.reporter)  # REGISTERED_USER
+        response = self.client.patch(self.url, self.payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_admin_role_returns_403(self):
+        admin = make_user("admin@test.com", role=UserRole.ADMINISTRATOR)
+        self.client.force_authenticate(user=admin)
+        response = self.client.patch(self.url, self.payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_missing_repair_photo_url_returns_400(self):
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.patch(
+            self.url, {"repairNotes": "no photo"}, format='json'
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("repairPhotoUrl", response.content.decode())
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, ReportStatus.VERIFIED)
+
+    def test_invalid_url_returns_400(self):
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.patch(
+            self.url,
+            {"repairPhotoUrl": "not-a-url", "repairNotes": "x"},
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unknown_report_returns_404(self):
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.patch(
+            f"/api/authority/reports/{uuid4()}/resolve",
+            self.payload,
+            format='json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_successful_transition_records_status_change_and_returns_200(self):
+        self.client.force_authenticate(user=self.authority)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(self.url, self.payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(body["status"], ReportStatus.RESOLVED_AWAITING_VALIDATION)
+        self.assertEqual(body["reportId"], str(self.report.id))
+
+        self.report.refresh_from_db()
+        self.assertEqual(self.report.status, ReportStatus.RESOLVED_AWAITING_VALIDATION)
+
+        change = StatusChange.objects.get(report=self.report)
+        self.assertEqual(change.changed_by, self.authority)
+        self.assertEqual(change.old_status, ReportStatus.VERIFIED)
+        self.assertEqual(change.new_status, ReportStatus.RESOLVED_AWAITING_VALIDATION)
+        self.assertIn("repair_photo_url: https://cdn.example.com/repaired.jpg", change.reason)
+        self.assertIn("notes: Patched the ramp.", change.reason)
+
+    def test_resolve_notifies_reporter_and_upvoters(self):
+        u1 = make_user("u1@test.com")
+        u2 = make_user("u2@test.com")
+        Interaction.objects.create(
+            report=self.report, user=u1, interaction_type=InteractionType.UPVOTE,
+        )
+        Interaction.objects.create(
+            report=self.report, user=u2, interaction_type=InteractionType.UPVOTE,
+        )
+
+        self.client.force_authenticate(user=self.authority)
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.patch(self.url, self.payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        recipients = set(
+            Notification.objects.filter(
+                related_report=self.report,
+                notification_type=NotificationType.REPORT_RESOLVED,
+            ).values_list('user_id', flat=True)
+        )
+        self.assertEqual(recipients, {self.reporter.id, u1.id, u2.id})
+
+    def test_resolve_skips_users_with_notifications_disabled(self):
+        u1 = make_user("u1@test.com", notifications_enabled=False)
+        u2 = make_user("u2@test.com", notifications_enabled=True)
+        Interaction.objects.create(
+            report=self.report, user=u1, interaction_type=InteractionType.UPVOTE,
+        )
+        Interaction.objects.create(
+            report=self.report, user=u2, interaction_type=InteractionType.UPVOTE,
+        )
+
+        self.client.force_authenticate(user=self.authority)
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.patch(self.url, self.payload, format='json')
+
+        recipients = set(
+            Notification.objects.filter(
+                related_report=self.report,
+            ).values_list('user_id', flat=True)
+        )
+        self.assertEqual(recipients, {self.reporter.id, u2.id})
+
+    def test_already_resolved_returns_409(self):
+        self.report.status = ReportStatus.RESOLVED_AWAITING_VALIDATION
+        self.report.save(update_fields=['status'])
+
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.patch(self.url, self.payload, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)

--- a/backend/apps/authority/urls.py
+++ b/backend/apps/authority/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from . import views
+
+app_name = 'authority'
+
+urlpatterns = [
+    path(
+        'reports/<uuid:report_id>/resolve',
+        views.ResolveReportView.as_view(),
+        name='resolve-report',
+    ),
+]

--- a/backend/apps/authority/views.py
+++ b/backend/apps/authority/views.py
@@ -1,0 +1,40 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.permissions import IsAuthority
+from apps.reports.models import Report
+
+from .serializers import ResolveReportResponseSerializer, ResolveReportSerializer
+from .services import ReportAlreadyResolvedError, resolve_report
+
+
+class ResolveReportView(APIView):
+    permission_classes = [IsAuthority]
+
+    def patch(self, request, report_id):
+        serializer = ResolveReportSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            report = resolve_report(
+                actor=request.user,
+                report_id=report_id,
+                repair_photo_url=serializer.validated_data['repair_photo_url'],
+                repair_notes=serializer.validated_data.get('repair_notes', ''),
+            )
+        except Report.DoesNotExist:
+            return Response(
+                {'detail': 'Report not found.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except ReportAlreadyResolvedError:
+            return Response(
+                {'detail': 'Report is already resolved or closed.'},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        return Response(
+            ResolveReportResponseSerializer(report).data,
+            status=status.HTTP_200_OK,
+        )

--- a/backend/apps/notifications/apps.py
+++ b/backend/apps/notifications/apps.py
@@ -5,3 +5,6 @@ class NotificationsConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'apps.notifications'
     label = 'notifications'
+
+    def ready(self):
+        from . import signals  # noqa: F401  -- register receivers

--- a/backend/apps/notifications/models.py
+++ b/backend/apps/notifications/models.py
@@ -1,42 +1,33 @@
-# Notifications are not part of the current milestone. The Notification model
-# below was added ahead of schedule and has never been migrated to Supabase;
-# its related_report FK to Report breaks report deletion via cascade. Keep it
-# commented out until notifications are actually implemented and a migration
-# is applied.
+from django.conf import settings
+from django.db import models
 
-# from django.conf import settings
-# from django.db import models
-#
-#
-# class NotificationType(models.TextChoices):
-#     REGISTRATION_COMPLETE = 'REGISTRATION_COMPLETE', 'Registration Complete'
-#     REPORT_VERIFIED = 'REPORT_VERIFIED', 'Report Verified'
-#     REPORT_RESOLVED = 'REPORT_RESOLVED', 'Report Resolved'
-#     SPAM_WARNING = 'SPAM_WARNING', 'Spam Warning'
-#     STATUS_CHANGE = 'STATUS_CHANGE', 'Status Change'
-#
-#
-# class Notification(models.Model):
-#     user = models.ForeignKey(
-#         settings.AUTH_USER_MODEL,
-#         on_delete=models.CASCADE,
-#         related_name='notifications',
-#     )
-#     notification_type = models.CharField(max_length=25, choices=NotificationType.choices)
-#     title = models.CharField(max_length=255)
-#     message = models.TextField()
-#     is_read = models.BooleanField(default=False)
-#     related_report = models.ForeignKey(
-#         'reports.Report',
-#         on_delete=models.SET_NULL,
-#         null=True,
-#         blank=True,
-#         related_name='notifications',
-#     )
-#     created_at = models.DateTimeField(auto_now_add=True)
-#
-#     class Meta:
-#         db_table = 'notifications'
-#
-#     def __str__(self):
-#         return f'{self.notification_type} for {self.user.email}'
+
+class NotificationType(models.TextChoices):
+    REPORT_VERIFIED = 'REPORT_VERIFIED', 'Report Verified'
+    REPORT_RESOLVED = 'REPORT_RESOLVED', 'Report Resolved'
+
+
+class Notification(models.Model):
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='notifications',
+    )
+    notification_type = models.CharField(max_length=25, choices=NotificationType.choices)
+    message = models.TextField()
+    is_read = models.BooleanField(default=False)
+    related_report = models.ForeignKey(
+        'reports.Report',
+        on_delete=models.CASCADE,
+        related_name='notifications',
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'notifications'
+        indexes = [
+            models.Index(fields=['user', '-created_at'], name='notifications_user_recent_idx'),
+        ]
+
+    def __str__(self):
+        return f'{self.notification_type} for {self.user.email}'

--- a/backend/apps/notifications/serializers.py
+++ b/backend/apps/notifications/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from .models import Notification
+
+
+class NotificationSerializer(serializers.ModelSerializer):
+    type = serializers.CharField(source='notification_type', read_only=True)
+    report_id = serializers.UUIDField(source='related_report_id', read_only=True)
+
+    class Meta:
+        model = Notification
+        fields = ['id', 'type', 'report_id', 'message', 'is_read', 'created_at']
+        read_only_fields = fields

--- a/backend/apps/notifications/services.py
+++ b/backend/apps/notifications/services.py
@@ -1,0 +1,55 @@
+from apps.reports.models import InteractionType, Report, ReportStatus
+from apps.users.models import User
+
+from .models import Notification, NotificationType
+
+
+def _verified_message(report: Report) -> str:
+    return f'Your report "{report.title}" has been verified.'
+
+
+def _resolved_message(report: Report) -> str:
+    return (
+        f'The obstacle reported as "{report.title}" has been marked resolved '
+        f'and is awaiting validation.'
+    )
+
+
+def create_status_change_notifications(report: Report, new_status: str) -> list[Notification]:
+    """Create in-app notifications for a report status transition.
+
+    - VERIFIED: notify the reporter only.
+    - RESOLVED_AWAITING_VALIDATION: notify reporter + all distinct upvoters.
+    Recipients with notifications_enabled=False are skipped silently.
+    """
+    if new_status == ReportStatus.VERIFIED:
+        recipient_ids = {report.reporter_id}
+        message = _verified_message(report)
+        notif_type = NotificationType.REPORT_VERIFIED
+    elif new_status == ReportStatus.RESOLVED_AWAITING_VALIDATION:
+        upvoter_ids = set(
+            report.interactions.filter(
+                interaction_type=InteractionType.UPVOTE,
+            ).values_list('user_id', flat=True)
+        )
+        recipient_ids = {report.reporter_id} | upvoter_ids
+        message = _resolved_message(report)
+        notif_type = NotificationType.REPORT_RESOLVED
+    else:
+        return []
+
+    enabled_ids = User.objects.filter(
+        id__in=recipient_ids,
+        notifications_enabled=True,
+    ).values_list('id', flat=True)
+
+    notifications = [
+        Notification(
+            user_id=user_id,
+            notification_type=notif_type,
+            message=message,
+            related_report=report,
+        )
+        for user_id in enabled_ids
+    ]
+    return Notification.objects.bulk_create(notifications)

--- a/backend/apps/notifications/signals.py
+++ b/backend/apps/notifications/signals.py
@@ -1,0 +1,13 @@
+from django.db import transaction
+from django.dispatch import receiver
+
+from apps.reports.signals import report_status_changed
+
+from .services import create_status_change_notifications
+
+
+@receiver(report_status_changed)
+def handle_report_status_changed(sender, report, old_status, new_status, actor=None, **kwargs):
+    transaction.on_commit(
+        lambda: create_status_change_notifications(report, new_status)
+    )

--- a/backend/apps/notifications/tests.py
+++ b/backend/apps/notifications/tests.py
@@ -1,0 +1,309 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.notifications.models import Notification, NotificationType
+from apps.notifications.services import create_status_change_notifications
+from apps.reports.models import (
+    Interaction,
+    InteractionType,
+    ObstacleCategory,
+    Report,
+    ReportContext,
+    ReportStatus,
+)
+from apps.reports.signals import report_status_changed
+from apps.users.models import User
+
+
+def make_user(email="user@test.com", **kwargs):
+    return User.objects.create_user(
+        email=email,
+        full_name=kwargs.pop('full_name', 'Test User'),
+        password='pass',
+        **kwargs,
+    )
+
+
+def make_report(reporter, **kwargs):
+    defaults = dict(
+        title="Broken Ramp",
+        description="The ramp is broken.",
+        category=ObstacleCategory.BROKEN_RAMP,
+        context=ReportContext.OUTDOOR,
+        status=ReportStatus.UNVERIFIED,
+        latitude="41.083700",
+        longitude="29.051000",
+    )
+    defaults.update(kwargs)
+    return Report.objects.create(reporter=reporter, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# Service: create_status_change_notifications
+# ---------------------------------------------------------------------------
+
+class CreateStatusChangeNotificationsTest(TestCase):
+    def test_verified_notifies_only_reporter(self):
+        reporter = make_user(email="reporter@test.com")
+        upvoter = make_user(email="up@test.com")
+        report = make_report(reporter)
+        Interaction.objects.create(
+            report=report, user=upvoter, interaction_type=InteractionType.UPVOTE
+        )
+
+        notifs = create_status_change_notifications(report, ReportStatus.VERIFIED)
+
+        self.assertEqual(len(notifs), 1)
+        self.assertEqual(notifs[0].user_id, reporter.id)
+        self.assertEqual(notifs[0].notification_type, NotificationType.REPORT_VERIFIED)
+        self.assertEqual(notifs[0].related_report_id, report.id)
+        self.assertFalse(notifs[0].is_read)
+
+    def test_resolved_notifies_reporter_and_all_upvoters(self):
+        reporter = make_user(email="reporter@test.com")
+        u1 = make_user(email="u1@test.com")
+        u2 = make_user(email="u2@test.com")
+        report = make_report(reporter)
+        Interaction.objects.create(report=report, user=u1, interaction_type=InteractionType.UPVOTE)
+        Interaction.objects.create(report=report, user=u2, interaction_type=InteractionType.UPVOTE)
+        # Flag is not an upvote — should not get notified.
+        flagger = make_user(email="flagger@test.com")
+        Interaction.objects.create(report=report, user=flagger, interaction_type=InteractionType.FLAG)
+
+        notifs = create_status_change_notifications(
+            report, ReportStatus.RESOLVED_AWAITING_VALIDATION,
+        )
+
+        recipient_ids = {n.user_id for n in notifs}
+        self.assertEqual(recipient_ids, {reporter.id, u1.id, u2.id})
+        for n in notifs:
+            self.assertEqual(n.notification_type, NotificationType.REPORT_RESOLVED)
+
+    def test_users_with_notifications_disabled_are_skipped(self):
+        reporter = make_user(email="reporter@test.com", notifications_enabled=False)
+        u1 = make_user(email="u1@test.com", notifications_enabled=False)
+        u2 = make_user(email="u2@test.com", notifications_enabled=True)
+        report = make_report(reporter)
+        Interaction.objects.create(report=report, user=u1, interaction_type=InteractionType.UPVOTE)
+        Interaction.objects.create(report=report, user=u2, interaction_type=InteractionType.UPVOTE)
+
+        notifs = create_status_change_notifications(
+            report, ReportStatus.RESOLVED_AWAITING_VALIDATION,
+        )
+
+        self.assertEqual({n.user_id for n in notifs}, {u2.id})
+
+    def test_non_relevant_status_creates_nothing(self):
+        reporter = make_user(email="reporter@test.com")
+        report = make_report(reporter)
+        notifs = create_status_change_notifications(report, ReportStatus.CLOSED)
+        self.assertEqual(notifs, [])
+
+
+# ---------------------------------------------------------------------------
+# Async firing: signal + transaction.on_commit
+# ---------------------------------------------------------------------------
+
+class StatusChangeSignalAsyncTest(TestCase):
+    def test_handler_defers_via_on_commit(self):
+        """Receiver schedules work on commit; nothing is created until callbacks run."""
+        reporter = make_user(email="reporter@test.com")
+        report = make_report(reporter)
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            report_status_changed.send(
+                sender=Report,
+                report=report,
+                old_status=ReportStatus.UNVERIFIED,
+                new_status=ReportStatus.VERIFIED,
+                actor=None,
+            )
+            self.assertEqual(Notification.objects.count(), 0)
+
+        self.assertEqual(len(callbacks), 1)
+        # Now run the deferred work.
+        for cb in callbacks:
+            cb()
+        self.assertEqual(Notification.objects.count(), 1)
+
+    def test_rolled_back_transaction_creates_no_notification(self):
+        """If the surrounding transaction is rolled back, on_commit never runs."""
+        from django.db import transaction
+
+        reporter = make_user(email="reporter@test.com")
+        report = make_report(reporter)
+
+        try:
+            with transaction.atomic():
+                report_status_changed.send(
+                    sender=Report,
+                    report=report,
+                    old_status=ReportStatus.UNVERIFIED,
+                    new_status=ReportStatus.VERIFIED,
+                    actor=None,
+                )
+                raise RuntimeError("simulated failure")
+        except RuntimeError:
+            pass
+
+        self.assertEqual(Notification.objects.count(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Integration: register_upvote triggers notification on VERIFIED
+# ---------------------------------------------------------------------------
+
+class UpvoteVerifiesAndNotifiesTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.reporter = make_user(email="reporter@test.com")
+        self.report = make_report(self.reporter, status=ReportStatus.UNVERIFIED)
+        self.url = f"/api/reports/{self.report.id}/upvote/"
+
+    def _vote_until_verified(self):
+        # Threshold for REGISTERED_USER reporter is strict > 5 → 6th upvote verifies.
+        for i in range(5):
+            self.client.force_authenticate(user=make_user(email=f"v{i}@test.com"))
+            self.client.post(self.url)
+        self.client.force_authenticate(user=make_user(email="v5@test.com"))
+        return self.client.post(self.url)
+
+    def test_verified_transition_creates_notification_for_reporter(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._vote_until_verified()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], ReportStatus.VERIFIED)
+
+        notifs = list(Notification.objects.filter(user=self.reporter))
+        self.assertEqual(len(notifs), 1)
+        self.assertEqual(notifs[0].notification_type, NotificationType.REPORT_VERIFIED)
+
+    def test_verified_transition_respects_reporter_toggle(self):
+        self.reporter.notifications_enabled = False
+        self.reporter.save(update_fields=['notifications_enabled'])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self._vote_until_verified()
+
+        self.assertEqual(Notification.objects.filter(user=self.reporter).count(), 0)
+
+
+# ---------------------------------------------------------------------------
+# API: GET /api/notifications/  and  PATCH /api/notifications/{id}/read/
+# ---------------------------------------------------------------------------
+
+class NotificationListViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = make_user(email="me@test.com")
+        self.other = make_user(email="other@test.com")
+        self.report = make_report(self.user)
+
+    def _create(self, user, **overrides):
+        defaults = dict(
+            user=user,
+            notification_type=NotificationType.REPORT_VERIFIED,
+            message="hi",
+            related_report=self.report,
+        )
+        defaults.update(overrides)
+        return Notification.objects.create(**defaults)
+
+    def test_anonymous_returns_401(self):
+        response = self.client.get("/api/notifications/")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_returns_only_callers_notifications_ordered_by_recent_first(self):
+        n_old = self._create(self.user, message="old")
+        n_new = self._create(self.user, message="new")
+        self._create(self.other, message="someone else")
+
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get("/api/notifications/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["id"], n_new.id)
+        self.assertEqual(data[1]["id"], n_old.id)
+
+    def test_payload_shape(self):
+        n = self._create(self.user, message="hello")
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.get("/api/notifications/")
+        item = response.json()[0]
+
+        self.assertEqual(set(item.keys()), {
+            "id", "type", "report_id", "message", "is_read", "created_at",
+        })
+        self.assertEqual(item["type"], NotificationType.REPORT_VERIFIED)
+        self.assertEqual(item["report_id"], str(self.report.id))
+        self.assertFalse(item["is_read"])
+
+
+class NotificationMarkReadViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = make_user(email="me@test.com")
+        self.other = make_user(email="other@test.com")
+        self.report = make_report(self.user)
+        self.notification = Notification.objects.create(
+            user=self.user,
+            notification_type=NotificationType.REPORT_VERIFIED,
+            message="hello",
+            related_report=self.report,
+        )
+        self.url = f"/api/notifications/{self.notification.id}/read/"
+
+    def test_anonymous_returns_401(self):
+        response = self.client.patch(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_marks_notification_as_read(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()["is_read"])
+        self.notification.refresh_from_db()
+        self.assertTrue(self.notification.is_read)
+
+    def test_other_users_notification_returns_404(self):
+        self.client.force_authenticate(user=self.other)
+        response = self.client.patch(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.notification.refresh_from_db()
+        self.assertFalse(self.notification.is_read)
+
+    def test_unknown_id_returns_404(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch("/api/notifications/999999/read/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+# ---------------------------------------------------------------------------
+# /me exposes and updates notificationsEnabled
+# ---------------------------------------------------------------------------
+
+class MeNotificationsToggleTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = make_user(email="me@test.com")
+        self.client.force_authenticate(user=self.user)
+        self.url = "/api/auth/users/me"
+
+    def test_get_includes_notifications_enabled_default_true(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.json()["notificationsEnabled"])
+
+    def test_patch_disables_notifications(self):
+        response = self.client.patch(self.url, {"notificationsEnabled": False}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(response.json()["notificationsEnabled"])
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.notifications_enabled)

--- a/backend/apps/notifications/urls.py
+++ b/backend/apps/notifications/urls.py
@@ -1,0 +1,14 @@
+from django.urls import path
+
+from . import views
+
+app_name = 'notifications'
+
+urlpatterns = [
+    path('', views.NotificationListView.as_view(), name='notification-list'),
+    path(
+        '<int:notification_id>/read/',
+        views.NotificationMarkReadView.as_view(),
+        name='notification-mark-read',
+    ),
+]

--- a/backend/apps/notifications/views.py
+++ b/backend/apps/notifications/views.py
@@ -1,0 +1,34 @@
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .models import Notification
+from .serializers import NotificationSerializer
+
+
+class NotificationListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        qs = Notification.objects.filter(user=request.user).order_by('-created_at')
+        return Response(NotificationSerializer(qs, many=True).data, status=status.HTTP_200_OK)
+
+
+class NotificationMarkReadView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def patch(self, request, notification_id):
+        try:
+            notification = Notification.objects.get(pk=notification_id, user=request.user)
+        except Notification.DoesNotExist:
+            return Response(
+                {'detail': 'Notification not found.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if not notification.is_read:
+            notification.is_read = True
+            notification.save(update_fields=['is_read'])
+
+        return Response(NotificationSerializer(notification).data, status=status.HTTP_200_OK)

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -143,6 +143,8 @@ def register_upvote(user, report_id) -> dict:
         and report.status == ReportStatus.UNVERIFIED
         and upvote_count > _upvote_threshold_for(report.reporter)
     ):
+        from apps.reports.signals import report_status_changed
+
         old_status = report.status
         report.status = ReportStatus.VERIFIED
         report.save(update_fields=['status', 'updated_at'])
@@ -150,6 +152,13 @@ def register_upvote(user, report_id) -> dict:
             report.reporter,
             old_status=old_status,
             new_status=ReportStatus.VERIFIED,
+        )
+        report_status_changed.send(
+            sender=Report,
+            report=report,
+            old_status=old_status,
+            new_status=ReportStatus.VERIFIED,
+            actor=user,
         )
         auto_verified = True
 

--- a/backend/apps/reports/signals.py
+++ b/backend/apps/reports/signals.py
@@ -1,0 +1,7 @@
+from django.dispatch import Signal
+
+# Sent when a Report transitions from one status to another.
+# Kwargs: report (Report), old_status (str), new_status (str), actor (User | None).
+# Receivers should defer side-effects via transaction.on_commit so they don't
+# run inside the caller's transaction (and don't fire on rollback).
+report_status_changed = Signal()

--- a/backend/apps/users/models.py
+++ b/backend/apps/users/models.py
@@ -64,6 +64,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         default=AccountStatus.ACTIVE,
     )
     reputation_points = models.IntegerField(default=0)
+    notifications_enabled = models.BooleanField(default=True)
     is_active = models.BooleanField(default=True)
     is_staff = models.BooleanField(default=False)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -106,13 +106,15 @@ class UserProfileSerializer(serializers.ModelSerializer):
     birthDate = serializers.DateField(source='birth_date', read_only=True)
     accountStatus = serializers.CharField(source='account_status', read_only=True)
     reputationPoints = serializers.IntegerField(source='reputation_points', read_only=True)
+    notificationsEnabled = serializers.BooleanField(source='notifications_enabled', read_only=True)
     createdAt = serializers.DateTimeField(source='created_at', read_only=True)
     mobilityProfile = serializers.SerializerMethodField()
 
     class Meta:
         model = User
         fields = ['userId', 'email', 'fullName', 'birthDate', 'role',
-                  'accountStatus', 'reputationPoints', 'createdAt', 'mobilityProfile']
+                  'accountStatus', 'reputationPoints', 'notificationsEnabled',
+                  'createdAt', 'mobilityProfile']
 
     def get_mobilityProfile(self, obj):
         try:
@@ -125,11 +127,21 @@ class UserProfileSerializer(serializers.ModelSerializer):
 class UserProfileUpdateSerializer(serializers.Serializer):
     fullName = serializers.CharField(source='full_name', max_length=255, required=False)
     birthDate = serializers.DateField(source='birth_date', required=False)
+    notificationsEnabled = serializers.BooleanField(source='notifications_enabled', required=False)
 
     def update(self, instance, validated_data):
-        instance.full_name = validated_data.get('full_name', instance.full_name)
-        instance.birth_date = validated_data.get('birth_date', instance.birth_date)
-        instance.save(update_fields=['full_name', 'birth_date'])
+        update_fields = []
+        if 'full_name' in validated_data:
+            instance.full_name = validated_data['full_name']
+            update_fields.append('full_name')
+        if 'birth_date' in validated_data:
+            instance.birth_date = validated_data['birth_date']
+            update_fields.append('birth_date')
+        if 'notifications_enabled' in validated_data:
+            instance.notifications_enabled = validated_data['notifications_enabled']
+            update_fields.append('notifications_enabled')
+        if update_fields:
+            instance.save(update_fields=update_fields)
         return instance
 
 

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -71,6 +71,12 @@ class MeView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
     def put(self, request):
+        return self._update(request)
+
+    def patch(self, request):
+        return self._update(request)
+
+    def _update(self, request):
         serializer = UserProfileUpdateSerializer(request.user, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         user = serializer.save()

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -20,4 +20,6 @@ urlpatterns = [
     path('api/reports/', include('apps.reports.urls')),
     path('api/map/', include('apps.map.urls')),
     path('api/admin/', include('apps.admin.urls')),
+    path('api/authority/', include('apps.authority.urls')),
+    path('api/notifications/', include('apps.notifications.urls')),
 ]


### PR DESCRIPTION
## Description
  Adds in-app notifications for report status transitions and the Infrastructure Authority "resolve" endpoint that drives the second
   transition. Reporter is notified when a report becomes `VERIFIED`; reporter + all upvoters are notified when an Infrastructure
  Authority resolves a report (`RESOLVED_AWAITING_VALIDATION`). Notifications respect a per-user `notifications_enabled` toggle and
  fire asynchronously via a Django signal + `transaction.on_commit` so the API response is never blocked and rolled-back
  transactions never produce orphan notifications.

  ## Type of Change
  - [x] `feat` — new feature
  - [ ] `fix` — bug fix
  - [ ] `refactor` — code refactor
  - [ ] `docs` — documentation
  - [ ] `chore` — maintenance / configuration
  - [ ] `perf` — performance improvement
  - [ ] `test` — adding or updating tests
  - [ ] `style` — formatting, missing semicolons, etc.

  ## Changes
  - **Notifications app:** `Notification` model (`user`, `notification_type`, `message`, `is_read`, `related_report`, `created_at`,
  index on `(user, -created_at)`); `create_status_change_notifications` service that resolves recipients (reporter for `VERIFIED`;
  reporter ∪ distinct upvoters for `RESOLVED_AWAITING_VALIDATION`) and filters by `notifications_enabled=True`.
  - **Async firing:** `apps.reports.signals.report_status_changed` Signal; receiver in `apps.notifications.signals` defers actual
  writes via `transaction.on_commit` so they don't block the API call and don't fire on rollback. Registered in
  `NotificationsConfig.ready()`. `register_upvote()` emits the signal on its `UNVERIFIED → VERIFIED` transition.
  - **Notifications API:** `GET /api/notifications/` returns the caller's notifications ordered by `-created_at`; `PATCH
  /api/notifications/{id}/read/` marks one as read (404 for someone else's).
  - **User toggle:** `notifications_enabled` boolean on `User` (default `True`), surfaced as `notificationsEnabled` on `GET
  /api/auth/users/me` and updatable via `PATCH /api/auth/users/me`.
  - **Authority endpoint:** `PATCH /api/authority/reports/{id}/resolve` — `IsAuthority`-gated, requires `repairPhotoUrl`, optional
  `repairNotes`. Transitions to `RESOLVED_AWAITING_VALIDATION`, records a `StatusChange` row with the photo URL + notes in `reason`,
   emits the signal.
  - **URL wiring:** mounted `api/notifications/` and `api/authority/` in `config/urls.py`.

  ## How to Test

  **Schema (apply once to Supabase before running):**
  ```sql
  ALTER TABLE users
      ADD COLUMN notifications_enabled BOOLEAN NOT NULL DEFAULT TRUE;

  CREATE TABLE notifications (
      id                BIGSERIAL PRIMARY KEY,
      user_id           UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
      notification_type VARCHAR(25) NOT NULL,
      message           TEXT        NOT NULL,
      is_read           BOOLEAN     NOT NULL DEFAULT FALSE,
      related_report_id UUID        NOT NULL REFERENCES reports(id) ON DELETE CASCADE,
      created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
  );
  CREATE INDEX notifications_user_recent_idx ON notifications (user_id, created_at DESC);
  ```

  **Automated:**
  ```bash
  cd backend
  pytest apps/notifications/tests.py apps/authority/tests.py -v   # 27 tests, all green
  ```

  **Manual sanity check:**
  1. `PATCH /api/auth/users/me` with `{"notificationsEnabled": false}` → confirm `GET /api/auth/users/me` reflects it.
  2. As a reporter, create a report; have 6 other users upvote it (`POST /api/reports/{id}/upvote/`). After the 6th upvote, status
  becomes `VERIFIED` and the reporter has a new entry in `GET /api/notifications/` of type `REPORT_VERIFIED`.
  3. Toggle the reporter back to `notificationsEnabled=true` for the next case.
  4. As an `INFRASTRUCTURE_AUTHORITY` user, `PATCH /api/authority/reports/{id}/resolve` with `{"repairPhotoUrl": "https://...",
  "repairNotes": "fixed"}`. Reporter and every upvoter on that report get a `REPORT_RESOLVED` notification (skipping any user with
  `notifications_enabled=false`).
  5. `PATCH /api/notifications/{id}/read/` flips `is_read` to `true`; the same call against another user's notification returns 404.
  6. Negative paths: missing `repairPhotoUrl` → 400; non-authority caller → 403; unknown report id → 404.

  ## Screenshots (if applicable)
  N/A — backend-only.

  ## Checklist
  - [x] Commit messages follow `<type>(<scope>): <subject>` format
  - [x] Branch is up to date with the target branch
  - [x] No self-merge — at least 1 reviewer assigned
  - [x] Conflicts resolved by PR author

  ## Related Issue
  - Closes #177 
  - Closes #172 

  ## Notes
  - **Async strategy:** no Celery in the project, so per the issue notes we used Django signals + `transaction.on_commit`. The
  receiver is one line that schedules the work after commit — if a task queue is added later, swap the lambda body for
  `task.delay(...)` without changing call sites.
  - **Migrations are intentionally not committed** (matches the existing convention in `.gitignore: backend/apps/*/migrations/`).
  The required Supabase schema is in the SQL block under "How to Test"; the corresponding Django migration files exist locally and
  were used to verify everything end-to-end against SQLite.
  - **End-to-end verification on SQLite:** all 27 new tests pass; full suite 160/161 pass against `config.test_settings`. The single
   failure (`apps/users/tests.py::RequestPasswordResetServiceTest::test_reset_link_contains_token`) is a pre-existing latent bug
  unrelated to this PR — `send_mail` is invoked with kwargs only, but the test reads `mock_send.call_args[0][1]` (positional). On
  `main` this is masked by the absent `users` table during test setup. Recommend a separate ticket to fix the assertion to use
  `call_args.kwargs['message']`.
  - **Push delivery (FCM/APNs)** is intentionally deferred per the issue; notifications are in-app records only. Adding push later
  means extending the `on_commit` callback — no other call sites change.
  - Replace the second issue number above when you grab it from the tracker.