### PR TITLE
fix(notifications): alias serializer fields to camelCase for frontend…

### DIFF
--- a/backend/apps/notifications/serializers.py
+++ b/backend/apps/notifications/serializers.py
@@ -5,9 +5,11 @@ from .models import Notification
 
 class NotificationSerializer(serializers.ModelSerializer):
     type = serializers.CharField(source='notification_type', read_only=True)
-    report_id = serializers.UUIDField(source='related_report_id', read_only=True)
+    reportId = serializers.UUIDField(source='related_report_id', read_only=True)
+    isRead = serializers.BooleanField(source='is_read', read_only=True)
+    createdAt = serializers.DateTimeField(source='created_at', read_only=True)
 
     class Meta:
         model = Notification
-        fields = ['id', 'type', 'report_id', 'message', 'is_read', 'created_at']
+        fields = ['id', 'type', 'reportId', 'message', 'isRead', 'createdAt']
         read_only_fields = fields

--- a/backend/apps/notifications/tests.py
+++ b/backend/apps/notifications/tests.py
@@ -237,11 +237,11 @@ class NotificationListViewTest(TestCase):
         item = response.json()[0]
 
         self.assertEqual(set(item.keys()), {
-            "id", "type", "report_id", "message", "is_read", "created_at",
+            "id", "type", "reportId", "message", "isRead", "createdAt",
         })
         self.assertEqual(item["type"], NotificationType.REPORT_VERIFIED)
-        self.assertEqual(item["report_id"], str(self.report.id))
-        self.assertFalse(item["is_read"])
+        self.assertEqual(item["reportId"], str(self.report.id))
+        self.assertFalse(item["isRead"])
 
 
 class NotificationMarkReadViewTest(TestCase):
@@ -267,7 +267,7 @@ class NotificationMarkReadViewTest(TestCase):
         response = self.client.patch(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue(response.json()["is_read"])
+        self.assertTrue(response.json()["isRead"])
         self.notification.refresh_from_db()
         self.assertTrue(self.notification.is_read)
 


### PR DESCRIPTION
## Description
NotificationSerializer was emitting snake_case keys (`report_id`, `is_read`, `created_at`) while every other serializer uses camelCase. This broke the frontend notifications screen where `item.isRead`, `item.reportId`, and `item.createdAt` resolved to `undefined`.

## Type of Change
- [x] `fix` — bug fix

## Changes
- Alias `report_id` → `reportId`, `is_read` → `isRead`, `created_at` → `createdAt` in `NotificationSerializer` with explicit field declarations
- Update `Meta.fields` list to use camelCase keys
- Update `test_payload_shape` assertions to expect `reportId`, `isRead`, `createdAt`
- Update `test_marks_notification_as_read` assertion to expect `isRead`

## How to Test
1. `GET /api/notifications/` — response objects should have keys `{id, type, reportId, message, isRead, createdAt}`
2. `PATCH /api/notifications/{id}/read/` — response should return `isRead: true`
3. Run `python manage.py test apps.notifications` — all tests pass

## Screenshots (if applicable)
N/A — no UI changes, backend-only fix.

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #223

## Notes
Follows the same camelCase aliasing convention used in `UserProfileSerializer` (`notificationsEnabled`, `createdAt`). No migration or API behavior change beyond field naming.
