### PR TITLE
Feature/trust score badge ekin

### DIFF
--- a/frontend/app/tabs/profile.tsx
+++ b/frontend/app/tabs/profile.tsx
@@ -5,6 +5,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../src/constants/theme';
 import { getMe, updateMe, clearTokens, isLoggedIn, parseDRFError, UserProfile } from '../../src/services/auth';
 import { MobilityProfileCard } from '../../src/components/profile/MobilityProfileCard';
+import { TrustedContributorBadge } from '../../src/components/profile/TrustedContributorBadge';
 import { getSavedPlaces, deleteSavedPlace, SavedPlace } from '../../src/api/savedPlaces';
 
 function getInitials(name: string): string {
@@ -76,10 +77,18 @@ export default function ProfileScreen() {
             <Text style={s.email}>{user?.email || '—'}</Text>
             <View style={s.badgeRow}>
               <View style={[s.badge, s.badgeGreen]}><Ionicons name="shield-checkmark" size={12} color={COLORS.green700} /><Text style={[s.badgeText, { color: COLORS.green700 }]}>{user?.status || 'ACTIVE'}</Text></View>
-              <View style={[s.badge, s.badgeAmber]}><Ionicons name="star" size={12} color={COLORS.orange500} /><Text style={[s.badgeText, { color: COLORS.orange500 }]}>Trust: {user?.trustScore ?? 0}</Text></View>
+              {user?.role === 'TRUSTED_CONTRIBUTOR' && <TrustedContributorBadge />}
             </View>
           </View>
           <TouchableOpacity style={s.editBtn} onPress={() => { setEditing(!editing); setEditError(''); }}><Ionicons name="create-outline" size={16} color={COLORS.gray500} /></TouchableOpacity>
+        </View>
+      </View>
+
+      <View style={s.card}>
+        <View style={s.cardTitleRow}><Ionicons name="star" size={16} color={COLORS.orange500} /><Text style={s.cardTitle}>Trust Score</Text></View>
+        <View style={s.trustRow}>
+          <Text testID="trust-score-value" style={s.trustValue}>{user?.trustScore ?? 0}</Text>
+          <Text style={s.trustHint}>Earned from helpful reports and community contributions.</Text>
         </View>
       </View>
 
@@ -160,6 +169,9 @@ const s = StyleSheet.create({
   badgeGreen: { backgroundColor: COLORS.green100 },
   badgeAmber: { backgroundColor: COLORS.orange100 },
   badgeText: { fontSize: 11, fontWeight: '700' },
+  trustRow: { flexDirection: 'row', alignItems: 'center', gap: 14 },
+  trustValue: { fontSize: 32, fontWeight: '800', color: COLORS.green700, minWidth: 56 },
+  trustHint: { flex: 1, fontSize: 12, color: COLORS.gray500, lineHeight: 17 },
   editBtn: { width: 36, height: 36, borderRadius: 18, backgroundColor: COLORS.gray100, borderWidth: 1, borderColor: COLORS.gray200, alignItems: 'center', justifyContent: 'center' },
   label: { fontSize: 12, fontWeight: '700', color: COLORS.gray600, letterSpacing: 0.5, marginBottom: 5 },
   input: { borderWidth: 1.5, borderColor: COLORS.gray300, borderRadius: 10, paddingHorizontal: 14, paddingVertical: 12, fontSize: 15, color: COLORS.gray900, backgroundColor: COLORS.white },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "react-native": "0.81.5",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-screens": "~4.16.0",
+        "react-native-svg": "15.12.1",
         "react-native-web": "^0.21.0",
         "react-native-webview": "13.15.0"
       },
@@ -4243,6 +4244,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -4805,6 +4812,47 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssom": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
@@ -5005,6 +5053,44 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
     "node_modules/domexception": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
@@ -5017,6 +5103,35 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/dotenv": {
@@ -8007,6 +8122,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0"
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -8707,6 +8828,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -9547,6 +9680,21 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "react-native": "0.81.5",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.16.0",
+    "react-native-svg": "15.12.1",
     "react-native-web": "^0.21.0",
     "react-native-webview": "13.15.0"
   },

--- a/frontend/src/__tests__/TrustedContributorBadge.test.tsx
+++ b/frontend/src/__tests__/TrustedContributorBadge.test.tsx
@@ -146,9 +146,14 @@ describe('Profile screen — Trusted Contributor badge & Trust Score', () => {
       data: makeUser({ trustScore: 137 }),
     } as any);
 
-    const { findByTestId } = render(<ProfileScreen />);
-    const node = await findByTestId('trust-score-value');
-    expect(node.props.children).toBe(137);
+    const { getByTestId } = render(<ProfileScreen />);
+    // Re-query inside waitFor so we never hold a stale ReactTestInstance:
+    // the screen re-renders after getSavedPlaces() settles, which would
+    // unmount the fiber referenced by a one-shot findByTestId() result.
+    await waitFor(() => {
+      const value = getByTestId('trust-score-value').props.children;
+      expect(String(value)).toBe('137');
+    });
   });
 
   it('falls back to 0 when trustScore is missing', async () => {
@@ -158,8 +163,10 @@ describe('Profile screen — Trusted Contributor badge & Trust Score', () => {
       data: makeUser({ trustScore: undefined }),
     } as any);
 
-    const { findByTestId } = render(<ProfileScreen />);
-    const node = await findByTestId('trust-score-value');
-    expect(node.props.children).toBe(0);
+    const { getByTestId } = render(<ProfileScreen />);
+    await waitFor(() => {
+      const value = getByTestId('trust-score-value').props.children;
+      expect(String(value)).toBe('0');
+    });
   });
 });

