### PR TITLE
fix: implement toggle behavior for upvote and flag interactions

### DIFF
--- a/backend/apps/reports/serializers.py
+++ b/backend/apps/reports/serializers.py
@@ -40,6 +40,7 @@ class ReportResponseSerializer(serializers.Serializer):
 class UpvoteResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField()
     upvoteCount = serializers.IntegerField()
+    userUpvoted = serializers.BooleanField()
     status = serializers.CharField()
     autoVerified = serializers.BooleanField()
 
@@ -47,7 +48,7 @@ class UpvoteResponseSerializer(serializers.Serializer):
 class FlagResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField()
     flagCount = serializers.IntegerField()
-    queuedForModeration = serializers.BooleanField()
+    userFlagged = serializers.BooleanField()
 
 
 class ConfirmResolutionResponseSerializer(serializers.Serializer):

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -100,8 +100,14 @@ def auto_verify(report: Report) -> bool:
     pass
 
 
-class SelfUpvoteError(Exception):
-    """Raised when a user attempts to upvote their own report."""
+class SelfInteractionError(Exception):
+    """Raised when a user attempts to interact with their own report."""
+
+SelfUpvoteError = SelfInteractionError
+
+
+class ConflictingInteractionError(Exception):
+    """Raised when a user tries to upvote a report they flagged, or vice versa."""
 
 
 class AlreadyUpvotedError(Exception):
@@ -123,62 +129,116 @@ def _upvote_threshold_for(reporter) -> int:
 
 
 @transaction.atomic
-def register_upvote(user, report_id) -> dict:
-    """Record an upvote on a report. Idempotent: re-calling does not double-count.
+def toggle_upvote(user, report_id) -> dict:
+    """Toggle an upvote on a report (add if absent, remove if present).
 
     - Raises Report.DoesNotExist for an unknown id.
