### PR TITLE
feat(users): implement GET/POST/PUT /users/me/mobility-profile endpoint

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -145,6 +145,35 @@ class UserProfileUpdateSerializer(serializers.Serializer):
         return instance
 
 
+class MobilityProfileInputSerializer(serializers.Serializer):
+    mobilityAid = serializers.ChoiceField(
+        choices=MobilityAidType.choices, source='mobility_aid_type',
+    )
+    avoidStairs = serializers.BooleanField(
+        source='avoid_stairs', required=False, default=False,
+    )
+    avoidSteepSlopes = serializers.BooleanField(
+        source='avoid_steep_slopes', required=False, default=False,
+    )
+    maxSlopeGradient = serializers.FloatField(
+        source='max_slope_gradient', required=False, default=None, allow_null=True,
+    )
+
+
+class MobilityProfileOutputSerializer(serializers.ModelSerializer):
+    profileId = serializers.UUIDField(source='id', read_only=True)
+    mobilityAid = serializers.CharField(source='mobility_aid_type', read_only=True)
+    avoidStairs = serializers.BooleanField(source='avoid_stairs', read_only=True)
+    avoidSteepSlopes = serializers.BooleanField(source='avoid_steep_slopes', read_only=True)
+    maxSlopeGradient = serializers.FloatField(source='max_slope_gradient', read_only=True)
+    createdAt = serializers.DateTimeField(source='created_at', read_only=True)
+
+    class Meta:
+        model = MobilityProfile
+        fields = ['profileId', 'mobilityAid', 'avoidStairs', 'avoidSteepSlopes',
+                  'maxSlopeGradient', 'createdAt']
+
+
 class PasswordResetRequestSerializer(serializers.Serializer):
     email = serializers.EmailField()
 

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -287,3 +287,85 @@ class PasswordResetConfirmViewTest(TestCase):
             self.url, {'token': 'validtoken123', 'password': '123'}, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