--- a/frontend/src/__tests__/TrustedContributorBadge.test.tsx
+++ b/frontend/src/__tests__/TrustedContributorBadge.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Tests for TrustedContributorBadge + its integration on the Profile screen.
+ *
+ * Covers:
+ *   - Badge visible when role === 'TRUSTED_CONTRIBUTOR'
+ *   - Badge absent when role is anything else
+ *   - Trust Score number renders correctly
+ *
+ * react-native-svg is mocked so tests don't need the native module.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+
+// ── Mock react-native-svg with simple RN primitives ─────────────────────────
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const Stub = (name: string) => {
+    const C = ({ children, ...rest }: any) =>
+      React.createElement(View, { ...rest, testID: rest.testID }, children);
+    C.displayName = name;
+    return C;
+  };
+  return {
+    __esModule: true,
+    default: Stub('Svg'),
+    Svg: Stub('Svg'),
+    Path: Stub('Path'),
+    Circle: Stub('Circle'),
+    Rect: Stub('Rect'),
+    G: Stub('G'),
+    Defs: Stub('Defs'),
+    LinearGradient: Stub('LinearGradient'),
+    Stop: Stub('Stop'),
+  };
+});
+
+// ── Mock services consumed by the Profile screen ────────────────────────────
+jest.mock('../services/auth', () => ({
+  __esModule: true,
+  isLoggedIn: () => true,
+  clearTokens: jest.fn(),
+  parseDRFError: (e: any) => String(e),
+  getMe: jest.fn(),
+  updateMe: jest.fn(),
+}));
+
+jest.mock('../api/savedPlaces', () => ({
+  __esModule: true,
+  getSavedPlaces: jest.fn().mockResolvedValue([]),
+  deleteSavedPlace: jest.fn(),
+}));
+
+jest.mock('../components/profile/MobilityProfileCard', () => ({
+  __esModule: true,
+  MobilityProfileCard: () => null,
+}));
+
+jest.mock('expo-router', () => ({
+  __esModule: true,
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn() }),
+}));
+
+import { TrustedContributorBadge } from '../components/profile/TrustedContributorBadge';
+import * as authService from '../services/auth';
+import ProfileScreen from '../../app/tabs/profile';
+
+const mockGetMe = authService.getMe as jest.MockedFunction<typeof authService.getMe>;
+
+function makeUser(overrides: Partial<any> = {}) {
+  return {
+    userId: 'u1',
+    email: 'jane@example.com',
+    fullName: 'Jane Doe',
+    status: 'ACTIVE',
+    trustScore: 42,
+    role: 'USER',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ── Standalone component ────────────────────────────────────────────────────
+describe('TrustedContributorBadge (standalone)', () => {
+  it('renders the SVG icon and the label', () => {
+    const { getByTestId, getByText } = render(<TrustedContributorBadge />);
+    expect(getByTestId('trusted-contributor-badge')).toBeTruthy();
+    expect(getByTestId('trusted-contributor-badge-svg')).toBeTruthy();
+    expect(getByText('Trusted Contributor')).toBeTruthy();
+  });
+
+  it('honors a custom testID prop', () => {
+    const { getByTestId } = render(<TrustedContributorBadge testID="custom-tcb" />);
+    expect(getByTestId('custom-tcb')).toBeTruthy();
+    expect(getByTestId('custom-tcb-svg')).toBeTruthy();
+  });
+});
+
+// ── Integration with the profile screen ─────────────────────────────────────
+describe('Profile screen — Trusted Contributor badge & Trust Score', () => {
+  it('renders the badge when role === "TRUSTED_CONTRIBUTOR"', async () => {
+    mockGetMe.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: makeUser({ role: 'TRUSTED_CONTRIBUTOR' }),
+    } as any);
+
+    const { findByTestId } = render(<ProfileScreen />);
+    expect(await findByTestId('trusted-contributor-badge')).toBeTruthy();
+  });
+
+  it('does NOT render the badge when role is "USER"', async () => {
+    mockGetMe.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: makeUser({ role: 'USER' }),
+    } as any);
+
+    const { queryByTestId, findByTestId } = render(<ProfileScreen />);
+    // Wait for the screen to finish loading (trust score renders after fetch)
+    await findByTestId('trust-score-value');
+    expect(queryByTestId('trusted-contributor-badge')).toBeNull();
+  });
+
+  it('does NOT render the badge for unrelated roles (e.g. "ADMIN")', async () => {
+    mockGetMe.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: makeUser({ role: 'ADMIN' }),
+    } as any);
+
+    const { queryByTestId, findByTestId } = render(<ProfileScreen />);
+    await findByTestId('trust-score-value');
+    expect(queryByTestId('trusted-contributor-badge')).toBeNull();
+  });
+
+  it('renders the Trust Score numerical value from /users/me', async () => {
+    mockGetMe.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: makeUser({ trustScore: 137 }),
+    } as any);
+
+    const { findByTestId } = render(<ProfileScreen />);
+    const node = await findByTestId('trust-score-value');
+    expect(node.props.children).toBe(137);
+  });
+
+  it('falls back to 0 when trustScore is missing', async () => {
+    mockGetMe.mockResolvedValue({
+      ok: true,
+      status: 200,
+      data: makeUser({ trustScore: undefined }),
+    } as any);
+
+    const { findByTestId } = render(<ProfileScreen />);
+    const node = await findByTestId('trust-score-value');
+    expect(node.props.children).toBe(0);
+  });
+});

