### PR TITLE
feat(map): add passive obstacle toggle to map view

### DIFF
--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -274,6 +274,9 @@ export default function MapView() {
   const source = useMemo(() => ({ html: MAP_HTML }), []);
   const prefetchedRef = useRef<Obstacle[] | null>(null);
 
+  // Filter state
+  const [showPassive, setShowPassive] = useState(false);
+
   const { location: currentLocation } = useLocation();
 
   // ── Saved places ─────────────────────────────────────────────────────────
@@ -333,9 +336,14 @@ export default function MapView() {
   const loadObstacles = useCallback(async (
     bbox: { north: number; south: number; east: number; west: number },
   ) => {
-    const data = await fetchObstacles(bbox, false);
-    pushObstacles(data, false);
-  }, [pushObstacles]);
+    const data = await fetchObstacles(bbox, showPassive);
+    pushObstacles(data, showPassive);
+  }, [pushObstacles, showPassive]);
+
+  useEffect(() => {
+    if (!currentBoundsRef.current || !readyRef.current) return;
+    loadObstacles(currentBoundsRef.current);
+  }, [showPassive, loadObstacles]);
 
   // ── Autocomplete for main search ─────────────────────────────────────────
 
@@ -808,6 +816,17 @@ export default function MapView() {
           )}
         </View>
 
+        {/* Passive toggle chip */}
+        <TouchableOpacity
+          style={[s.passiveChip, showPassive && s.passiveChipActive]}
+          onPress={() => setShowPassive((v) => !v)}
+        >
+          <Ionicons name="layers-outline" size={13} color={showPassive ? COLORS.white : COLORS.gray600} />
+          <Text style={[s.passiveChipText, showPassive && { color: COLORS.white }]}>
+            {showPassive ? 'Showing inactive' : 'Show inactive'}
+          </Text>
+        </TouchableOpacity>
+
         {/* Pin mode banner */}
         {pinMode && (
           <View style={s.pinBanner}>
@@ -1105,4 +1124,15 @@ const s = StyleSheet.create({
   prefsCalcBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
   prefsCancelBtn: { alignItems: 'center', paddingVertical: 4 },
   prefsCancelText: { fontSize: 14, color: COLORS.gray400 },
+
+  passiveChip: {
+    position: 'absolute', bottom: 80, left: 12,
+    flexDirection: 'row', alignItems: 'center', gap: 5,
+    backgroundColor: COLORS.white,
+    paddingHorizontal: 11, paddingVertical: 7,
+    borderRadius: 20, borderWidth: 1, borderColor: COLORS.gray200,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.10, shadowRadius: 4, elevation: 3,
+  },
+  passiveChipActive: { backgroundColor: COLORS.green700, borderColor: COLORS.green700 },
+  passiveChipText: { fontSize: 12, fontWeight: '600', color: COLORS.gray600 },
 });

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -210,6 +210,7 @@ export default function MapView() {
   const [boundsKey, setBoundsKey] = useState('');
   const [detailMap, setDetailMap] = useState<Record<string, ObstacleDetail | 'loading'>>({});
   const prefetchedRef = useRef(false);
+  const [showPassive, setShowPassive] = useState(false);
 
   // Search state
   const [query, setQuery] = useState('');
@@ -305,10 +306,10 @@ export default function MapView() {
         east: currentBounds.getEast(),
         west: currentBounds.getWest(),
       },
-      false,
+      showPassive,
     ).then((data) => { if (!cancelled) setObstacles(data); });
     return () => { cancelled = true; };
-  }, [boundsKey]);
+  }, [boundsKey, showPassive]);
 
   const handleBoundsChange = useCallback((b: L.LatLngBounds, z: number) => {
     setCurrentBounds(b);
@@ -830,6 +831,19 @@ export default function MapView() {
           )}
         </View>
 
+        {/* Passive toggle chip */}
+        <View style={s.passiveToggleWrap} pointerEvents="box-none">
+          <TouchableOpacity
+            style={[s.passiveChip, showPassive && s.passiveChipActive]}
+            onPress={() => setShowPassive((v) => !v)}
+          >
+            <Ionicons name="layers-outline" size={13} color={showPassive ? COLORS.white : COLORS.gray600} />
+            <Text style={[s.passiveChipText, showPassive && { color: COLORS.white }]}>
+              {showPassive ? 'Showing inactive' : 'Show inactive'}
+            </Text>
+          </TouchableOpacity>
+        </View>
+
         {/* Pin mode banner */}
         {pinMode && (
           <View style={s.pinBanner}>
@@ -1119,4 +1133,15 @@ const s = StyleSheet.create({
   prefsCalcBtnText: { color: COLORS.white, fontWeight: '700', fontSize: 15 },
   prefsCancelBtn: { alignItems: 'center', paddingVertical: 4 },
   prefsCancelText: { fontSize: 14, color: COLORS.gray400 },
+
+  passiveToggleWrap: { position: 'absolute', bottom: 80, left: 12 },
+  passiveChip: {
+    flexDirection: 'row', alignItems: 'center', gap: 5,
+    backgroundColor: COLORS.white,
+    paddingHorizontal: 11, paddingVertical: 7,
+    borderRadius: 20, borderWidth: 1, borderColor: COLORS.gray200,
+    shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.10, shadowRadius: 4, elevation: 3,
+  },
+  passiveChipActive: { backgroundColor: COLORS.green700, borderColor: COLORS.green700 },
+  passiveChipText: { fontSize: 12, fontWeight: '600', color: COLORS.gray600 },
 });


### PR DESCRIPTION
## Description
Adds a "Show inactive" toggle chip to the map overlay. By default only VERIFIED reports appear; toggling ON reveals PASSIVE (auto-decayed, older unverified) reports alongside them. CLOSED reports are always excluded — the backend never returns them regardless of this toggle.

## Type of Change
- [x] `feat` — new feature

## Changes
- `MapView.web.tsx`: added `showPassive` state; bounds-change effect passes it to `fetchObstacles` and re-runs when it changes; floating pill chip added to the overlay
- `MapView.tsx` (native): same `showPassive` state; `loadObstacles` callback uses it in deps; a `useEffect` re-triggers a load on toggle; pill chip added to overlay

## How to Test
1. Open map — only VERIFIED markers appear by default
2. Tap/click **"Show inactive"** chip (bottom-left corner) — chip turns green, dimmed PASSIVE markers appear
3. Tap/click again — chip reverts, PASSIVE markers disappear without full map reload
4. Pan/zoom while toggle is ON — new area fetches with `includePassive=true`
5. Verify CLOSED reports never appear regardless of toggle state

## Screenshots (if applicable)
N/A

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #186

## Notes
Depends on `GET /api/map/obstacles?includePassive=true` which is already merged into `main` from the `feature/flag-and-exclude-closed` backend PR.