-    - Raises SelfUpvoteError if the caller is the report's reporter.
-    - When the upvote count *strictly exceeds* the threshold (picked by reporter role)
-      and the report is still UNVERIFIED, transitions to VERIFIED and awards trust score.
+    - Raises SelfInteractionError if the caller is the report's reporter.
+    - Raises ConflictingInteractionError if the user has flagged the report.
+    - When adding an upvote and the count exceeds the threshold while the report
+      is still UNVERIFIED, transitions to VERIFIED and awards trust score.
     """
     from apps.trust_scores.services import apply_status_change_delta
+    from apps.reports.signals import report_status_changed
 
     report = Report.objects.select_for_update().select_related('reporter').get(pk=report_id)
 
     if report.reporter_id == user.id:
-        raise SelfUpvoteError()
+        raise SelfInteractionError()
 
-    _, created = Interaction.objects.get_or_create(
-        report=report,
-        user=user,
-        interaction_type=InteractionType.UPVOTE,
-    )
+    if Interaction.objects.filter(report=report, user=user, interaction_type=InteractionType.FLAG).exists():
+        raise ConflictingInteractionError()
+
+    try:
+        existing = Interaction.objects.get(
+            report=report, user=user, interaction_type=InteractionType.UPVOTE,
+        )
+        existing.delete()
+        user_upvoted = False
+        auto_verified = False
+    except Interaction.DoesNotExist:
+        Interaction.objects.create(
+            report=report, user=user, interaction_type=InteractionType.UPVOTE,
+        )
+        user_upvoted = True
+        upvote_count_check = Interaction.objects.filter(
+            report=report, interaction_type=InteractionType.UPVOTE,
+        ).count()
+        auto_verified = False
+        if (
+            report.status == ReportStatus.UNVERIFIED
+            and upvote_count_check > _upvote_threshold_for(report.reporter)
+        ):
+            old_status = report.status
+            report.status = ReportStatus.VERIFIED
+            report.save(update_fields=['status', 'updated_at'])
+            apply_status_change_delta(
+                report.reporter,
+                old_status=old_status,
+                new_status=ReportStatus.VERIFIED,
+            )
+            report_status_changed.send(
+                sender=Report,
+                report=report,
+                old_status=old_status,
+                new_status=ReportStatus.VERIFIED,
+                actor=user,
+            )
+            auto_verified = True
 
     upvote_count = Interaction.objects.filter(
-        report=report,
-        interaction_type=InteractionType.UPVOTE,
+        report=report, interaction_type=InteractionType.UPVOTE,
     ).count()
-
-    auto_verified = False
-    if (
-        created
-        and report.status == ReportStatus.UNVERIFIED
-        and upvote_count > _upvote_threshold_for(report.reporter)
-    ):
-        from apps.reports.signals import report_status_changed
-
-        old_status = report.status
-        report.status = ReportStatus.VERIFIED
-        report.save(update_fields=['status', 'updated_at'])
-        apply_status_change_delta(
-            report.reporter,
-            old_status=old_status,
-            new_status=ReportStatus.VERIFIED,
-        )
-        report_status_changed.send(
-            sender=Report,
-            report=report,
-            old_status=old_status,
-            new_status=ReportStatus.VERIFIED,
-            actor=user,
-        )
-        auto_verified = True
 
     return {
         'reportId': report.id,
         'upvoteCount': upvote_count,
+        'userUpvoted': user_upvoted,
         'status': report.status,
         'autoVerified': auto_verified,
+    }
+
+
+# Keep old name as alias so existing imports don't break
+register_upvote = toggle_upvote
+
+
+@transaction.atomic
+def toggle_flag(user, report_id) -> dict:
+    """Toggle a flag on a report (add if absent, remove if present).
+
+    - Raises Report.DoesNotExist for an unknown id.
+    - Raises SelfInteractionError if the caller is the report's reporter.
+    - Raises ConflictingInteractionError if the user has upvoted the report.
+    """
+    report = Report.objects.select_for_update().get(pk=report_id)
+
+    if report.reporter_id == user.id:
+        raise SelfInteractionError()
+
+    if Interaction.objects.filter(report=report, user=user, interaction_type=InteractionType.UPVOTE).exists():
+        raise ConflictingInteractionError()
+
+    try:
+        existing = Interaction.objects.get(
+            report=report, user=user, interaction_type=InteractionType.FLAG,
+        )
+        existing.delete()
+        user_flagged = False
+    except Interaction.DoesNotExist:
+        Interaction.objects.create(
+            report=report, user=user, interaction_type=InteractionType.FLAG,
+        )
+        user_flagged = True
+
+    flag_count = Interaction.objects.filter(
+        report=report, interaction_type=InteractionType.FLAG,
+    ).count()
+
+    return {
+        'reportId': report.id,
+        'flagCount': flag_count,
+        'userFlagged': user_flagged,
     }
 
 

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -257,7 +257,7 @@ from uuid import uuid4
 
 from django.test import override_settings
 
-from apps.reports.models import Interaction, InteractionType
+from apps.reports.models import Interaction, InteractionType, StatusChange
 from apps.users.models import UserRole
 
 
@@ -306,7 +306,7 @@ class ReportUpvoteViewTest(TestCase):
         self.assertEqual(data["status"], ReportStatus.UNVERIFIED)
         self.assertFalse(data["autoVerified"])
 
-    def test_duplicate_upvote_is_idempotent(self):
+    def test_second_upvote_removes_upvote(self):
         voter = self._voter(1)
         self.client.force_authenticate(user=voter)
 
@@ -316,12 +316,31 @@ class ReportUpvoteViewTest(TestCase):
         self.assertEqual(first.status_code, status.HTTP_200_OK)
         self.assertEqual(second.status_code, status.HTTP_200_OK)
         self.assertEqual(first.json()["upvoteCount"], 1)
-        self.assertEqual(second.json()["upvoteCount"], 1)
+        self.assertTrue(first.json()["userUpvoted"])
+        self.assertEqual(second.json()["upvoteCount"], 0)
+        self.assertFalse(second.json()["userUpvoted"])
         self.assertEqual(
             Interaction.objects.filter(
                 report=self.report, interaction_type=InteractionType.UPVOTE
             ).count(),
-            1,
+            0,
+        )
+
+    def test_cannot_upvote_a_flagged_report(self):
+        voter = self._voter(1)
+        self.client.force_authenticate(user=voter)
+        Interaction.objects.create(
+            report=self.report, user=voter, interaction_type=InteractionType.FLAG
+        )
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(
+            Interaction.objects.filter(
+                report=self.report, user=voter, interaction_type=InteractionType.UPVOTE
+            ).count(),
+            0,
         )
 
     def test_standard_reporter_transitions_above_threshold(self):
@@ -413,54 +432,42 @@ from django.utils import timezone
 from apps.reports.models import StatusChange
 
 
-@override_settings(SPAM_FLAG_THRESHOLD=3)
 class ReportFlagViewTest(TestCase):
     def setUp(self):
         self.client = APIClient()
         self.reporter = make_user(email="reporter@test.com")
-        self.report = make_report(self.reporter, status=ReportStatus.VERIFIED)
+        self.report = make_report(self.reporter)
         self.url = f"/api/reports/{self.report.id}/flag/"
 
     def _flagger(self, n):
         return make_user(email=f"flagger{n}@test.com")
+
+    def test_author_cannot_flag_own_report_403(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(Interaction.objects.filter(report=self.report).count(), 0)
+
 
     def test_anonymous_returns_401(self):
         response = self.client.post(self.url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_unknown_report_returns_404(self):
-        self.client.force_authenticate(user=self._flagger(0))
+        self.client.force_authenticate(user=self._flagger(1))
         response = self.client.post(f"/api/reports/{uuid4()}/flag/")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-    def test_upvoter_cannot_flag_same_report(self):
-        voter = self._flagger(1)
-        Interaction.objects.create(
-            report=self.report, user=voter, interaction_type=InteractionType.UPVOTE
-        )
-        self.client.force_authenticate(user=voter)
-        response = self.client.post(self.url)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_flag_increments_count(self):
-        flagger = self._flagger(2)
+    def test_first_flag_returns_count_and_state(self):
+        flagger = self._flagger(1)
         self.client.force_authenticate(user=flagger)
+
         response = self.client.post(self.url)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
-        self.assertIn("reportId", data)
-        self.assertIn("flagCount", data)
-        self.assertIn("queuedForModeration", data)
         self.assertEqual(data["flagCount"], 1)
-        self.assertFalse(data["queuedForModeration"])
-
-    def test_idempotent_flag_does_not_double_count(self):
-        flagger = self._flagger(3)
-        self.client.force_authenticate(user=flagger)
-        self.client.post(self.url)
-        response = self.client.post(self.url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.json()["flagCount"], 1)
+        self.assertTrue(data["userFlagged"])
         self.assertEqual(
             Interaction.objects.filter(
                 report=self.report, interaction_type=InteractionType.FLAG
@@ -468,24 +475,50 @@ class ReportFlagViewTest(TestCase):
             1,
         )
 
-    def test_queued_for_moderation_at_threshold(self):
+    def test_second_flag_removes_flag(self):
+        flagger = self._flagger(1)
+        self.client.force_authenticate(user=flagger)
+
+        first = self.client.post(self.url)
+        second = self.client.post(self.url)
+
+        self.assertEqual(first.status_code, status.HTTP_200_OK)
+        self.assertEqual(second.status_code, status.HTTP_200_OK)
+        self.assertEqual(first.json()["flagCount"], 1)
+        self.assertTrue(first.json()["userFlagged"])
+        self.assertEqual(second.json()["flagCount"], 0)
+        self.assertFalse(second.json()["userFlagged"])
+        self.assertEqual(
+            Interaction.objects.filter(
+                report=self.report, interaction_type=InteractionType.FLAG
+            ).count(),
+            0,
+        )
+
+    def test_cannot_flag_an_upvoted_report(self):
+        flagger = self._flagger(1)
+        self.client.force_authenticate(user=flagger)
+        Interaction.objects.create(
+            report=self.report, user=flagger, interaction_type=InteractionType.UPVOTE
+        )
+
+        response = self.client.post(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(
+            Interaction.objects.filter(
+                report=self.report, user=flagger, interaction_type=InteractionType.FLAG
+            ).count(),
+            0,
+        )
+
+    def test_multiple_users_can_flag_independently(self):
         for i in range(3):
-            flagger = self._flagger(i + 10)
+            flagger = self._flagger(i)
             self.client.force_authenticate(user=flagger)
             response = self.client.post(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.json()
-        self.assertEqual(data["flagCount"], 3)
-        self.assertTrue(data["queuedForModeration"])
-
-    def test_not_queued_below_threshold(self):
-        for i in range(2):
-            flagger = self._flagger(i + 20)
-            self.client.force_authenticate(user=flagger)
-            response = self.client.post(self.url)
-
-        self.assertFalse(response.json()["queuedForModeration"])
+            self.assertEqual(response.json()["flagCount"], i + 1)
+            self.assertTrue(response.json()["userFlagged"])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -6,12 +6,14 @@ from apps.core.permissions import IsUser
 
 from .models import Report
 from .serializers import (
-    ReportSerializer, ReportResponseSerializer, UpvoteResponseSerializer,
-    FlagResponseSerializer, ConfirmResolutionResponseSerializer,
+    ReportSerializer, ReportResponseSerializer,
+    UpvoteResponseSerializer, FlagResponseSerializer, ConfirmResolutionResponseSerializer,
 )
 from .services import (
-    SelfUpvoteError, AlreadyUpvotedError, NotEligibleToConfirmError, ReportNotAwaitingValidationError,
-    create_report, detect_duplicate, auto_verify, register_upvote, register_flag, register_resolution_confirmation,
+    SelfInteractionError, ConflictingInteractionError,
+    NotEligibleToConfirmError, ReportNotAwaitingValidationError,
+    create_report, detect_duplicate, auto_verify,
+    register_upvote, toggle_flag, register_resolution_confirmation,
 )
 
 
@@ -45,10 +47,15 @@ class ReportUpvoteView(APIView):
                 {'detail': 'Report not found.'},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        except SelfUpvoteError:
+        except SelfInteractionError:
             return Response(
                 {'detail': 'You cannot upvote your own report.'},
                 status=status.HTTP_403_FORBIDDEN,
+            )
+        except ConflictingInteractionError:
+            return Response(
+                {'detail': 'You cannot upvote a report you have flagged.'},
+                status=status.HTTP_409_CONFLICT,
             )
         return Response(UpvoteResponseSerializer(result).data, status=status.HTTP_200_OK)
 
@@ -58,16 +65,21 @@ class ReportFlagView(APIView):
 
     def post(self, request, report_id):
         try:
-            result = register_flag(request.user, report_id)
+            result = toggle_flag(request.user, report_id)
         except Report.DoesNotExist:
             return Response(
                 {'detail': 'Report not found.'},
                 status=status.HTTP_404_NOT_FOUND,
             )
-        except AlreadyUpvotedError:
+        except SelfInteractionError:
             return Response(
-                {'detail': 'You cannot flag a report you have already upvoted.'},
-                status=status.HTTP_400_BAD_REQUEST,
+                {'detail': 'You cannot flag your own report.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+        except ConflictingInteractionError:
+            return Response(
+                {'detail': 'You cannot flag a report you have upvoted.'},
+                status=status.HTTP_409_CONFLICT,
             )
         return Response(FlagResponseSerializer(result).data, status=status.HTTP_200_OK)
 

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 set -e
-
 python manage.py migrate --noinput
-
 exec "$@"

--- a/frontend/src/__tests__/InteractionBar.test.tsx
+++ b/frontend/src/__tests__/InteractionBar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { Alert } from 'react-native';
 import InteractionBar from '../components/reports/InteractionBar';
 import * as interactionsApi from '../api/interactions';
@@ -21,19 +21,153 @@ const BASE_PROPS = {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockPostUpvote.mockResolvedValue({ ok: true, data: { upvoteCount: 4, userUpvoted: true } });
-  mockPostFlag.mockResolvedValue({ ok: true, data: { flagCount: 2, userFlagged: true } });
+  mockPostUpvote.mockResolvedValue({ ok: true, status: 200, data: { upvoteCount: 4, userUpvoted: true } });
+  mockPostFlag.mockResolvedValue({ ok: true, status: 200, data: { flagCount: 2, userFlagged: true } });
 });
 
-it('calls onUpdate optimistically and calls postUpvote on tap', async () => {
+// ── Upvote ────────────────────────────────────────────────────────────────────
+
+it('optimistically increments count and sets userUpvoted when toggling ON', async () => {
   const onUpdate = jest.fn();
   const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={onUpdate} />);
 
   fireEvent.press(getByTestId('upvote-button'));
 
-  expect(onUpdate).toHaveBeenCalledWith({ upvoteCount: 4, userUpvoted: true });
+  expect(onUpdate).toHaveBeenNthCalledWith(1, { upvoteCount: 4, userUpvoted: true });
   await waitFor(() => expect(mockPostUpvote).toHaveBeenCalledWith('report-123'));
 });
+
+it('optimistically decrements count and clears userUpvoted when toggling OFF', async () => {
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} userUpvoted={true} upvoteCount={4} onUpdate={onUpdate} />,
+  );
+
+  fireEvent.press(getByTestId('upvote-button'));
+
+  expect(onUpdate).toHaveBeenNthCalledWith(1, { upvoteCount: 3, userUpvoted: false });
+});
+
+it('reconciles upvote count and state from server response', async () => {
+  mockPostUpvote.mockResolvedValue({ ok: true, status: 200, data: { upvoteCount: 5, userUpvoted: true } });
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={onUpdate} />);
+
+  fireEvent.press(getByTestId('upvote-button'));
+
+  await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(2));
+  expect(onUpdate).toHaveBeenNthCalledWith(2, expect.objectContaining({ upvoteCount: 5, userUpvoted: true }));
+});
+
+it('rolls back optimistic upvote update on API failure', async () => {
+  mockPostUpvote.mockResolvedValue({ ok: false, status: 500, data: {} });
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={onUpdate} />);
+
+  await act(async () => { fireEvent.press(getByTestId('upvote-button')); });
+
+  expect(onUpdate).toHaveBeenNthCalledWith(2, { upvoteCount: 3, userUpvoted: false });
+});
+
+it('shows conflict alert without calling API when user has flagged the report', () => {
+  const alertSpy = jest.spyOn(Alert, 'alert');
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} userFlagged={true} onUpdate={onUpdate} />,
+  );
+
+  fireEvent.press(getByTestId('upvote-button'));
+
+  expect(alertSpy).toHaveBeenCalledWith('Cannot upvote', expect.stringContaining('flagged'));
+  expect(mockPostUpvote).not.toHaveBeenCalled();
+  expect(onUpdate).not.toHaveBeenCalled();
+});
+
+it('ignores duplicate taps while upvote request is in flight', async () => {
+  let resolve!: (v: any) => void;
+  mockPostUpvote.mockReturnValue(new Promise(r => { resolve = r; }));
+  const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={jest.fn()} />);
+
+  fireEvent.press(getByTestId('upvote-button'));
+  fireEvent.press(getByTestId('upvote-button'));
+
+  expect(mockPostUpvote).toHaveBeenCalledTimes(1);
+
+  await act(async () => { resolve({ ok: true, status: 200, data: {} }); });
+});
+
+// ── Flag ──────────────────────────────────────────────────────────────────────
+
+it('optimistically increments flagCount and sets userFlagged when toggling ON', async () => {
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={onUpdate} />);
+
+  fireEvent.press(getByTestId('flag-button'));
+
+  expect(onUpdate).toHaveBeenNthCalledWith(1, { flagCount: 2, userFlagged: true });
+  await waitFor(() => expect(mockPostFlag).toHaveBeenCalledWith('report-123'));
+});
+
+it('optimistically decrements flagCount and clears userFlagged when toggling OFF', async () => {
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} userFlagged={true} flagCount={2} onUpdate={onUpdate} />,
+  );
+
+  fireEvent.press(getByTestId('flag-button'));
+
+  expect(onUpdate).toHaveBeenNthCalledWith(1, { flagCount: 1, userFlagged: false });
+});
+
+it('reconciles flag count and state from server response', async () => {
+  mockPostFlag.mockResolvedValue({ ok: true, status: 200, data: { flagCount: 3, userFlagged: true } });
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={onUpdate} />);
+
+  fireEvent.press(getByTestId('flag-button'));
+
+  await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(2));
+  expect(onUpdate).toHaveBeenNthCalledWith(2, { flagCount: 3, userFlagged: true });
+});
+
+it('rolls back optimistic flag update on API failure', async () => {
+  mockPostFlag.mockResolvedValue({ ok: false, status: 500, data: {} });
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={onUpdate} />);
+
+  await act(async () => { fireEvent.press(getByTestId('flag-button')); });
+
+  expect(onUpdate).toHaveBeenNthCalledWith(2, { flagCount: 1, userFlagged: false });
+});
+
+it('shows conflict alert without calling API when user has upvoted the report', () => {
+  const alertSpy = jest.spyOn(Alert, 'alert');
+  const onUpdate = jest.fn();
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} userUpvoted={true} onUpdate={onUpdate} />,
+  );
+
+  fireEvent.press(getByTestId('flag-button'));
+
+  expect(alertSpy).toHaveBeenCalledWith('Cannot flag', expect.stringContaining('upvoted'));
+  expect(mockPostFlag).not.toHaveBeenCalled();
+  expect(onUpdate).not.toHaveBeenCalled();
+});
+
+it('ignores duplicate taps while flag request is in flight', async () => {
+  let resolve!: (v: any) => void;
+  mockPostFlag.mockReturnValue(new Promise(r => { resolve = r; }));
+  const { getByTestId } = render(<InteractionBar {...BASE_PROPS} onUpdate={jest.fn()} />);
+
+  fireEvent.press(getByTestId('flag-button'));
+  fireEvent.press(getByTestId('flag-button'));
+
+  expect(mockPostFlag).toHaveBeenCalledTimes(1);
+
+  await act(async () => { resolve({ ok: true, status: 200, data: {} }); });
+});
+
+// ── Reporter / guest guards ───────────────────────────────────────────────────
 
 it('shows disabled views and hides interactive buttons when user is the reporter', () => {
   const { getByTestId, queryByTestId } = render(

--- a/frontend/src/api/interactions.ts
+++ b/frontend/src/api/interactions.ts
@@ -18,31 +18,31 @@ export interface UpvoteResponse {
 
 export async function postUpvote(
   reportId: string,
-): Promise<{ ok: boolean; data: UpvoteResponse }> {
+): Promise<{ ok: boolean; status: number; data: UpvoteResponse }> {
   try {
     const res = await fetch(`${API_BASE}/api/reports/${reportId}/upvote/`, {
       method: 'POST',
       headers: authHeaders(),
     });
     const data = await res.json().catch(() => ({}));
-    return { ok: res.ok, data };
+    return { ok: res.ok, status: res.status, data };
   } catch {
-    return { ok: false, data: {} };
+    return { ok: false, status: 0, data: {} };
   }
 }
 
 export async function postFlag(
   reportId: string,
-): Promise<{ ok: boolean; data: { flagCount: number; userFlagged: boolean } }> {
+): Promise<{ ok: boolean; status: number; data: { flagCount?: number; userFlagged?: boolean } }> {
   try {
     const res = await fetch(`${API_BASE}/api/reports/${reportId}/flag/`, {
       method: 'POST',
       headers: authHeaders(),
     });
     const data = await res.json().catch(() => ({}));
-    return { ok: res.ok, data };
+    return { ok: res.ok, status: res.status, data };
   } catch {
-    return { ok: false, data: { flagCount: 0, userFlagged: false } };
+    return { ok: false, status: 0, data: {} };
   }
 }
 

--- a/frontend/src/components/reports/InteractionBar.tsx
+++ b/frontend/src/components/reports/InteractionBar.tsx
@@ -1,4 +1,13 @@
-import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { useState } from 'react';
+import { Alert, Platform, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+function showAlert(title: string, message: string) {
+  if (Platform.OS === 'web') {
+    window.alert(`${title}\n\n${message}`);
+  } else {
+    showAlert(title, message);
+  }
+}
 import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../constants/theme';
 import type { ObstacleDetail } from '../../api/map';
@@ -15,52 +24,92 @@ export interface InteractionBarProps {
   onUpdate: (patch: Partial<ObstacleDetail>) => void;
 }
 
+const VALID_STATUSES = new Set([
+  'UNVERIFIED', 'PASSIVE', 'VERIFIED', 'RESOLVED_AWAITING_VALIDATION', 'CLOSED',
+]);
+
 export default function InteractionBar({
   reportId, reporterId, upvoteCount, flagCount,
   userUpvoted, userFlagged, currentUserId, onUpdate,
 }: InteractionBarProps) {
+  const [upvoting, setUpvoting] = useState(false);
+  const [flagging, setFlagging] = useState(false);
+
   const isOwn = currentUserId !== '' && currentUserId === reporterId;
   const isGuest = currentUserId === '';
 
   async function handleUpvote() {
     if (isGuest) {
-      Alert.alert('Sign in to vote', 'You need to be logged in to upvote reports.');
+      showAlert('Sign in to vote', 'You need to be logged in to upvote reports.');
       return;
     }
-    onUpdate({ upvoteCount: upvoteCount + 1, userUpvoted: true });
+    if (userFlagged) {
+      showAlert('Cannot upvote', 'You have already flagged this report. Remove your flag first.');
+      return;
+    }
+    if (upvoting) return;
+
+    const nextUpvoted = !userUpvoted;
+    const nextCount = nextUpvoted ? upvoteCount + 1 : upvoteCount - 1;
+    onUpdate({ upvoteCount: nextCount, userUpvoted: nextUpvoted });
+
+    setUpvoting(true);
     const res = await postUpvote(reportId);
+    setUpvoting(false);
+
     if (!res.ok) {
-      onUpdate({ upvoteCount, userUpvoted: false });
-      Alert.alert('Something went wrong', 'Could not upvote. Please try again.');
+      onUpdate({ upvoteCount, userUpvoted });
+      if (res.status === 409) {
+        showAlert('Cannot upvote', 'You have already flagged this report. Remove your flag first.');
+      } else {
+        showAlert('Something went wrong', 'Could not upvote. Please try again.');
+      }
       return;
     }
-    if (typeof res.data.upvoteCount === 'number') {
-      const patch: Partial<ObstacleDetail> = {
-        upvoteCount: res.data.upvoteCount,
-        userUpvoted: true,
-      };
-      const next = res.data.status;
-      if (
-        next === 'UNVERIFIED' || next === 'PASSIVE' || next === 'VERIFIED' ||
-        next === 'RESOLVED_AWAITING_VALIDATION' || next === 'CLOSED'
-      ) {
-        patch.status = next;
-      }
-      onUpdate(patch);
+
+    const patch: Partial<ObstacleDetail> = {
+      upvoteCount: typeof res.data.upvoteCount === 'number' ? res.data.upvoteCount : nextCount,
+      userUpvoted: typeof res.data.userUpvoted === 'boolean' ? res.data.userUpvoted : nextUpvoted,
+    };
+    if (res.data.status && VALID_STATUSES.has(res.data.status)) {
+      patch.status = res.data.status;
     }
+    onUpdate(patch);
   }
 
   async function handleFlag() {
     if (isGuest) {
-      Alert.alert('Sign in to vote', 'You need to be logged in to flag reports.');
+      showAlert('Sign in to vote', 'You need to be logged in to flag reports.');
       return;
     }
-    onUpdate({ flagCount: flagCount + 1, userFlagged: true });
-    const res = await postFlag(reportId);
-    if (!res.ok) {
-      onUpdate({ flagCount, userFlagged: false });
-      Alert.alert('Something went wrong', 'Could not flag. Please try again.');
+    if (userUpvoted) {
+      showAlert('Cannot flag', 'You have already upvoted this report. Remove your upvote first.');
+      return;
     }
+    if (flagging) return;
+
+    const nextFlagged = !userFlagged;
+    const nextCount = nextFlagged ? flagCount + 1 : flagCount - 1;
+    onUpdate({ flagCount: nextCount, userFlagged: nextFlagged });
+
+    setFlagging(true);
+    const res = await postFlag(reportId);
+    setFlagging(false);
+
+    if (!res.ok) {
+      onUpdate({ flagCount, userFlagged });
+      if (res.status === 409) {
+        showAlert('Cannot flag', 'You have already upvoted this report. Remove your upvote first.');
+      } else {
+        showAlert('Something went wrong', 'Could not flag. Please try again.');
+      }
+      return;
+    }
+
+    onUpdate({
+      flagCount: typeof res.data.flagCount === 'number' ? res.data.flagCount : nextCount,
+      userFlagged: typeof res.data.userFlagged === 'boolean' ? res.data.userFlagged : nextFlagged,
+    });
   }
 
   if (isOwn) {
@@ -81,23 +130,33 @@ export default function InteractionBar({
 
   return (
     <View style={s.row}>
-      <TouchableOpacity style={s.btn} onPress={handleUpvote} testID="upvote-button">
+      <TouchableOpacity
+        style={[s.btn, upvoting && s.btnDisabled]}
+        onPress={handleUpvote}
+        disabled={upvoting}
+        testID="upvote-button"
+      >
         <Ionicons
           name={userUpvoted ? 'thumbs-up' : 'thumbs-up-outline'}
           size={16}
-          color={userUpvoted ? COLORS.green600 : COLORS.gray600}
+          color={upvoting ? COLORS.gray400 : userUpvoted ? COLORS.green600 : COLORS.gray600}
         />
-        <Text style={[s.count, userUpvoted && s.activeCount]} testID="upvote-count">
+        <Text style={[s.count, !upvoting && userUpvoted && s.activeCount]} testID="upvote-count">
           {upvoteCount}
         </Text>
       </TouchableOpacity>
-      <TouchableOpacity style={s.btn} onPress={handleFlag} testID="flag-button">
+      <TouchableOpacity
+        style={[s.btn, flagging && s.btnDisabled]}
+        onPress={handleFlag}
+        disabled={flagging}
+        testID="flag-button"
+      >
         <Ionicons
           name={userFlagged ? 'flag' : 'flag-outline'}
           size={16}
-          color={userFlagged ? COLORS.red500 : COLORS.gray600}
+          color={flagging ? COLORS.gray400 : userFlagged ? COLORS.red500 : COLORS.gray600}
         />
-        <Text style={[s.count, userFlagged && s.flagActiveCount]} testID="flag-count">
+        <Text style={[s.count, !flagging && userFlagged && s.flagActiveCount]} testID="flag-count">
           {flagCount}
         </Text>
       </TouchableOpacity>
@@ -112,6 +171,7 @@ const s = StyleSheet.create({
     paddingVertical: 6, paddingHorizontal: 10,
     borderRadius: 6, borderWidth: 1, borderColor: COLORS.gray200,
   },
+  btnDisabled: { opacity: 0.5 },
   count: { fontSize: 13, color: COLORS.gray600 },
   activeCount: { color: COLORS.green600 },
   flagActiveCount: { color: COLORS.red500 },

--- a/frontend/src/components/reports/InteractionBar.tsx
+++ b/frontend/src/components/reports/InteractionBar.tsx
@@ -5,7 +5,7 @@ function showAlert(title: string, message: string) {
   if (Platform.OS === 'web') {
     window.alert(`${title}\n\n${message}`);
   } else {
-    showAlert(title, message);
+    Alert.alert(title, message);
   }
 }
 import { Ionicons } from '@expo/vector-icons';
@@ -72,7 +72,7 @@ export default function InteractionBar({
       userUpvoted: typeof res.data.userUpvoted === 'boolean' ? res.data.userUpvoted : nextUpvoted,
     };
     if (res.data.status && VALID_STATUSES.has(res.data.status)) {
-      patch.status = res.data.status;
+      patch.status = res.data.status as ObstacleDetail['status'];
     }
     onUpdate(patch);
   }


### PR DESCRIPTION
## Description
Fixes the interaction bar bug (#209) where tapping upvote or flag a second time had no effect. A second tap now removes the interaction (toggle). Also adds the missing flag endpoint, enforces mutual exclusion between upvote and flag on the same report, and surfaces proper conflict alerts on both web and native.

## Type of Change
- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes
- **Backend:** replaced `get_or_create` with toggle logic — second tap deletes the existing interaction
- **Backend:** added `POST /api/reports/<id>/flag/` endpoint with the same toggle behavior
- **Backend:** added `ConflictingInteractionError` — upvoting a flagged report (or vice versa) returns 409
- **Backend:** `UpvoteResponseSerializer` now includes `userUpvoted` field
- **Frontend:** optimistic UI update before API call, with server reconciliation and rollback on failure
- **Frontend:** in-flight guard prevents duplicate API calls while a request is pending
- **Frontend:** client-side conflict check — shows alert immediately without calling the API
- **Frontend:** cross-platform alert helper (`window.alert` on web, `Alert.alert` on native)
- **Tests:** full upvote and flag test suites covering toggle ON/OFF, reconciliation, rollback, duplicate tap, conflict alert, and reporter guard

## How to Test
1. Open any report you did not create
2. Tap the upvote button — count should increase immediately
3. Tap upvote again — count should decrease back (toggle off)
4. Tap flag — count increases
5. Tap flag again — count decreases (toggle off)
6. Upvote a report, then tap flag — alert: "You have already upvoted this report. Remove your upvote first."
7. Flag a report, then tap upvote — alert: "You have already flagged this report. Remove your flag first."
8. Tap upvote/flag rapidly — only one API call is made

## Screenshots (if applicable)
N/A

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #209

## Notes
- The 409 conflict is enforced on both the backend (for direct API calls) and the frontend (for in-app usage)
- `register_upvote` is kept as an alias for `toggle_upvote` to avoid breaking existing imports