--- a/frontend/src/components/profile/TrustedContributorBadge.tsx
+++ b/frontend/src/components/profile/TrustedContributorBadge.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Svg, { Path, Circle, Defs, LinearGradient, Stop } from 'react-native-svg';
+import { COLORS } from '../../constants/theme';
+
+export interface TrustedContributorBadgeProps {
+  size?: number;
+  testID?: string;
+  label?: string;
+}
+
+export function TrustedContributorBadge({
+  size = 18,
+  testID = 'trusted-contributor-badge',
+  label = 'Trusted Contributor',
+}: TrustedContributorBadgeProps) {
+  return (
+    <View
+      testID={testID}
+      accessibilityRole="text"
+      accessibilityLabel={label}
+      style={s.pill}
+    >
+      <Svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        testID={`${testID}-svg`}
+      >
+        <Defs>
+          <LinearGradient id="tcShield" x1="0" y1="0" x2="0" y2="1">
+            <Stop offset="0" stopColor={COLORS.green500} />
+            <Stop offset="1" stopColor={COLORS.green700} />
+          </LinearGradient>
+        </Defs>
+        {/* Shield outline */}
+        <Path
+          d="M12 1.5 4 4.6v6.3c0 4.7 3.3 9 8 11.6 4.7-2.6 8-6.9 8-11.6V4.6L12 1.5z"
+          fill="url(#tcShield)"
+          stroke={COLORS.green800}
+          strokeWidth={0.6}
+        />
+        {/* Inner ring */}
+        <Circle cx="12" cy="11" r="4.6" fill={COLORS.white} opacity={0.95} />
+        {/* Checkmark */}
+        <Path
+          d="M9.4 11.2l1.7 1.8 3.5-3.7"
+          fill="none"
+          stroke={COLORS.green700}
+          strokeWidth={1.8}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </Svg>
+      <Text style={s.label}>{label}</Text>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 100,
+    backgroundColor: COLORS.green100,
+    borderWidth: 1,
+    borderColor: COLORS.green200,
+    alignSelf: 'flex-start',
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: COLORS.green800,
+    letterSpacing: 0.2,
+  },
+});

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -57,7 +57,8 @@ export interface RegisterPayload { email: string; fullName: string; password: st
 export interface RegisterResponse { userId: string; email: string; fullName: string; status: string; trustScore: number; accessToken: string; refreshToken: string; createdAt: string; }
 export interface LoginPayload { email: string; password: string; }
 export interface LoginResponse { access: string; refresh: string; }
-export interface UserProfile { userId: string; email: string; fullName: string; status: string; trustScore: number; createdAt: string; }
+export type UserRole = 'USER' | 'TRUSTED_CONTRIBUTOR' | 'ADMIN' | string;
+export interface UserProfile { userId: string; email: string; fullName: string; status: string; trustScore: number; role: UserRole; createdAt: string; }
 
 export function parseDRFError(data: any): string {
   if (!data) return 'Something went wrong.';
@@ -89,6 +90,7 @@ export async function getMe() {
   if (res.ok) {
     data.trustScore = data.trustScore ?? data.reputationPoints ?? 0;
     data.status = data.status ?? data.accountStatus ?? 'ACTIVE';
+    data.role = data.role ?? 'USER';
   }
   return { ok: res.ok, status: res.status, data };
 }


### PR DESCRIPTION
Closes #168

## Changes
- Added `role` field to `UserProfile` interface
- New `TrustedContributorBadge` SVG component using `react-native-svg` (dark-mode safe, no PNG)
- Trust Score numerical display on profile screen
- Conditional badge rendering: only when `role === 'TRUSTED_CONTRIBUTOR'`
- Jest tests for badge presence/absence and trust score rendering

## Acceptance Criteria
- [x] Profile page displays numerical Trust Score
- [x] "Trusted Contributor" badge renders when role matches; absent otherwise
- [x] Badge is an SVG component (dark-mode safe, no image file)
- [x] Jest tests: badge visible, badge absent, score display

## Testing
- All 7 tests pass: `npm test -- TrustedContributorBadge`
- Manually verified on profile screen

## Notes
Data comes from `GET /api/auth/users/me` (`trustScore`, `role` fields) — no backend changes needed.