+# ---------------------------------------------------------------------------
+# View: GET/POST/PUT /api/users/me/mobility-profile
+# ---------------------------------------------------------------------------
+
+MOBILITY_URL = '/api/users/me/mobility-profile'
+
+
+class MobilityProfileViewTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email='user@test.com', full_name='Test User', password='SecureP@ss123',
+        )
+        self.valid_payload = {
+            'mobilityAid': 'WHEELCHAIR',
+            'avoidStairs': True,
+            'avoidSteepSlopes': True,
+            'maxSlopeGradient': 8.0,
+        }
+
+    def test_get_returns_404_when_no_profile(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(MOBILITY_URL)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_create_profile(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(MOBILITY_URL, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        data = response.json()
+        self.assertEqual(data['mobilityAid'], 'WHEELCHAIR')
+        self.assertTrue(data['avoidStairs'])
+        self.assertTrue(data['avoidSteepSlopes'])
+        self.assertEqual(data['maxSlopeGradient'], 8.0)
+        self.assertIn('profileId', data)
+        self.assertIn('createdAt', data)
+
+    def test_get_returns_profile_after_create(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post(MOBILITY_URL, self.valid_payload, format='json')
+        response = self.client.get(MOBILITY_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()['mobilityAid'], 'WHEELCHAIR')
+
+    def test_create_duplicate_returns_409(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post(MOBILITY_URL, self.valid_payload, format='json')
+        response = self.client.post(MOBILITY_URL, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+    def test_update_profile(self):
+        self.client.force_authenticate(user=self.user)
+        self.client.post(MOBILITY_URL, self.valid_payload, format='json')
+        updated = {
+            'mobilityAid': 'ELECTRIC_WHEELCHAIR',
+            'avoidStairs': False,
+            'avoidSteepSlopes': False,
+            'maxSlopeGradient': 5.0,
+        }
+        response = self.client.put(MOBILITY_URL, updated, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data['mobilityAid'], 'ELECTRIC_WHEELCHAIR')
+        self.assertFalse(data['avoidStairs'])
+        self.assertEqual(data['maxSlopeGradient'], 5.0)
+
+    def test_update_returns_404_when_no_profile(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.put(MOBILITY_URL, self.valid_payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_unauthenticated_returns_401(self):
+        response = self.client.get(MOBILITY_URL)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_mobility_aid_returns_400(self):
+        self.client.force_authenticate(user=self.user)
+        payload = {**self.valid_payload, 'mobilityAid': 'JETPACK'}
+        response = self.client.post(MOBILITY_URL, payload, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -7,7 +7,9 @@ from rest_framework_simplejwt.views import TokenRefreshView
 
 from apps.users.serializers import (LoginSerializer, TokenOutputSerializer, LogoutSerializer,
                                     RegisterSerializer, UserProfileSerializer, UserProfileUpdateSerializer,
-                                    PasswordResetRequestSerializer, PasswordResetConfirmSerializer)
+                                    PasswordResetRequestSerializer, PasswordResetConfirmSerializer,
+                                    MobilityProfileInputSerializer, MobilityProfileOutputSerializer)
+from apps.users.models import MobilityProfile
 from apps.users.services import login_user, logout_user, request_password_reset, confirm_password_reset
 from apps.users.throttles import AuthRateThrottle
 
@@ -132,3 +134,34 @@ class AuthorityDashboardView(APIView):
 
     def get(self, request):
         return Response({'message': 'Authority dashboard'}, status=status.HTTP_200_OK)
+
+
+class MobilityProfileView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        try:
+            profile = request.user.mobility_profile
+        except MobilityProfile.DoesNotExist:
+            return Response({'detail': 'Mobility profile not found.'}, status=status.HTTP_404_NOT_FOUND)
+        return Response(MobilityProfileOutputSerializer(profile).data)
+
+    def post(self, request):
+        if MobilityProfile.objects.filter(user=request.user).exists():
+            return Response({'detail': 'Mobility profile already exists.'}, status=status.HTTP_409_CONFLICT)
+        serializer = MobilityProfileInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        profile = MobilityProfile.objects.create(user=request.user, **serializer.validated_data)
+        return Response(MobilityProfileOutputSerializer(profile).data, status=status.HTTP_201_CREATED)
+
+    def put(self, request):
+        try:
+            profile = request.user.mobility_profile
+        except MobilityProfile.DoesNotExist:
+            return Response({'detail': 'Mobility profile not found.'}, status=status.HTTP_404_NOT_FOUND)
+        serializer = MobilityProfileInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        for attr, value in serializer.validated_data.items():
+            setattr(profile, attr, value)
+        profile.save()
+        return Response(MobilityProfileOutputSerializer(profile).data)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -3,6 +3,8 @@ from django.db import connection
 from django.http import JsonResponse
 from django.urls import include, path
 
+from apps.users.views import MobilityProfileView
+
 
 def health(request):
     try:
@@ -23,4 +25,5 @@ urlpatterns = [
     path('api/authority/', include('apps.authority.urls')),
     path('api/notifications/', include('apps.notifications.urls')),
     path('api/users/me/saved-places/', include('apps.places.urls')),
+    path('api/users/me/mobility-profile', MobilityProfileView.as_view(), name='mobility-profile'),
 ]

--- a/frontend/src/api/mobilityProfile.ts
+++ b/frontend/src/api/mobilityProfile.ts
@@ -6,7 +6,7 @@ import { MobilityProfile, MobilityProfilePayload } from '../types/mobilityProfil
  * Set MOCK = true while the backend endpoints are not yet implemented.
  * Flip to false once GET/POST/PUT /users/me/mobility-profile are live.
  */
-export const MOCK = true;
+export const MOCK = false;
 
 // ── In-memory mock store ───────────────────────────────────────────────────
 let _mockProfile: MobilityProfile | null = null;


### PR DESCRIPTION
## Description
Adds mobility profile support for authenticated users by implementing backend serializers, endpoint, and tests, and connecting the frontend to the real API. This enables users to create, retrieve, and update their mobility preferences.

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes
- Added `MobilityProfileInputSerializer` and `MobilityProfileOutputSerializer` aligned with frontend interfaces
- Implemented `GET/POST/PUT /users/me/mobility-profile` endpoint
- Registered route in `config/urls.py`
- Flipped `MOCK = false` in frontend mobilityProfile API
- Added 8 tests covering success cases and edge cases
- 
## Related Issue 
- Closes #143 
- 
## How to Test
1. Run backend tests:
   ```bash
   pytest
   # or
   python manage.py test