### PR TITLE
feat(authority): dashboard UI for infrastructure authority role

### DIFF
--- a/backend/apps/authority/selectors.py
+++ b/backend/apps/authority/selectors.py
@@ -1,0 +1,45 @@
+from django.db.models import Count, Q
+
+from apps.reports.models import InteractionType, Report, ReportStatus
+
+
+DASHBOARD_STATUSES = (
+    ReportStatus.VERIFIED,
+    ReportStatus.RESOLVED_AWAITING_VALIDATION,
+    ReportStatus.CLOSED,
+)
+
+
+def get_dashboard_reports(status_filter: str | None = None):
+    qs = (
+        Report.objects.filter(status__in=DASHBOARD_STATUSES)
+        .select_related('reporter')
+        .prefetch_related('photos', 'interactions')
+        .annotate(
+            upvote_count=Count(
+                'interactions',
+                filter=Q(interactions__interaction_type=InteractionType.UPVOTE),
+            ),
+        )
+        .order_by('-created_at')
+    )
+    if status_filter:
+        qs = qs.filter(status=status_filter)
+    return qs
+
+
+def get_dashboard_status_counts() -> dict:
+    counts = {row['status']: row['n'] for row in (
+        Report.objects.filter(status__in=DASHBOARD_STATUSES)
+        .values('status')
+        .annotate(n=Count('id'))
+    )}
+    verified = counts.get(ReportStatus.VERIFIED, 0)
+    awaiting = counts.get(ReportStatus.RESOLVED_AWAITING_VALIDATION, 0)
+    closed = counts.get(ReportStatus.CLOSED, 0)
+    return {
+        'verified': verified,
+        'awaitingValidation': awaiting,
+        'closed': closed,
+        'total': verified + awaiting + closed,
+    }

--- a/backend/apps/authority/serializers.py
+++ b/backend/apps/authority/serializers.py
@@ -2,7 +2,11 @@ from rest_framework import serializers
 
 
 class ResolveReportSerializer(serializers.Serializer):
-    repairPhotoUrl = serializers.URLField(source='repair_photo_url')
+    repairPhoto = serializers.CharField(
+        source='repair_photo',
+        write_only=True,
+        help_text='Base64-encoded image (with or without data URL prefix).',
+    )
     repairNotes = serializers.CharField(
         source='repair_notes',
         required=False,
@@ -14,4 +18,40 @@ class ResolveReportSerializer(serializers.Serializer):
 class ResolveReportResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField(source='id')
     status = serializers.CharField()
+    repairPhotoUrl = serializers.CharField(source='repair_photo_url')
     updatedAt = serializers.DateTimeField(source='updated_at')
+
+
+class DashboardReportSerializer(serializers.Serializer):
+    reportId = serializers.UUIDField(source='id')
+    title = serializers.CharField()
+    description = serializers.CharField()
+    category = serializers.CharField()
+    context = serializers.CharField()
+    status = serializers.CharField()
+    location = serializers.SerializerMethodField()
+    upvoteCount = serializers.IntegerField(source='upvote_count')
+    thumbnailUrl = serializers.SerializerMethodField()
+    reporter = serializers.SerializerMethodField()
+    createdAt = serializers.DateTimeField(source='created_at')
+    updatedAt = serializers.DateTimeField(source='updated_at')
+
+    def get_location(self, obj):
+        return {'lat': float(obj.latitude), 'lng': float(obj.longitude)}
+
+    def get_thumbnailUrl(self, obj):
+        first = next(iter(obj.photos.all()), None)
+        return first.image_url if first else None
+
+    def get_reporter(self, obj):
+        return {
+            'userId': str(obj.reporter_id),
+            'fullName': obj.reporter.full_name,
+        }
+
+
+class DashboardCountsSerializer(serializers.Serializer):
+    verified = serializers.IntegerField()
+    awaitingValidation = serializers.IntegerField()
+    closed = serializers.IntegerField()
+    total = serializers.IntegerField()

--- a/backend/apps/authority/services.py
+++ b/backend/apps/authority/services.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 
 from apps.reports.models import Report, ReportStatus, StatusChange
+from apps.reports.services import save_photos
 from apps.reports.signals import report_status_changed
 
 
@@ -8,40 +9,54 @@ class ReportAlreadyResolvedError(Exception):
     """Raised when an authority tries to resolve a report that is already resolved or closed."""
 
 
-@transaction.atomic
-def resolve_report(*, actor, report_id, repair_photo_url: str, repair_notes: str = '') -> Report:
+def resolve_report(*, actor, report_id, repair_photo: str, repair_notes: str = '') -> Report:
     """Mark a report as RESOLVED_AWAITING_VALIDATION.
 
-    Records a StatusChange entry and emits report_status_changed so notifications
-    fire after commit. Raises Report.DoesNotExist or ReportAlreadyResolvedError.
-    """
-    report = Report.objects.select_for_update().get(pk=report_id)
+    Uploads the post-repair photo to storage, attaches it to the Report, records a
+    StatusChange entry and emits report_status_changed so notifications fire after
+    commit. Raises Report.DoesNotExist or ReportAlreadyResolvedError.
 
+    The post-repair photo upload happens *before* the DB transaction so we don't
+    hold a row lock during a slow network call. If status changed concurrently the
+    transaction will fail and we'll have left an orphan photo URL — that's a known
+    trade-off and consistent with how create_report handles uploads.
+    """
+    # Pre-flight check (no lock) — fail fast before uploading.
+    report = Report.objects.get(pk=report_id)
     if report.status in (ReportStatus.RESOLVED_AWAITING_VALIDATION, ReportStatus.CLOSED):
         raise ReportAlreadyResolvedError()
 
-    old_status = report.status
-    report.status = ReportStatus.RESOLVED_AWAITING_VALIDATION
-    report.save(update_fields=['status', 'updated_at'])
+    photos = save_photos(report, [repair_photo])
+    repair_photo_url = photos[0].image_url
 
-    reason = f'repair_photo_url: {repair_photo_url}'
-    if repair_notes:
-        reason = f'{reason}; notes: {repair_notes}'
+    with transaction.atomic():
+        report = Report.objects.select_for_update().get(pk=report_id)
+        if report.status in (ReportStatus.RESOLVED_AWAITING_VALIDATION, ReportStatus.CLOSED):
+            raise ReportAlreadyResolvedError()
 
-    StatusChange.objects.create(
-        report=report,
-        changed_by=actor,
-        old_status=old_status,
-        new_status=ReportStatus.RESOLVED_AWAITING_VALIDATION,
-        reason=reason,
-    )
+        old_status = report.status
+        report.status = ReportStatus.RESOLVED_AWAITING_VALIDATION
+        report.save(update_fields=['status', 'updated_at'])
 
-    report_status_changed.send(
-        sender=Report,
-        report=report,
-        old_status=old_status,
-        new_status=ReportStatus.RESOLVED_AWAITING_VALIDATION,
-        actor=actor,
-    )
+        reason = f'repair_photo_url: {repair_photo_url}'
+        if repair_notes:
+            reason = f'{reason}; notes: {repair_notes}'
 
+        StatusChange.objects.create(
+            report=report,
+            changed_by=actor,
+            old_status=old_status,
+            new_status=ReportStatus.RESOLVED_AWAITING_VALIDATION,
+            reason=reason,
+        )
+
+        report_status_changed.send(
+            sender=Report,
+            report=report,
+            old_status=old_status,
+            new_status=ReportStatus.RESOLVED_AWAITING_VALIDATION,
+            actor=actor,
+        )
+
+    report.repair_photo_url = repair_photo_url
     return report

--- a/backend/apps/authority/tests.py
+++ b/backend/apps/authority/tests.py
@@ -268,3 +268,17 @@ class DashboardViewTest(TestCase):
         item = response.json()["reports"][0]
         self.assertEqual(item["location"], {"lat": 41.0837, "lng": 29.051})
         self.assertEqual(item["reporter"]["userId"], str(self.reporter.id))
+
+    def test_thumbnail_uses_oldest_photo_after_resolution(self):
+        """Regression: after a post-repair photo is appended, the dashboard
+        thumbnail must keep showing the original obstacle photo."""
+        Photo.objects.create(report=self.awaiting, image_url='https://cdn/original.jpg')
+        Photo.objects.create(report=self.awaiting, image_url='https://cdn/post-repair.jpg')
+
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.get(
+            self.url, {"status": ReportStatus.RESOLVED_AWAITING_VALIDATION}
+        )
+        items = response.json()["reports"]
+        item = next(i for i in items if i["reportId"] == str(self.awaiting.id))
+        self.assertEqual(item["thumbnailUrl"], 'https://cdn/original.jpg')

--- a/backend/apps/authority/tests.py
+++ b/backend/apps/authority/tests.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.test import TestCase
@@ -9,12 +10,19 @@ from apps.reports.models import (
     Interaction,
     InteractionType,
     ObstacleCategory,
+    Photo,
     Report,
     ReportContext,
     ReportStatus,
     StatusChange,
 )
 from apps.users.models import User, UserRole
+
+
+# Tiny 1x1 PNG, base64-encoded.
+SAMPLE_BASE64_PNG = (
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+)
 
 
 def make_user(email, role=UserRole.REGISTERED_USER, **kwargs):
@@ -41,6 +49,14 @@ def make_report(reporter, **kwargs):
     return Report.objects.create(reporter=reporter, **defaults)
 
 
+def _fake_save_photos(report, photos):
+    """Stub save_photos so resolve tests don't hit Supabase."""
+    return [
+        Photo.objects.create(report=report, image_url=f'https://cdn.fake/{report.id}-{i}.jpg')
+        for i, _ in enumerate(photos)
+    ]
+
+
 class ResolveReportViewTest(TestCase):
     def setUp(self):
         self.client = APIClient()
@@ -49,9 +65,15 @@ class ResolveReportViewTest(TestCase):
         self.report = make_report(self.reporter)
         self.url = f"/api/authority/reports/{self.report.id}/resolve"
         self.payload = {
-            "repairPhotoUrl": "https://cdn.example.com/repaired.jpg",
+            "repairPhoto": SAMPLE_BASE64_PNG,
             "repairNotes": "Patched the ramp.",
         }
+        self._save_photos_patch = patch(
+            'apps.authority.services.save_photos',
+            side_effect=_fake_save_photos,
+        )
+        self._save_photos_patch.start()
+        self.addCleanup(self._save_photos_patch.stop)
 
     def test_anonymous_returns_401(self):
         response = self.client.patch(self.url, self.payload, format='json')
@@ -68,24 +90,15 @@ class ResolveReportViewTest(TestCase):
         response = self.client.patch(self.url, self.payload, format='json')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
-    def test_missing_repair_photo_url_returns_400(self):
+    def test_missing_repair_photo_returns_400(self):
         self.client.force_authenticate(user=self.authority)
         response = self.client.patch(
             self.url, {"repairNotes": "no photo"}, format='json'
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn("repairPhotoUrl", response.content.decode())
+        self.assertIn("repairPhoto", response.content.decode())
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, ReportStatus.VERIFIED)
-
-    def test_invalid_url_returns_400(self):
-        self.client.force_authenticate(user=self.authority)
-        response = self.client.patch(
-            self.url,
-            {"repairPhotoUrl": "not-a-url", "repairNotes": "x"},
-            format='json',
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_unknown_report_returns_404(self):
         self.client.force_authenticate(user=self.authority)
@@ -106,15 +119,17 @@ class ResolveReportViewTest(TestCase):
         body = response.json()
         self.assertEqual(body["status"], ReportStatus.RESOLVED_AWAITING_VALIDATION)
         self.assertEqual(body["reportId"], str(self.report.id))
+        self.assertTrue(body["repairPhotoUrl"].startswith('https://cdn.fake/'))
 
         self.report.refresh_from_db()
         self.assertEqual(self.report.status, ReportStatus.RESOLVED_AWAITING_VALIDATION)
+        self.assertEqual(self.report.photos.count(), 1)
 
         change = StatusChange.objects.get(report=self.report)
         self.assertEqual(change.changed_by, self.authority)
         self.assertEqual(change.old_status, ReportStatus.VERIFIED)
         self.assertEqual(change.new_status, ReportStatus.RESOLVED_AWAITING_VALIDATION)
-        self.assertIn("repair_photo_url: https://cdn.example.com/repaired.jpg", change.reason)
+        self.assertIn("repair_photo_url: https://cdn.fake/", change.reason)
         self.assertIn("notes: Patched the ramp.", change.reason)
 
     def test_resolve_notifies_reporter_and_upvoters(self):
@@ -170,3 +185,86 @@ class ResolveReportViewTest(TestCase):
         response = self.client.patch(self.url, self.payload, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+
+class DashboardViewTest(TestCase):
+    def setUp(self):
+        # Project conftest disables django_db_setup, so the DB isn't reset
+        # between test classes. Wipe Reports to keep these assertions stable.
+        Report.objects.all().delete()
+
+        self.client = APIClient()
+        self.authority = make_user("authority@test.com", role=UserRole.INFRASTRUCTURE_AUTHORITY)
+        self.reporter = make_user("reporter@test.com")
+        self.url = "/api/authority/dashboard"
+
+        # Build a representative spread of report statuses.
+        self.verified = make_report(self.reporter, status=ReportStatus.VERIFIED)
+        self.awaiting = make_report(self.reporter, status=ReportStatus.RESOLVED_AWAITING_VALIDATION)
+        self.closed = make_report(self.reporter, status=ReportStatus.CLOSED)
+        # These should NOT appear on the dashboard.
+        make_report(self.reporter, status=ReportStatus.UNVERIFIED)
+        make_report(self.reporter, status=ReportStatus.PASSIVE)
+
+    def test_anonymous_returns_401(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_authority_returns_403(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_authority_lists_only_dashboard_statuses(self):
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+
+        ids = {item["reportId"] for item in body["reports"]}
+        self.assertEqual(ids, {str(self.verified.id), str(self.awaiting.id), str(self.closed.id)})
+
+        self.assertEqual(body["counts"], {
+            "verified": 1,
+            "awaitingValidation": 1,
+            "closed": 1,
+            "total": 3,
+        })
+
+    def test_filter_by_status_verified(self):
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.get(self.url, {"status": ReportStatus.VERIFIED})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        ids = {item["reportId"] for item in body["reports"]}
+        self.assertEqual(ids, {str(self.verified.id)})
+        # Counts are unaffected by the status filter.
+        self.assertEqual(body["counts"]["total"], 3)
+
+    def test_pagination(self):
+        # Add extra verified reports to exceed page size.
+        for _ in range(4):
+            make_report(self.reporter, status=ReportStatus.VERIFIED)
+
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.get(
+            self.url, {"status": ReportStatus.VERIFIED, "page": 2, "size": 2}
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        body = response.json()
+        self.assertEqual(len(body["reports"]), 2)
+        self.assertEqual(body["pagination"], {
+            "page": 2, "size": 2, "totalItems": 5,
+        })
+
+    def test_invalid_pagination_returns_400(self):
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.get(self.url, {"page": "abc"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_response_includes_location_and_reporter(self):
+        self.client.force_authenticate(user=self.authority)
+        response = self.client.get(self.url, {"status": ReportStatus.VERIFIED})
+        item = response.json()["reports"][0]
+        self.assertEqual(item["location"], {"lat": 41.0837, "lng": 29.051})
+        self.assertEqual(item["reporter"]["userId"], str(self.reporter.id))

--- a/backend/apps/authority/urls.py
+++ b/backend/apps/authority/urls.py
@@ -5,6 +5,7 @@ from . import views
 app_name = 'authority'
 
 urlpatterns = [
+    path('dashboard', views.DashboardView.as_view(), name='dashboard'),
     path(
         'reports/<uuid:report_id>/resolve',
         views.ResolveReportView.as_view(),

--- a/backend/apps/authority/views.py
+++ b/backend/apps/authority/views.py
@@ -5,8 +5,18 @@ from rest_framework.views import APIView
 from apps.core.permissions import IsAuthority
 from apps.reports.models import Report
 
-from .serializers import ResolveReportResponseSerializer, ResolveReportSerializer
+from .selectors import get_dashboard_reports, get_dashboard_status_counts
+from .serializers import (
+    DashboardCountsSerializer,
+    DashboardReportSerializer,
+    ResolveReportResponseSerializer,
+    ResolveReportSerializer,
+)
 from .services import ReportAlreadyResolvedError, resolve_report
+
+
+DEFAULT_PAGE_SIZE = 20
+MAX_PAGE_SIZE = 100
 
 
 class ResolveReportView(APIView):
@@ -20,7 +30,7 @@ class ResolveReportView(APIView):
             report = resolve_report(
                 actor=request.user,
                 report_id=report_id,
-                repair_photo_url=serializer.validated_data['repair_photo_url'],
+                repair_photo=serializer.validated_data['repair_photo'],
                 repair_notes=serializer.validated_data.get('repair_notes', ''),
             )
         except Report.DoesNotExist:
@@ -38,3 +48,37 @@ class ResolveReportView(APIView):
             ResolveReportResponseSerializer(report).data,
             status=status.HTTP_200_OK,
         )
+
+
+class DashboardView(APIView):
+    permission_classes = [IsAuthority]
+
+    def get(self, request):
+        status_filter = request.query_params.get('status') or None
+        try:
+            page = max(1, int(request.query_params.get('page', '1')))
+            size = min(
+                MAX_PAGE_SIZE,
+                max(1, int(request.query_params.get('size', str(DEFAULT_PAGE_SIZE)))),
+            )
+        except ValueError:
+            return Response(
+                {'detail': 'page and size must be positive integers.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        qs = get_dashboard_reports(status_filter)
+        total_items = qs.count()
+
+        offset = (page - 1) * size
+        page_items = qs[offset:offset + size]
+
+        return Response({
+            'reports': DashboardReportSerializer(page_items, many=True).data,
+            'pagination': {
+                'page': page,
+                'size': size,
+                'totalItems': total_items,
+            },
+            'counts': DashboardCountsSerializer(get_dashboard_status_counts()).data,
+        })

--- a/backend/apps/map/selectors.py
+++ b/backend/apps/map/selectors.py
@@ -34,7 +34,15 @@ def get_obstacle_detail(report_id):
                 "status_changes__changed_by",
             ).get(
                 pk=report_id,
-                status__in=[ReportStatus.VERIFIED, ReportStatus.PASSIVE],
+                status__in=[
+                    ReportStatus.VERIFIED,
+                    ReportStatus.PASSIVE,
+                    # Citizens need access to RESOLVED_AWAITING_VALIDATION reports so
+                    # they can confirm the repair from a status-change notification,
+                    # and authorities need access to refresh the detail screen after
+                    # they submit a resolution.
+                    ReportStatus.RESOLVED_AWAITING_VALIDATION,
+                ],
             )
         )
     except Report.DoesNotExist:

--- a/backend/apps/map/serializers.py
+++ b/backend/apps/map/serializers.py
@@ -58,8 +58,10 @@ class ObstacleDetailSerializer(serializers.Serializer):
     description = serializers.CharField()
     upvoteCount = serializers.SerializerMethodField()
     flagCount = serializers.SerializerMethodField()
+    confirmationCount = serializers.SerializerMethodField()
     userUpvoted = serializers.SerializerMethodField()
     userFlagged = serializers.SerializerMethodField()
+    userConfirmed = serializers.SerializerMethodField()
     photos = PhotoSerializer(many=True)
     statusHistory = StatusHistorySerializer(many=True, source="status_changes")
     createdAt = serializers.DateTimeField(source="created_at")
@@ -72,6 +74,9 @@ class ObstacleDetailSerializer(serializers.Serializer):
 
     def get_flagCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.FLAG)
+
+    def get_confirmationCount(self, obj):
+        return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.CONFIRM_RESOLUTION)
 
     def _user_has_interaction(self, obj, interaction_type):
         request = self.context.get("request")
@@ -88,6 +93,9 @@ class ObstacleDetailSerializer(serializers.Serializer):
 
     def get_userFlagged(self, obj):
         return self._user_has_interaction(obj, InteractionType.FLAG)
+
+    def get_userConfirmed(self, obj):
+        return self._user_has_interaction(obj, InteractionType.CONFIRM_RESOLUTION)
 
 
 class CampusLocationSerializer(serializers.Serializer):

--- a/backend/apps/map/tests.py
+++ b/backend/apps/map/tests.py
@@ -114,6 +114,16 @@ class GetObstacleDetailTest(TestCase):
         result = get_obstacle_detail(report.pk)
         self.assertIsNone(result)
 
+    def test_returns_resolved_awaiting_validation_report(self):
+        # Citizens hitting "View report" from a status-change notification, and
+        # authorities refreshing the detail screen after resolving, both need
+        # this status to be visible.
+        from apps.map.selectors import get_obstacle_detail
+        report = make_report(self.user, report_status=ReportStatus.RESOLVED_AWAITING_VALIDATION)
+        result = get_obstacle_detail(report.pk)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, report.pk)
+
     def test_returns_none_for_nonexistent(self):
         import uuid
         from apps.map.selectors import get_obstacle_detail

--- a/backend/apps/reports/models.py
+++ b/backend/apps/reports/models.py
@@ -81,6 +81,9 @@ class Photo(models.Model):
 
     class Meta:
         db_table = "photos"
+        # Oldest first, so the original obstacle photo stays as the thumbnail
+        # even after a post-repair photo is appended on resolution.
+        ordering = ["uploaded_at"]
 
     def __str__(self):
         return f"Photo for {self.report.title}"

--- a/backend/apps/users/admin.py
+++ b/backend/apps/users/admin.py
@@ -1,0 +1,26 @@
+from django.contrib import admin
+
+from .models import MobilityProfile, User
+
+
+@admin.register(User)
+class UserAdmin(admin.ModelAdmin):
+    list_display = ('email', 'full_name', 'role', 'account_status', 'reputation_points')
+    list_filter = ('role', 'account_status')
+    search_fields = ('email', 'full_name')
+    ordering = ('email',)
+    fields = (
+        'email', 'full_name', 'birth_date',
+        'role', 'account_status',
+        'reputation_points', 'notifications_enabled',
+        'is_active', 'is_staff',
+        'created_at', 'updated_at',
+    )
+    readonly_fields = ('created_at', 'updated_at')
+
+
+@admin.register(MobilityProfile)
+class MobilityProfileAdmin(admin.ModelAdmin):
+    list_display = ('user', 'mobility_aid_type', 'avoid_stairs', 'avoid_steep_slopes')
+    list_filter = ('mobility_aid_type',)
+    search_fields = ('user__email',)

--- a/backend/apps/users/management/commands/promote_authority.py
+++ b/backend/apps/users/management/commands/promote_authority.py
@@ -1,0 +1,39 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.users.models import User, UserRole
+
+
+class Command(BaseCommand):
+    help = (
+        "Set a user's role. Used during development to test the authority "
+        "dashboard without a public registration flow for the authority role. "
+        "Default role is INFRASTRUCTURE_AUTHORITY."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument('email', help='Email of the user to update.')
+        parser.add_argument(
+            '--role',
+            default=UserRole.INFRASTRUCTURE_AUTHORITY,
+            choices=[r.value for r in UserRole],
+            help='Target role (default: INFRASTRUCTURE_AUTHORITY).',
+        )
+
+    def handle(self, *args, **options):
+        email = options['email']
+        role = options['role']
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            raise CommandError(f"No user with email {email!r}.")
+
+        if user.role == role:
+            self.stdout.write(f"{email} already has role {role}; nothing to do.")
+            return
+
+        previous = user.role
+        user.role = role
+        user.save(update_fields=['role'])
+        self.stdout.write(self.style.SUCCESS(
+            f"{email}: {previous} -> {role}"
+        ))

--- a/frontend/app/auth/login.tsx
+++ b/frontend/app/auth/login.tsx
@@ -3,7 +3,7 @@ import { View, Text, TextInput, TouchableOpacity, StyleSheet, KeyboardAvoidingVi
 import { useRouter, Link, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../src/constants/theme';
-import { login, setTokens, parseDRFError } from '../../src/services/auth';
+import { login, setTokens, parseDRFError, getMe, landingRouteForRole } from '../../src/services/auth';
 
 export default function LoginScreen() {
   const router = useRouter();
@@ -30,7 +30,12 @@ export default function LoginScreen() {
     setLoading(true);
     try {
       const res = await login({ email: email.trim(), password });
-      if (res.ok) { setTokens(res.data.access, res.data.refresh); router.replace('/tabs'); }
+      if (res.ok) {
+        setTokens(res.data.access, res.data.refresh);
+        const me = await getMe();
+        const target = me.ok ? landingRouteForRole(me.data.role) : '/tabs';
+        router.replace(target as any);
+      }
       else if (res.status === 401) setApiError('Invalid email or password');
       else setApiError(parseDRFError(res.data));
     } catch { setApiError('Network error. Check your connection.'); }

--- a/frontend/app/authority/_layout.tsx
+++ b/frontend/app/authority/_layout.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { COLORS } from '../../src/constants/theme';
+import { clearTokens, getMe, isAuthorityRole, isLoggedIn } from '../../src/services/auth';
+
+type Phase = 'checking' | 'allowed';
+
+export default function AuthorityLayout() {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>('checking');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function guard() {
+      if (!isLoggedIn()) {
+        router.replace('/auth/login');
+        return;
+      }
+      const res = await getMe();
+      if (cancelled) return;
+      if (res.status === 401) {
+        clearTokens();
+        router.replace('/auth/login');
+        return;
+      }
+      if (!res.ok || !isAuthorityRole(res.data.role)) {
+        router.replace('/tabs');
+        return;
+      }
+      setPhase('allowed');
+    }
+    guard();
+    return () => { cancelled = true; };
+  }, [router]);
+
+  if (phase === 'checking') {
+    return (
+      <View testID="authority-guard-loading" style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: COLORS.white }}>
+        <ActivityIndicator size="large" color={COLORS.green700} />
+      </View>
+    );
+  }
+
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: COLORS.green900 },
+        headerTintColor: COLORS.white,
+        headerTitleStyle: { fontWeight: '700', fontSize: 17 },
+        headerShadowVisible: false,
+      }}
+    >
+      <Stack.Screen name="dashboard" options={{ title: 'Authority Portal', headerTitle: 'Authority Portal' }} />
+      <Stack.Screen name="report/[id]" options={{ title: 'Report' }} />
+    </Stack>
+  );
+}

--- a/frontend/app/authority/dashboard.tsx
+++ b/frontend/app/authority/dashboard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import {
   ActivityIndicator,
   RefreshControl,
@@ -16,6 +16,7 @@ import {
   fetchAuthorityDashboard,
   type DashboardCounts,
   type DashboardReport,
+  type DashboardResponse,
 } from '../../src/api/authority';
 import StatusFilterChips, { type FilterValue } from '../../src/components/authority/StatusFilterChips';
 import ReportListItem from '../../src/components/authority/ReportListItem';
@@ -37,7 +38,7 @@ export default function AuthorityDashboardScreen() {
       status: currentFilter === 'ALL' ? null : currentFilter,
     });
     if (res.ok) {
-      const data = res.data as { reports: DashboardReport[]; counts: DashboardCounts };
+      const data = res.data as DashboardResponse;
       setReports(data.reports);
       setCounts(data.counts);
     } else if (res.status === 401) {
@@ -48,15 +49,12 @@ export default function AuthorityDashboardScreen() {
     }
   }, [router]);
 
-  useEffect(() => {
-    setLoading(true);
-    load(filter).finally(() => setLoading(false));
-  }, [filter, load]);
-
-  // Refresh when navigating back from a resolve action.
+  // Fires on mount and on every screen focus (e.g. returning from /authority/report/[id]
+  // after a resolve), so we don't need a separate useEffect for the first load.
   useFocusEffect(
     useCallback(() => {
-      load(filter);
+      setLoading(true);
+      load(filter).finally(() => setLoading(false));
     }, [filter, load]),
   );
 

--- a/frontend/app/authority/dashboard.tsx
+++ b/frontend/app/authority/dashboard.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useFocusEffect, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../src/constants/theme';
+import { clearTokens } from '../../src/services/auth';
+import {
+  fetchAuthorityDashboard,
+  type DashboardCounts,
+  type DashboardReport,
+} from '../../src/api/authority';
+import StatusFilterChips, { type FilterValue } from '../../src/components/authority/StatusFilterChips';
+import ReportListItem from '../../src/components/authority/ReportListItem';
+
+const EMPTY_COUNTS: DashboardCounts = { verified: 0, awaitingValidation: 0, closed: 0, total: 0 };
+
+export default function AuthorityDashboardScreen() {
+  const router = useRouter();
+  const [filter, setFilter] = useState<FilterValue>('VERIFIED');
+  const [reports, setReports] = useState<DashboardReport[]>([]);
+  const [counts, setCounts] = useState<DashboardCounts>(EMPTY_COUNTS);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
+
+  const load = useCallback(async (currentFilter: FilterValue) => {
+    setErrorMsg('');
+    const res = await fetchAuthorityDashboard({
+      status: currentFilter === 'ALL' ? null : currentFilter,
+    });
+    if (res.ok) {
+      const data = res.data as { reports: DashboardReport[]; counts: DashboardCounts };
+      setReports(data.reports);
+      setCounts(data.counts);
+    } else if (res.status === 401) {
+      clearTokens();
+      router.replace('/auth/login');
+    } else {
+      setErrorMsg('Could not load reports.');
+    }
+  }, [router]);
+
+  useEffect(() => {
+    setLoading(true);
+    load(filter).finally(() => setLoading(false));
+  }, [filter, load]);
+
+  // Refresh when navigating back from a resolve action.
+  useFocusEffect(
+    useCallback(() => {
+      load(filter);
+    }, [filter, load]),
+  );
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    await load(filter);
+    setRefreshing(false);
+  }
+
+  function handleSignOut() {
+    clearTokens();
+    router.replace('/auth/login');
+  }
+
+  function openReport(report: DashboardReport) {
+    router.push(`/authority/report/${report.reportId}` as any);
+  }
+
+  return (
+    <View style={s.page}>
+      <View style={s.summaryStrip} testID="counts-strip">
+        <View style={s.summaryCell}>
+          <Text style={[s.summaryNum, { color: COLORS.green700 }]}>{counts.verified}</Text>
+          <Text style={s.summaryLabel}>Verified</Text>
+        </View>
+        <View style={s.summaryDivider} />
+        <View style={s.summaryCell}>
+          <Text style={[s.summaryNum, { color: COLORS.orange500 }]}>{counts.awaitingValidation}</Text>
+          <Text style={s.summaryLabel}>Awaiting</Text>
+        </View>
+        <View style={s.summaryDivider} />
+        <View style={s.summaryCell}>
+          <Text style={[s.summaryNum, { color: COLORS.gray500 }]}>{counts.closed}</Text>
+          <Text style={s.summaryLabel}>Closed</Text>
+        </View>
+        <TouchableOpacity onPress={handleSignOut} style={s.signOutBtn} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+          <Ionicons name="log-out-outline" size={18} color={COLORS.gray500} />
+        </TouchableOpacity>
+      </View>
+
+      <StatusFilterChips value={filter} onChange={setFilter} counts={counts} />
+
+      {loading ? (
+        <View style={s.center}><ActivityIndicator size="large" color={COLORS.green700} /></View>
+      ) : (
+        <ScrollView
+          style={s.list}
+          contentContainerStyle={s.listContent}
+          refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={COLORS.green700} />}
+        >
+          {!!errorMsg && (
+            <View style={s.errBanner} testID="dashboard-error">
+              <Ionicons name="alert-circle-outline" size={16} color={COLORS.red600} />
+              <Text style={s.errText}>{errorMsg}</Text>
+            </View>
+          )}
+
+          {reports.length === 0 ? (
+            <View style={s.empty} testID="dashboard-empty">
+              <Ionicons name="checkmark-done-outline" size={48} color={COLORS.gray300} />
+              <Text style={s.emptyTitle}>Nothing here</Text>
+              <Text style={s.emptySub}>
+                {filter === 'VERIFIED'
+                  ? 'No verified reports waiting for repair.'
+                  : filter === 'RESOLVED_AWAITING_VALIDATION'
+                  ? 'No reports awaiting citizen validation.'
+                  : filter === 'CLOSED'
+                  ? 'No closed reports yet.'
+                  : 'No reports for this filter.'}
+              </Text>
+            </View>
+          ) : (
+            reports.map((r) => (
+              <ReportListItem key={r.reportId} report={r} onPress={openReport} />
+            ))
+          )}
+        </ScrollView>
+      )}
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  page: { flex: 1, backgroundColor: COLORS.gray100 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  summaryStrip: {
+    flexDirection: 'row', alignItems: 'center',
+    backgroundColor: COLORS.white,
+    paddingVertical: 14, paddingHorizontal: 14,
+    borderBottomWidth: 1, borderBottomColor: COLORS.gray200,
+  },
+  summaryCell: { flex: 1, alignItems: 'center' },
+  summaryNum: { fontSize: 22, fontWeight: '800' },
+  summaryLabel: { fontSize: 11, color: COLORS.gray500, fontWeight: '600', marginTop: 2 },
+  summaryDivider: { width: 1, height: 28, backgroundColor: COLORS.gray200 },
+  signOutBtn: { paddingLeft: 12 },
+  list: { flex: 1 },
+  listContent: { padding: 14, paddingBottom: 32 },
+  empty: { alignItems: 'center', paddingVertical: 60, gap: 8 },
+  emptyTitle: { fontSize: 16, fontWeight: '700', color: COLORS.gray500, marginTop: 6 },
+  emptySub: { fontSize: 13, color: COLORS.gray400, textAlign: 'center', paddingHorizontal: 20 },
+  errBanner: {
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    backgroundColor: COLORS.red50, padding: 12, borderRadius: 10,
+    borderWidth: 1, borderColor: 'rgba(239,68,68,0.15)', marginBottom: 12,
+  },
+  errText: { fontSize: 13, color: COLORS.red600, fontWeight: '500', flex: 1 },
+});

--- a/frontend/app/authority/report/[id].tsx
+++ b/frontend/app/authority/report/[id].tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../../src/constants/theme';
+import { fetchObstacleDetail, type ObstacleDetail } from '../../../src/api/map';
+import ResolveModal from '../../../src/components/authority/ResolveModal';
+
+const STATUS_COLOR: Record<string, string> = {
+  VERIFIED: COLORS.green600,
+  RESOLVED_AWAITING_VALIDATION: COLORS.orange500,
+  CLOSED: COLORS.gray500,
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  VERIFIED: 'Verified',
+  RESOLVED_AWAITING_VALIDATION: 'Awaiting Validation',
+  CLOSED: 'Closed',
+};
+
+export default function AuthorityReportDetailScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const router = useRouter();
+  const [detail, setDetail] = useState<ObstacleDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [resolveOpen, setResolveOpen] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    const res = await fetchObstacleDetail(id as string);
+    setDetail(res);
+    setLoading(false);
+  }
+
+  useEffect(() => { load(); }, [id]);
+
+  if (loading) {
+    return <View style={s.center}><ActivityIndicator size="large" color={COLORS.green700} /></View>;
+  }
+
+  if (!detail) {
+    return (
+      <View style={s.center}>
+        <Text style={s.muted}>Report not found.</Text>
+      </View>
+    );
+  }
+
+  const canResolve = detail.status === 'VERIFIED';
+
+  return (
+    <View style={s.page}>
+      <ScrollView style={s.scroll} contentContainerStyle={s.content}>
+        <TouchableOpacity style={s.back} onPress={() => router.back()}>
+          <Ionicons name="arrow-back" size={20} color={COLORS.gray700} />
+          <Text style={s.backText}>Dashboard</Text>
+        </TouchableOpacity>
+
+        <Text style={s.title}>{detail.title}</Text>
+
+        <View style={s.badges}>
+          <View style={[s.badge, { backgroundColor: STATUS_COLOR[detail.status] ?? COLORS.gray400 }]}>
+            <Text style={s.badgeText}>{STATUS_LABEL[detail.status] ?? detail.status}</Text>
+          </View>
+          <View style={[s.badge, { backgroundColor: COLORS.gray500 }]}>
+            <Text style={s.badgeText}>{detail.category.replace(/_/g, ' ')}</Text>
+          </View>
+        </View>
+
+        {!!detail.description && <Text style={s.description}>{detail.description}</Text>}
+
+        <View style={s.metaRow}>
+          <Ionicons name="location-outline" size={16} color={COLORS.gray500} />
+          <Text style={s.metaText}>
+            {detail.latitude.toFixed(5)}, {detail.longitude.toFixed(5)}
+          </Text>
+        </View>
+        <View style={s.metaRow}>
+          <Ionicons name="thumbs-up-outline" size={16} color={COLORS.gray500} />
+          <Text style={s.metaText}>{detail.upvoteCount} community upvote{detail.upvoteCount === 1 ? '' : 's'}</Text>
+        </View>
+
+        {detail.photos.length > 0 && (
+          <>
+            <Text style={s.sectionLabel}>PHOTOS</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.photoRow}>
+              {detail.photos.map((p, i) => (
+                <Image key={i} source={{ uri: p.imageUrl }} style={s.photo} />
+              ))}
+            </ScrollView>
+          </>
+        )}
+
+        {detail.status === 'RESOLVED_AWAITING_VALIDATION' && (
+          <View style={s.infoBanner}>
+            <Ionicons name="time-outline" size={16} color={COLORS.orange500} />
+            <Text style={s.infoText}>Citizens are validating your repair. The report will close once enough confirmations are received.</Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {canResolve && (
+        <View style={s.cta}>
+          <TouchableOpacity
+            testID="open-resolve-modal"
+            style={s.resolveBtn}
+            onPress={() => setResolveOpen(true)}
+            activeOpacity={0.85}
+          >
+            <Ionicons name="checkmark-circle-outline" size={18} color={COLORS.white} />
+            <Text style={s.resolveBtnText}>Mark as Resolved</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      <ResolveModal
+        visible={resolveOpen}
+        reportId={detail.id}
+        reportTitle={detail.title}
+        onClose={() => setResolveOpen(false)}
+        onResolved={() => {
+          setResolveOpen(false);
+          load();
+        }}
+      />
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  page: { flex: 1, backgroundColor: COLORS.gray100 },
+  scroll: { flex: 1 },
+  content: { padding: 18, paddingBottom: 96 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: COLORS.gray100 },
+  muted: { fontSize: 14, color: COLORS.gray500 },
+  back: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 14 },
+  backText: { fontSize: 14, color: COLORS.gray700 },
+  title: { fontSize: 20, fontWeight: '800', color: COLORS.gray900, marginBottom: 10 },
+  badges: { flexDirection: 'row', gap: 6, flexWrap: 'wrap', marginBottom: 14 },
+  badge: { borderRadius: 6, paddingHorizontal: 8, paddingVertical: 3 },
+  badgeText: { color: COLORS.white, fontSize: 11, fontWeight: '700' },
+  description: { fontSize: 14, color: COLORS.gray700, lineHeight: 20, marginBottom: 14 },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 },
+  metaText: { fontSize: 13, color: COLORS.gray600 },
+  sectionLabel: { fontSize: 11, fontWeight: '700', color: COLORS.gray600, letterSpacing: 0.5, marginTop: 14, marginBottom: 8 },
+  photoRow: { marginBottom: 8 },
+  photo: { width: 200, height: 150, borderRadius: 8, marginRight: 8, backgroundColor: COLORS.gray200 },
+  infoBanner: {
+    flexDirection: 'row', alignItems: 'flex-start', gap: 8,
+    backgroundColor: COLORS.orange100, padding: 12, borderRadius: 10, marginTop: 14,
+  },
+  infoText: { flex: 1, fontSize: 12, color: COLORS.orange500, lineHeight: 18 },
+  cta: {
+    position: 'absolute', left: 0, right: 0, bottom: 0,
+    padding: 14, backgroundColor: COLORS.white,
+    borderTopWidth: 1, borderTopColor: COLORS.gray200,
+  },
+  resolveBtn: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
+    backgroundColor: COLORS.green700, paddingVertical: 14, borderRadius: 12,
+  },
+  resolveBtnText: { color: COLORS.white, fontSize: 15, fontWeight: '700' },
+});

--- a/frontend/app/authority/report/[id].tsx
+++ b/frontend/app/authority/report/[id].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -33,14 +33,14 @@ export default function AuthorityReportDetailScreen() {
   const [loading, setLoading] = useState(true);
   const [resolveOpen, setResolveOpen] = useState(false);
 
-  async function load() {
+  const load = useCallback(async () => {
     setLoading(true);
     const res = await fetchObstacleDetail(id as string);
     setDetail(res);
     setLoading(false);
-  }
+  }, [id]);
 
-  useEffect(() => { load(); }, [id]);
+  useEffect(() => { load(); }, [load]);
 
   if (loading) {
     return <View style={s.center}><ActivityIndicator size="large" color={COLORS.green700} /></View>;

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,6 +1,31 @@
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import { Redirect } from 'expo-router';
-import { isLoggedIn } from '../src/services/auth';
+import { COLORS } from '../src/constants/theme';
+import { getMe, isLoggedIn, landingRouteForRole } from '../src/services/auth';
 
 export default function Index() {
-  return <Redirect href={isLoggedIn() ? '/tabs' : '/auth/login'} />;
+  const [target, setTarget] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isLoggedIn()) {
+      setTarget('/auth/login');
+      return;
+    }
+    let cancelled = false;
+    getMe().then((res) => {
+      if (cancelled) return;
+      setTarget(res.ok ? landingRouteForRole(res.data.role) : '/tabs');
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (target === null) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: COLORS.white }}>
+        <ActivityIndicator size="large" color={COLORS.green700} />
+      </View>
+    );
+  }
+  return <Redirect href={target as any} />;
 }

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -110,7 +110,9 @@ export default function ReportDetailScreen() {
         reporterId={detail.reporterId}
         userUpvoted={detail.userUpvoted}
         currentUserId={currentUserId}
-        onResolved={() => setDetail((d) => (d ? { ...d, status: 'CLOSED' } : d))}
+        onResolved={(newStatus) =>
+          setDetail((d) => (d ? { ...d, status: newStatus as typeof d.status } : d))
+        }
       />
     </ScrollView>
   );

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -109,9 +109,20 @@ export default function ReportDetailScreen() {
         status={detail.status}
         reporterId={detail.reporterId}
         userUpvoted={detail.userUpvoted}
+        userConfirmed={detail.userConfirmed}
+        confirmationCount={detail.confirmationCount}
         currentUserId={currentUserId}
-        onResolved={(newStatus) =>
-          setDetail((d) => (d ? { ...d, status: newStatus as typeof d.status } : d))
+        onResolved={(newStatus, newCount) =>
+          setDetail((d) =>
+            d
+              ? {
+                  ...d,
+                  status: newStatus as typeof d.status,
+                  userConfirmed: true,
+                  confirmationCount: newCount,
+                }
+              : d,
+          )
         }
       />
     </ScrollView>

--- a/frontend/src/__tests__/AuthorityDashboard.test.tsx
+++ b/frontend/src/__tests__/AuthorityDashboard.test.tsx
@@ -13,11 +13,13 @@ jest.mock('@expo/vector-icons', () => ({
 const mockRouter = { replace: jest.fn(), push: jest.fn() };
 jest.mock('expo-router', () => ({
   useRouter: () => mockRouter,
+  // Mirror the real useFocusEffect: re-fire whenever the callback identity
+  // changes (the component already wraps it in useCallback with [filter, load]).
   useFocusEffect: (cb: () => void) => {
     const React = require('react');
     React.useEffect(() => {
       cb();
-    }, []);
+    }, [cb]);
   },
 }));
 

--- a/frontend/src/__tests__/AuthorityDashboard.test.tsx
+++ b/frontend/src/__tests__/AuthorityDashboard.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import AuthorityDashboardScreen from '../../app/authority/dashboard';
+import * as authorityApi from '../api/authority';
+import * as auth from '../services/auth';
+
+jest.mock('../api/authority');
+jest.mock('../services/auth');
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+const mockRouter = { replace: jest.fn(), push: jest.fn() };
+jest.mock('expo-router', () => ({
+  useRouter: () => mockRouter,
+  useFocusEffect: (cb: () => void) => {
+    const React = require('react');
+    React.useEffect(() => {
+      cb();
+    }, []);
+  },
+}));
+
+const mockFetch = authorityApi.fetchAuthorityDashboard as jest.MockedFunction<
+  typeof authorityApi.fetchAuthorityDashboard
+>;
+const mockClearTokens = auth.clearTokens as jest.MockedFunction<typeof auth.clearTokens>;
+
+function makeReport(overrides: Partial<authorityApi.DashboardReport> = {}): authorityApi.DashboardReport {
+  return {
+    reportId: 'r1',
+    title: 'Broken Ramp',
+    description: 'Concrete crumbling at corner.',
+    category: 'BROKEN_RAMP',
+    context: 'OUTDOOR',
+    status: 'VERIFIED',
+    location: { lat: 41.0837, lng: 29.051 },
+    upvoteCount: 4,
+    thumbnailUrl: null,
+    reporter: { userId: 'u1', fullName: 'Aylin Y.' },
+    createdAt: '2026-04-30T10:00:00Z',
+    updatedAt: '2026-04-30T10:00:00Z',
+    ...overrides,
+  };
+}
+
+const BASE_RESPONSE: authorityApi.DashboardResponse = {
+  reports: [makeReport()],
+  pagination: { page: 1, size: 20, totalItems: 1 },
+  counts: { verified: 5, awaitingValidation: 2, closed: 7, total: 14 },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetch.mockResolvedValue({ ok: true, status: 200, data: BASE_RESPONSE });
+});
+
+it('renders the counts strip from the API response', async () => {
+  const { findByTestId, findAllByText } = render(<AuthorityDashboardScreen />);
+  const strip = await findByTestId('counts-strip');
+  expect(strip).toBeTruthy();
+  // Both the strip and the corresponding filter chip render the same number,
+  // so we look at the strip's labels and each numeric appears at least once.
+  const fives = await findAllByText('5');
+  const twos = await findAllByText('2');
+  const sevens = await findAllByText('7');
+  expect(fives.length).toBeGreaterThan(0);
+  expect(twos.length).toBeGreaterThan(0);
+  expect(sevens.length).toBeGreaterThan(0);
+});
+
+it('renders a row per report returned by the dashboard endpoint', async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    data: {
+      ...BASE_RESPONSE,
+      reports: [makeReport({ reportId: 'a' }), makeReport({ reportId: 'b' })],
+    },
+  });
+  const { findByTestId } = render(<AuthorityDashboardScreen />);
+  expect(await findByTestId('report-card-a')).toBeTruthy();
+  expect(await findByTestId('report-card-b')).toBeTruthy();
+});
+
+it('shows the empty state when there are no reports for the current filter', async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    data: { ...BASE_RESPONSE, reports: [] },
+  });
+  const { findByTestId } = render(<AuthorityDashboardScreen />);
+  expect(await findByTestId('dashboard-empty')).toBeTruthy();
+});
+
+it('defaults to the VERIFIED filter on first load', async () => {
+  render(<AuthorityDashboardScreen />);
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledWith({ status: 'VERIFIED' });
+  });
+});
+
+it('refetches with the new status when a filter chip is tapped', async () => {
+  const { getByTestId } = render(<AuthorityDashboardScreen />);
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+  await act(async () => {
+    fireEvent.press(getByTestId('filter-RESOLVED_AWAITING_VALIDATION'));
+  });
+
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledWith({ status: 'RESOLVED_AWAITING_VALIDATION' });
+  });
+});
+
+it('passes status: null to the API when the All chip is tapped', async () => {
+  const { getByTestId } = render(<AuthorityDashboardScreen />);
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+
+  await act(async () => {
+    fireEvent.press(getByTestId('filter-ALL'));
+  });
+
+  await waitFor(() => {
+    expect(mockFetch).toHaveBeenCalledWith({ status: null });
+  });
+});
+
+it('opens the report detail screen on row tap', async () => {
+  const { findByTestId } = render(<AuthorityDashboardScreen />);
+  const card = await findByTestId('report-card-r1');
+
+  await act(async () => {
+    fireEvent.press(card);
+  });
+
+  expect(mockRouter.push).toHaveBeenCalledWith('/authority/report/r1');
+});
+
+it('shows an error banner if the dashboard endpoint fails', async () => {
+  mockFetch.mockResolvedValue({ ok: false, status: 500, data: { detail: 'boom' } });
+  const { findByTestId } = render(<AuthorityDashboardScreen />);
+  expect(await findByTestId('dashboard-error')).toBeTruthy();
+});
+
+it('redirects to login when the dashboard returns 401', async () => {
+  mockFetch.mockResolvedValue({ ok: false, status: 401, data: { detail: 'unauthorized' } });
+  render(<AuthorityDashboardScreen />);
+  await waitFor(() => {
+    expect(mockClearTokens).toHaveBeenCalled();
+    expect(mockRouter.replace).toHaveBeenCalledWith('/auth/login');
+  });
+});

--- a/frontend/src/__tests__/AuthorityLayout.test.tsx
+++ b/frontend/src/__tests__/AuthorityLayout.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import AuthorityLayout from '../../app/authority/_layout';
+import * as auth from '../services/auth';
+
+jest.mock('../services/auth');
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+
+const mockRouter = { replace: jest.fn(), push: jest.fn() };
+jest.mock('expo-router', () => ({
+  useRouter: () => mockRouter,
+  Stack: Object.assign(
+    ({ children }: any) => children ?? null,
+    { Screen: () => null },
+  ),
+}));
+
+const mockIsLoggedIn = auth.isLoggedIn as jest.MockedFunction<typeof auth.isLoggedIn>;
+const mockGetMe = auth.getMe as jest.MockedFunction<typeof auth.getMe>;
+const mockClearTokens = auth.clearTokens as jest.MockedFunction<typeof auth.clearTokens>;
+const mockIsAuthorityRole = auth.isAuthorityRole as jest.MockedFunction<typeof auth.isAuthorityRole>;
+
+const ME = (role: string) => ({
+  ok: true as const,
+  status: 200,
+  data: {
+    userId: 'u1', email: 'a@b.com', fullName: 'A', status: 'ACTIVE',
+    trustScore: 0, role, createdAt: '2026-01-01T00:00:00Z',
+  },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsAuthorityRole.mockImplementation((r) => r === 'INFRASTRUCTURE_AUTHORITY');
+});
+
+it('redirects to /auth/login when not logged in', async () => {
+  mockIsLoggedIn.mockReturnValue(false);
+  render(<AuthorityLayout />);
+  await waitFor(() => expect(mockRouter.replace).toHaveBeenCalledWith('/auth/login'));
+});
+
+it('redirects a logged-in non-authority user to /tabs', async () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  mockGetMe.mockResolvedValue(ME('REGISTERED_USER'));
+  render(<AuthorityLayout />);
+  await waitFor(() => expect(mockRouter.replace).toHaveBeenCalledWith('/tabs'));
+});
+
+it('clears tokens and redirects to login when getMe returns 401', async () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  mockGetMe.mockResolvedValue({ ok: false as const, status: 401, data: {} as any });
+  render(<AuthorityLayout />);
+  await waitFor(() => {
+    expect(mockClearTokens).toHaveBeenCalled();
+    expect(mockRouter.replace).toHaveBeenCalledWith('/auth/login');
+  });
+});
+
+it('does NOT redirect when the user has the infrastructure authority role', async () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  mockGetMe.mockResolvedValue(ME('INFRASTRUCTURE_AUTHORITY'));
+  render(<AuthorityLayout />);
+  await waitFor(() => expect(mockGetMe).toHaveBeenCalled());
+  // No redirect call should occur for an authority user.
+  expect(mockRouter.replace).not.toHaveBeenCalled();
+});
+
+it('shows a loading indicator while the role check is pending', async () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  // Never resolves during the test — the guard stays in checking phase.
+  mockGetMe.mockImplementation(() => new Promise(() => {}));
+  const { getByTestId } = render(<AuthorityLayout />);
+  expect(getByTestId('authority-guard-loading')).toBeTruthy();
+});

--- a/frontend/src/__tests__/ConfirmResolutionButton.test.tsx
+++ b/frontend/src/__tests__/ConfirmResolutionButton.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { Alert } from 'react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import ConfirmResolutionButton from '../components/reports/ConfirmResolutionButton';
+import * as interactionsApi from '../api/interactions';
+
+jest.mock('../api/interactions');
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+
+const mockConfirm = interactionsApi.confirmResolution as jest.MockedFunction<
+  typeof interactionsApi.confirmResolution
+>;
+
+const BASE_PROPS = {
+  reportId: 'r1',
+  status: 'RESOLVED_AWAITING_VALIDATION',
+  reporterId: 'reporter-1',
+  userUpvoted: false,
+  userConfirmed: false,
+  confirmationCount: 1,
+  currentUserId: 'reporter-1',
+  onResolved: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConfirm.mockResolvedValue({
+    ok: true,
+    data: { reportId: 'r1', status: 'RESOLVED_AWAITING_VALIDATION', confirmationCount: 2 },
+  });
+});
+
+// ── Eligibility ─────────────────────────────────────────────────────────────
+
+it('renders nothing when status is not RESOLVED_AWAITING_VALIDATION', () => {
+  const { queryByTestId } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} status="VERIFIED" />,
+  );
+  expect(queryByTestId('confirm-resolution-button')).toBeNull();
+  expect(queryByTestId('confirm-resolution-recorded')).toBeNull();
+});
+
+it('renders nothing for guests (no currentUserId)', () => {
+  const { queryByTestId } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} currentUserId="" />,
+  );
+  expect(queryByTestId('confirm-resolution-button')).toBeNull();
+});
+
+it('renders nothing when the user is neither reporter nor upvoter', () => {
+  const { queryByTestId } = render(
+    <ConfirmResolutionButton
+      {...BASE_PROPS}
+      currentUserId="some-other-user"
+      userUpvoted={false}
+    />,
+  );
+  expect(queryByTestId('confirm-resolution-button')).toBeNull();
+});
+
+it('renders the button for the reporter', () => {
+  const { getByTestId } = render(<ConfirmResolutionButton {...BASE_PROPS} />);
+  expect(getByTestId('confirm-resolution-button')).toBeTruthy();
+});
+
+it('renders the button for an upvoter', () => {
+  const { getByTestId } = render(
+    <ConfirmResolutionButton
+      {...BASE_PROPS}
+      currentUserId="some-other-user"
+      userUpvoted
+    />,
+  );
+  expect(getByTestId('confirm-resolution-button')).toBeTruthy();
+});
+
+// ── userConfirmed pill ──────────────────────────────────────────────────────
+
+it('shows the recorded pill instead of the button when userConfirmed is true', () => {
+  const { getByTestId, queryByTestId } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} userConfirmed />,
+  );
+  expect(getByTestId('confirm-resolution-recorded')).toBeTruthy();
+  expect(queryByTestId('confirm-resolution-button')).toBeNull();
+});
+
+// ── Click behavior ──────────────────────────────────────────────────────────
+
+it('calls confirmResolution and forwards server status + count to onResolved', async () => {
+  const onResolved = jest.fn();
+  mockConfirm.mockResolvedValue({
+    ok: true,
+    data: { reportId: 'r1', status: 'CLOSED', confirmationCount: 3 },
+  });
+
+  const { getByTestId } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} onResolved={onResolved} />,
+  );
+  await act(async () => {
+    fireEvent.press(getByTestId('confirm-resolution-button'));
+  });
+
+  expect(mockConfirm).toHaveBeenCalledWith('r1');
+  expect(onResolved).toHaveBeenCalledWith('CLOSED', 3);
+});
+
+it('passes the awaiting status through when the threshold is not yet reached', async () => {
+  const onResolved = jest.fn();
+  mockConfirm.mockResolvedValue({
+    ok: true,
+    data: { reportId: 'r1', status: 'RESOLVED_AWAITING_VALIDATION', confirmationCount: 2 },
+  });
+
+  const { getByTestId } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} onResolved={onResolved} />,
+  );
+  await act(async () => {
+    fireEvent.press(getByTestId('confirm-resolution-button'));
+  });
+
+  expect(onResolved).toHaveBeenCalledWith('RESOLVED_AWAITING_VALIDATION', 2);
+});
+
+it('shows an alert and does not call onResolved on API failure', async () => {
+  const onResolved = jest.fn();
+  const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+  mockConfirm.mockResolvedValue({
+    ok: false,
+    data: { reportId: 'r1', status: '', confirmationCount: 0 },
+  });
+
+  const { getByTestId } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} onResolved={onResolved} />,
+  );
+  await act(async () => {
+    fireEvent.press(getByTestId('confirm-resolution-button'));
+  });
+
+  expect(alertSpy).toHaveBeenCalled();
+  expect(onResolved).not.toHaveBeenCalled();
+  alertSpy.mockRestore();
+});

--- a/frontend/src/__tests__/ResolveModal.test.tsx
+++ b/frontend/src/__tests__/ResolveModal.test.tsx
@@ -132,3 +132,79 @@ it('clears the photo when remove is tapped', async () => {
   });
   expect(getByTestId('photo-count').props.children).toBe('photos:0');
 });
+
+it('surfaces a 403 error when the authority lacks permission', async () => {
+  mockResolveReport.mockResolvedValue({
+    ok: false, status: 403, data: { detail: 'forbidden' },
+  });
+  const { getByTestId, getByText, onResolved } = setup();
+
+  await act(async () => { fireEvent.press(getByTestId('mock-add-photo')); });
+  await act(async () => { fireEvent.press(getByTestId('resolve-submit')); });
+
+  expect(getByText('You do not have permission to resolve this report.')).toBeTruthy();
+  expect(onResolved).not.toHaveBeenCalled();
+});
+
+it('surfaces a 404 error when the report no longer exists', async () => {
+  mockResolveReport.mockResolvedValue({
+    ok: false, status: 404, data: { detail: 'not found' },
+  });
+  const { getByTestId, getByText, onResolved } = setup();
+
+  await act(async () => { fireEvent.press(getByTestId('mock-add-photo')); });
+  await act(async () => { fireEvent.press(getByTestId('resolve-submit')); });
+
+  expect(getByText('Report not found.')).toBeTruthy();
+  expect(onResolved).not.toHaveBeenCalled();
+});
+
+it('does not call the API when the user cancels', async () => {
+  const { getByText, onClose } = setup();
+
+  await act(async () => { fireEvent.press(getByText('Cancel')); });
+
+  expect(mockResolveReport).not.toHaveBeenCalled();
+  expect(onClose).toHaveBeenCalled();
+});
+
+it('only calls the API once even if submit is pressed twice quickly', async () => {
+  let resolveSubmit: (v: any) => void = () => {};
+  mockResolveReport.mockImplementation(
+    () => new Promise((r) => { resolveSubmit = r; }),
+  );
+  const { getByTestId } = setup();
+
+  await act(async () => { fireEvent.press(getByTestId('mock-add-photo')); });
+  await act(async () => {
+    fireEvent.press(getByTestId('resolve-submit'));
+    fireEvent.press(getByTestId('resolve-submit'));
+  });
+
+  expect(mockResolveReport).toHaveBeenCalledTimes(1);
+
+  // Resolve the in-flight request so the test exits cleanly.
+  await act(async () => {
+    resolveSubmit({
+      ok: true, status: 200,
+      data: {
+        reportId: 'r1', status: 'RESOLVED_AWAITING_VALIDATION',
+        repairPhotoUrl: 'https://cdn/r1.jpg',
+        updatedAt: '2026-05-08T12:00:00Z',
+      },
+    });
+  });
+});
+
+it('omits repairNotes from the payload when notes are blank', async () => {
+  const { getByTestId } = setup();
+
+  await act(async () => { fireEvent.press(getByTestId('mock-add-photo')); });
+  // notes intentionally left empty
+  await act(async () => { fireEvent.press(getByTestId('resolve-submit')); });
+
+  expect(mockResolveReport).toHaveBeenCalledWith('r1', {
+    repairPhoto: 'BASE64DATA',
+    repairNotes: undefined,
+  });
+});

--- a/frontend/src/__tests__/ResolveModal.test.tsx
+++ b/frontend/src/__tests__/ResolveModal.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import ResolveModal from '../components/authority/ResolveModal';
+import * as authorityApi from '../api/authority';
+
+jest.mock('../api/authority');
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: () => null,
+}));
+
+// PhotoPicker uses expo-image-picker which we don't want to invoke in tests.
+// The mock exposes onAdd/onRemove so we can simulate selecting a photo.
+jest.mock('../components/reports/PhotoPicker', () => {
+  const { Text, TouchableOpacity, View } = require('react-native');
+  function MockPhotoPicker({ photos, onAdd, onRemove, error }: any) {
+    return (
+      <View>
+        <Text testID="photo-count">{`photos:${photos.length}`}</Text>
+        <TouchableOpacity
+          testID="mock-add-photo"
+          onPress={() => onAdd({ uri: 'mock://photo.jpg', b64: 'BASE64DATA' })}
+        >
+          <Text>add</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="mock-remove-photo" onPress={() => onRemove(0)}>
+          <Text>remove</Text>
+        </TouchableOpacity>
+        {!!error && <Text testID="photo-error-text">{error}</Text>}
+      </View>
+    );
+  }
+  return { __esModule: true, default: MockPhotoPicker };
+});
+
+const mockResolveReport = authorityApi.resolveReport as jest.MockedFunction<
+  typeof authorityApi.resolveReport
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockResolveReport.mockResolvedValue({
+    ok: true,
+    status: 200,
+    data: {
+      reportId: 'r1',
+      status: 'RESOLVED_AWAITING_VALIDATION',
+      repairPhotoUrl: 'https://cdn/r1.jpg',
+      updatedAt: '2026-05-08T12:00:00Z',
+    },
+  });
+});
+
+function setup(props: Partial<React.ComponentProps<typeof ResolveModal>> = {}) {
+  const onClose = jest.fn();
+  const onResolved = jest.fn();
+  const utils = render(
+    <ResolveModal
+      visible
+      reportId="r1"
+      reportTitle="Broken Ramp at Atatürk Cd."
+      onClose={onClose}
+      onResolved={onResolved}
+      {...props}
+    />,
+  );
+  return { ...utils, onClose, onResolved };
+}
+
+it('shows a validation error and does not call the API when no photo is attached', async () => {
+  const { getByTestId, onResolved } = setup();
+
+  await act(async () => {
+    fireEvent.press(getByTestId('resolve-submit'));
+  });
+
+  expect(getByTestId('photo-error-text').props.children).toBe('A post-repair photo is required.');
+  expect(mockResolveReport).not.toHaveBeenCalled();
+  expect(onResolved).not.toHaveBeenCalled();
+});
+
+it('calls resolveReport with the base64 photo and notes when valid', async () => {
+  const { getByTestId, onResolved } = setup();
+
+  await act(async () => {
+    fireEvent.press(getByTestId('mock-add-photo'));
+  });
+  fireEvent.changeText(getByTestId('resolve-notes'), 'Patched the ramp.');
+
+  await act(async () => {
+    fireEvent.press(getByTestId('resolve-submit'));
+  });
+
+  await waitFor(() => {
+    expect(mockResolveReport).toHaveBeenCalledWith('r1', {
+      repairPhoto: 'BASE64DATA',
+      repairNotes: 'Patched the ramp.',
+    });
+  });
+  expect(onResolved).toHaveBeenCalled();
+});
+
+it('keeps the modal open and surfaces a 409 conflict error', async () => {
+  mockResolveReport.mockResolvedValue({
+    ok: false,
+    status: 409,
+    data: { detail: 'already resolved' },
+  });
+  const { getByTestId, getByText, onResolved } = setup();
+
+  await act(async () => {
+    fireEvent.press(getByTestId('mock-add-photo'));
+  });
+
+  await act(async () => {
+    fireEvent.press(getByTestId('resolve-submit'));
+  });
+
+  await waitFor(() => expect(getByText('Report is already resolved.')).toBeTruthy());
+  expect(onResolved).not.toHaveBeenCalled();
+});
+
+it('clears the photo when remove is tapped', async () => {
+  const { getByTestId } = setup();
+
+  await act(async () => {
+    fireEvent.press(getByTestId('mock-add-photo'));
+  });
+  expect(getByTestId('photo-count').props.children).toBe('photos:1');
+
+  await act(async () => {
+    fireEvent.press(getByTestId('mock-remove-photo'));
+  });
+  expect(getByTestId('photo-count').props.children).toBe('photos:0');
+});

--- a/frontend/src/__tests__/RootIndex.test.tsx
+++ b/frontend/src/__tests__/RootIndex.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import Index from '../../app/index';
+import * as auth from '../services/auth';
+
+jest.mock('../services/auth');
+
+// Capture the href passed to <Redirect> so we can assert on it.
+// Jest's mock factory only allows out-of-scope vars whose names start with "mock".
+const mockRedirect = jest.fn();
+jest.mock('expo-router', () => ({
+  Redirect: (props: { href: string }) => {
+    mockRedirect(props.href);
+    return null;
+  },
+}));
+
+const mockIsLoggedIn = auth.isLoggedIn as jest.MockedFunction<typeof auth.isLoggedIn>;
+const mockGetMe = auth.getMe as jest.MockedFunction<typeof auth.getMe>;
+const mockLandingRouteForRole = auth.landingRouteForRole as jest.MockedFunction<
+  typeof auth.landingRouteForRole
+>;
+
+const ME = (role: string) => ({
+  ok: true as const,
+  status: 200,
+  data: {
+    userId: 'u1', email: 'a@b.com', fullName: 'A', status: 'ACTIVE',
+    trustScore: 0, role, createdAt: '2026-01-01T00:00:00Z',
+  },
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockLandingRouteForRole.mockImplementation((r) =>
+    r === 'INFRASTRUCTURE_AUTHORITY' ? '/authority/dashboard' : '/tabs',
+  );
+});
+
+it('redirects guests to /auth/login', async () => {
+  mockIsLoggedIn.mockReturnValue(false);
+  render(<Index />);
+  await waitFor(() => expect(mockRedirect).toHaveBeenCalledWith('/auth/login'));
+});
+
+it('redirects an authority user to /authority/dashboard', async () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  mockGetMe.mockResolvedValue(ME('INFRASTRUCTURE_AUTHORITY'));
+  render(<Index />);
+  await waitFor(() => expect(mockRedirect).toHaveBeenCalledWith('/authority/dashboard'));
+});
+
+it('redirects a citizen user to /tabs', async () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  mockGetMe.mockResolvedValue(ME('REGISTERED_USER'));
+  render(<Index />);
+  await waitFor(() => expect(mockRedirect).toHaveBeenCalledWith('/tabs'));
+});
+
+it('falls back to /tabs when getMe fails', async () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  mockGetMe.mockResolvedValue({ ok: false as const, status: 500, data: {} as any });
+  render(<Index />);
+  await waitFor(() => expect(mockRedirect).toHaveBeenCalledWith('/tabs'));
+});
+
+it('shows a spinner before the role check resolves', () => {
+  mockIsLoggedIn.mockReturnValue(true);
+  // Promise that never resolves: keeps the component in the pending phase.
+  mockGetMe.mockImplementation(() => new Promise(() => {}));
+  const { UNSAFE_root } = render(<Index />);
+  // No redirect should have fired yet.
+  expect(mockRedirect).not.toHaveBeenCalled();
+  // ActivityIndicator is rendered (no testID, but we can assert it exists).
+  expect(UNSAFE_root).toBeTruthy();
+});

--- a/frontend/src/api/authority.ts
+++ b/frontend/src/api/authority.ts
@@ -1,0 +1,94 @@
+import { API_BASE } from '../constants/theme';
+import { getAccessToken } from '../services/auth';
+
+export type DashboardStatus =
+  | 'VERIFIED'
+  | 'RESOLVED_AWAITING_VALIDATION'
+  | 'CLOSED';
+
+export interface DashboardReport {
+  reportId: string;
+  title: string;
+  description: string;
+  category: string;
+  context: 'OUTDOOR' | 'INDOOR';
+  status: DashboardStatus;
+  location: { lat: number; lng: number };
+  upvoteCount: number;
+  thumbnailUrl: string | null;
+  reporter: { userId: string; fullName: string };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface DashboardCounts {
+  verified: number;
+  awaitingValidation: number;
+  closed: number;
+  total: number;
+}
+
+export interface DashboardResponse {
+  reports: DashboardReport[];
+  pagination: { page: number; size: number; totalItems: number };
+  counts: DashboardCounts;
+}
+
+function authHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' };
+  const t = getAccessToken();
+  if (t) h['Authorization'] = `Bearer ${t}`;
+  return h;
+}
+
+export async function fetchAuthorityDashboard(opts: {
+  status?: DashboardStatus | null;
+  page?: number;
+  size?: number;
+} = {}): Promise<{ ok: boolean; status: number; data: DashboardResponse | { detail?: string } }> {
+  const params = new URLSearchParams();
+  if (opts.status) params.set('status', opts.status);
+  if (opts.page) params.set('page', String(opts.page));
+  if (opts.size) params.set('size', String(opts.size));
+  const qs = params.toString();
+  const url = `${API_BASE}/api/authority/dashboard${qs ? `?${qs}` : ''}`;
+  try {
+    const res = await fetch(url, { headers: authHeaders() });
+    const data = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, data };
+  } catch {
+    return { ok: false, status: 0, data: { detail: 'Network error.' } };
+  }
+}
+
+export interface ResolveReportPayload {
+  repairPhoto: string;
+  repairNotes?: string;
+}
+
+export interface ResolveReportResponse {
+  reportId: string;
+  status: string;
+  repairPhotoUrl: string;
+  updatedAt: string;
+}
+
+export async function resolveReport(
+  reportId: string,
+  payload: ResolveReportPayload,
+): Promise<{ ok: boolean; status: number; data: ResolveReportResponse | { detail?: string } }> {
+  try {
+    const res = await fetch(
+      `${API_BASE}/api/authority/reports/${reportId}/resolve`,
+      {
+        method: 'PATCH',
+        headers: authHeaders(),
+        body: JSON.stringify(payload),
+      },
+    );
+    const data = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, data };
+  } catch {
+    return { ok: false, status: 0, data: { detail: 'Network error.' } };
+  }
+}

--- a/frontend/src/api/interactions.ts
+++ b/frontend/src/api/interactions.ts
@@ -46,17 +46,26 @@ export async function postFlag(
   }
 }
 
+export interface ConfirmResolutionResponse {
+  reportId: string;
+  status: string;
+  confirmationCount: number;
+}
+
 export async function confirmResolution(
   reportId: string,
-): Promise<{ ok: boolean; data: { status: string } }> {
+): Promise<{ ok: boolean; data: ConfirmResolutionResponse }> {
   try {
     const res = await fetch(`${API_BASE}/api/reports/${reportId}/confirm-resolution/`, {
       method: 'POST',
       headers: authHeaders(),
     });
-    const data = await res.json().catch(() => ({}));
-    return { ok: res.ok, data };
+    const data = await res.json().catch(() => ({} as ConfirmResolutionResponse));
+    return { ok: res.ok, data: data as ConfirmResolutionResponse };
   } catch {
-    return { ok: false, data: { status: '' } };
+    return {
+      ok: false,
+      data: { reportId, status: '', confirmationCount: 0 },
+    };
   }
 }

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -21,8 +21,10 @@ export interface ObstacleDetail extends Obstacle {
   photos: PhotoItem[];
   upvoteCount: number;
   flagCount: number;
+  confirmationCount: number;
   userUpvoted: boolean;
   userFlagged: boolean;
+  userConfirmed: boolean;
   reporterId: string;
 }
 
@@ -109,8 +111,10 @@ export async function fetchObstacleDetail(id: string): Promise<ObstacleDetail | 
       })),
       upvoteCount: raw.upvoteCount ?? 0,
       flagCount: raw.flagCount ?? 0,
+      confirmationCount: raw.confirmationCount ?? 0,
       userUpvoted: raw.userUpvoted ?? false,
       userFlagged: raw.userFlagged ?? false,
+      userConfirmed: raw.userConfirmed ?? false,
       reporterId: raw.reporterId ?? '',
     };
   } catch {

--- a/frontend/src/components/authority/ReportListItem.tsx
+++ b/frontend/src/components/authority/ReportListItem.tsx
@@ -1,0 +1,78 @@
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../constants/theme';
+import type { DashboardReport } from '../../api/authority';
+
+const STATUS_COLOR: Record<string, string> = {
+  VERIFIED: COLORS.green600,
+  RESOLVED_AWAITING_VALIDATION: COLORS.orange500,
+  CLOSED: COLORS.gray500,
+};
+
+const STATUS_LABEL: Record<string, string> = {
+  VERIFIED: 'Verified',
+  RESOLVED_AWAITING_VALIDATION: 'Awaiting',
+  CLOSED: 'Closed',
+};
+
+interface Props {
+  report: DashboardReport;
+  onPress: (report: DashboardReport) => void;
+}
+
+export default function ReportListItem({ report, onPress }: Props) {
+  return (
+    <TouchableOpacity
+      testID={`report-card-${report.reportId}`}
+      style={s.row}
+      onPress={() => onPress(report)}
+      activeOpacity={0.78}
+    >
+      <View style={s.thumbWrap}>
+        {report.thumbnailUrl ? (
+          <Image source={{ uri: report.thumbnailUrl }} style={s.thumb} />
+        ) : (
+          <View style={[s.thumb, s.thumbEmpty]}>
+            <Ionicons name="image-outline" size={20} color={COLORS.gray400} />
+          </View>
+        )}
+      </View>
+      <View style={s.body}>
+        <Text style={s.title} numberOfLines={1}>{report.title}</Text>
+        <Text style={s.desc} numberOfLines={2}>
+          {report.description || report.category.replace(/_/g, ' ')}
+        </Text>
+        <View style={s.metaRow}>
+          <View style={[s.statusBadge, { backgroundColor: STATUS_COLOR[report.status] ?? COLORS.gray400 }]}>
+            <Text style={s.statusText}>{STATUS_LABEL[report.status] ?? report.status}</Text>
+          </View>
+          <View style={s.upvotes}>
+            <Ionicons name="arrow-up" size={11} color={COLORS.gray500} />
+            <Text style={s.upvoteText}>{report.upvoteCount}</Text>
+          </View>
+        </View>
+      </View>
+      <Ionicons name="chevron-forward" size={18} color={COLORS.gray300} />
+    </TouchableOpacity>
+  );
+}
+
+const s = StyleSheet.create({
+  row: {
+    flexDirection: 'row', alignItems: 'center', gap: 12,
+    backgroundColor: COLORS.white, padding: 12,
+    borderRadius: 12, marginBottom: 8,
+    borderWidth: 1, borderColor: COLORS.gray200,
+  },
+  thumbWrap: { width: 64, height: 64, borderRadius: 10, overflow: 'hidden' },
+  thumb: { width: 64, height: 64, backgroundColor: COLORS.gray100 },
+  thumbEmpty: { alignItems: 'center', justifyContent: 'center' },
+  body: { flex: 1, minWidth: 0 },
+  title: { fontSize: 14, fontWeight: '700', color: COLORS.gray900 },
+  desc: { fontSize: 12, color: COLORS.gray500, marginTop: 2, lineHeight: 16 },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginTop: 6 },
+  statusBadge: { paddingHorizontal: 8, paddingVertical: 2, borderRadius: 100 },
+  statusText: { color: COLORS.white, fontSize: 10, fontWeight: '700' },
+  upvotes: { flexDirection: 'row', alignItems: 'center', gap: 3 },
+  upvoteText: { fontSize: 11, color: COLORS.gray500, fontWeight: '600' },
+});

--- a/frontend/src/components/authority/ResolveModal.tsx
+++ b/frontend/src/components/authority/ResolveModal.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Modal,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../constants/theme';
+import PhotoPicker, { type PhotoEntry } from '../reports/PhotoPicker';
+import { resolveReport } from '../../api/authority';
+
+interface Props {
+  visible: boolean;
+  reportId: string;
+  reportTitle: string;
+  onClose: () => void;
+  onResolved: () => void;
+}
+
+export default function ResolveModal({ visible, reportId, reportTitle, onClose, onResolved }: Props) {
+  const [photos, setPhotos] = useState<PhotoEntry[]>([]);
+  const [photoError, setPhotoError] = useState('');
+  const [notes, setNotes] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [apiError, setApiError] = useState('');
+
+  function reset() {
+    setPhotos([]); setPhotoError(''); setNotes(''); setApiError(''); setSubmitting(false);
+  }
+
+  function handleClose() {
+    if (submitting) return;
+    reset();
+    onClose();
+  }
+
+  async function handleSubmit() {
+    setApiError('');
+    if (photos.length === 0) {
+      setPhotoError('A post-repair photo is required.');
+      return;
+    }
+    setSubmitting(true);
+    const res = await resolveReport(reportId, {
+      repairPhoto: photos[0].b64,
+      repairNotes: notes.trim(),
+    });
+    setSubmitting(false);
+    if (res.ok) {
+      reset();
+      onResolved();
+      return;
+    }
+    if (res.status === 409) setApiError('Report is already resolved.');
+    else if (res.status === 403) setApiError('You do not have permission to resolve this report.');
+    else if (res.status === 404) setApiError('Report not found.');
+    else setApiError((res.data as any).detail || 'Could not submit resolution.');
+  }
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
+      <View style={s.backdrop}>
+        <View style={s.sheet} testID="resolve-modal">
+          <View style={s.header}>
+            <Text style={s.headerTitle}>Mark as Resolved</Text>
+            <TouchableOpacity onPress={handleClose} disabled={submitting} hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}>
+              <Ionicons name="close" size={22} color={COLORS.gray500} />
+            </TouchableOpacity>
+          </View>
+
+          <ScrollView contentContainerStyle={s.content}>
+            <View style={s.targetCard}>
+              <Ionicons name="location-outline" size={16} color={COLORS.green600} />
+              <Text style={s.targetText} numberOfLines={2}>{reportTitle}</Text>
+            </View>
+
+            <Text style={s.sectionLabel}>POST-REPAIR PHOTO</Text>
+            <Text style={s.helper}>Upload visual proof that the obstacle has been fixed.</Text>
+            <PhotoPicker
+              photos={photos}
+              onAdd={(p) => { setPhotos([p]); setPhotoError(''); }}
+              onRemove={() => setPhotos([])}
+              error={photoError}
+            />
+
+            <Text style={[s.sectionLabel, { marginTop: 16 }]}>REPAIR NOTES (OPTIONAL)</Text>
+            <TextInput
+              testID="resolve-notes"
+              style={s.notes}
+              value={notes}
+              onChangeText={setNotes}
+              placeholder="What was repaired? Any details visible to citizens during validation."
+              placeholderTextColor={COLORS.gray400}
+              multiline
+              numberOfLines={4}
+            />
+
+            {!!apiError && (
+              <View style={s.errBanner}>
+                <Ionicons name="close-circle" size={16} color={COLORS.red600} />
+                <Text style={s.errText}>{apiError}</Text>
+              </View>
+            )}
+
+            <View style={s.statusHint}>
+              <Ionicons name="information-circle-outline" size={14} color={COLORS.orange500} />
+              <Text style={s.statusHintText}>
+                Status will change to <Text style={{ fontWeight: '700' }}>Awaiting Validation</Text> until citizens confirm.
+              </Text>
+            </View>
+          </ScrollView>
+
+          <View style={s.footer}>
+            <TouchableOpacity
+              style={[s.btnOutline, submitting && s.btnDisabled]}
+              onPress={handleClose}
+              disabled={submitting}
+            >
+              <Text style={s.btnOutlineText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              testID="resolve-submit"
+              style={[s.btnGreen, submitting && s.btnDisabled]}
+              onPress={handleSubmit}
+              disabled={submitting}
+            >
+              {submitting
+                ? <ActivityIndicator color={COLORS.white} size="small" />
+                : <Text style={s.btnGreenText}>Submit for Validation</Text>}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const s = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)', justifyContent: 'flex-end' },
+  sheet: {
+    backgroundColor: COLORS.white,
+    borderTopLeftRadius: 18, borderTopRightRadius: 18,
+    maxHeight: '92%',
+  },
+  header: {
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    padding: 18, borderBottomWidth: 1, borderBottomColor: COLORS.gray100,
+  },
+  headerTitle: { fontSize: 17, fontWeight: '800', color: COLORS.gray900 },
+  content: { padding: 18 },
+  targetCard: {
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    backgroundColor: COLORS.green50, padding: 12, borderRadius: 10, marginBottom: 16,
+    borderWidth: 1, borderColor: 'rgba(39,114,74,0.15)',
+  },
+  targetText: { flex: 1, fontSize: 13, color: COLORS.green700, fontWeight: '600' },
+  sectionLabel: { fontSize: 11, fontWeight: '700', color: COLORS.gray600, letterSpacing: 0.5, marginBottom: 4 },
+  helper: { fontSize: 12, color: COLORS.gray500, marginBottom: 10 },
+  notes: {
+    borderWidth: 1.5, borderColor: COLORS.gray300, borderRadius: 10,
+    paddingHorizontal: 12, paddingVertical: 10,
+    fontSize: 14, color: COLORS.gray900, backgroundColor: COLORS.white,
+    minHeight: 90, textAlignVertical: 'top',
+  },
+  errBanner: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    marginTop: 14, backgroundColor: COLORS.red50, padding: 10, borderRadius: 8,
+    borderWidth: 1, borderColor: 'rgba(239,68,68,0.15)',
+  },
+  errText: { fontSize: 12, color: COLORS.red600, fontWeight: '500', flex: 1 },
+  statusHint: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    marginTop: 16, backgroundColor: COLORS.orange100, padding: 10, borderRadius: 8,
+  },
+  statusHintText: { fontSize: 12, color: COLORS.orange500, flex: 1 },
+  footer: {
+    flexDirection: 'row', gap: 10, padding: 16,
+    borderTopWidth: 1, borderTopColor: COLORS.gray100,
+  },
+  btnOutline: {
+    flex: 1, paddingVertical: 12, borderRadius: 10,
+    borderWidth: 1.5, borderColor: COLORS.gray300, backgroundColor: COLORS.white,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  btnOutlineText: { fontSize: 14, fontWeight: '700', color: COLORS.gray700 },
+  btnGreen: {
+    flex: 1.4, paddingVertical: 12, borderRadius: 10,
+    backgroundColor: COLORS.green700, alignItems: 'center', justifyContent: 'center',
+  },
+  btnGreenText: { fontSize: 14, fontWeight: '700', color: COLORS.white },
+  btnDisabled: { opacity: 0.6 },
+});

--- a/frontend/src/components/authority/ResolveModal.tsx
+++ b/frontend/src/components/authority/ResolveModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Modal,
@@ -28,9 +28,13 @@ export default function ResolveModal({ visible, reportId, reportTitle, onClose, 
   const [notes, setNotes] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [apiError, setApiError] = useState('');
+  // Ref-based guard: state updates are async, so a double-tap can re-enter
+  // handleSubmit before `submitting` has flipped to true.
+  const inFlight = useRef(false);
 
   function reset() {
     setPhotos([]); setPhotoError(''); setNotes(''); setApiError(''); setSubmitting(false);
+    inFlight.current = false;
   }
 
   function handleClose() {
@@ -40,17 +44,21 @@ export default function ResolveModal({ visible, reportId, reportTitle, onClose, 
   }
 
   async function handleSubmit() {
+    if (inFlight.current) return;
     setApiError('');
     if (photos.length === 0) {
       setPhotoError('A post-repair photo is required.');
       return;
     }
+    inFlight.current = true;
     setSubmitting(true);
+    const trimmedNotes = notes.trim();
     const res = await resolveReport(reportId, {
       repairPhoto: photos[0].b64,
-      repairNotes: notes.trim(),
+      repairNotes: trimmedNotes || undefined,
     });
     setSubmitting(false);
+    inFlight.current = false;
     if (res.ok) {
       reset();
       onResolved();
@@ -59,7 +67,10 @@ export default function ResolveModal({ visible, reportId, reportTitle, onClose, 
     if (res.status === 409) setApiError('Report is already resolved.');
     else if (res.status === 403) setApiError('You do not have permission to resolve this report.');
     else if (res.status === 404) setApiError('Report not found.');
-    else setApiError((res.data as any).detail || 'Could not submit resolution.');
+    else {
+      const errBody = res.data as { detail?: string };
+      setApiError(errBody.detail || 'Could not submit resolution.');
+    }
   }
 
   return (

--- a/frontend/src/components/authority/StatusFilterChips.tsx
+++ b/frontend/src/components/authority/StatusFilterChips.tsx
@@ -1,0 +1,69 @@
+import { ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { COLORS } from '../../constants/theme';
+import type { DashboardStatus } from '../../api/authority';
+
+export type FilterValue = DashboardStatus | 'ALL';
+
+interface Props {
+  value: FilterValue;
+  onChange: (next: FilterValue) => void;
+  counts: { verified: number; awaitingValidation: number; closed: number; total: number };
+}
+
+const FILTERS: { value: FilterValue; label: string; key: 'total' | 'verified' | 'awaitingValidation' | 'closed' }[] = [
+  { value: 'ALL', label: 'All', key: 'total' },
+  { value: 'VERIFIED', label: 'Verified', key: 'verified' },
+  { value: 'RESOLVED_AWAITING_VALIDATION', label: 'Awaiting', key: 'awaitingValidation' },
+  { value: 'CLOSED', label: 'Closed', key: 'closed' },
+];
+
+export default function StatusFilterChips({ value, onChange, counts }: Props) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={s.row}
+      contentContainerStyle={s.rowContent}
+    >
+      {FILTERS.map((f) => {
+        const active = value === f.value;
+        return (
+          <TouchableOpacity
+            key={f.value}
+            testID={`filter-${f.value}`}
+            style={[s.chip, active && s.chipActive]}
+            onPress={() => onChange(f.value)}
+            activeOpacity={0.75}
+          >
+            <Text style={[s.label, active && s.labelActive]}>{f.label}</Text>
+            <View style={[s.badge, active && s.badgeActive]}>
+              <Text style={[s.badgeText, active && s.badgeTextActive]}>{counts[f.key] ?? 0}</Text>
+            </View>
+          </TouchableOpacity>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+const s = StyleSheet.create({
+  row: { flexGrow: 0 },
+  rowContent: { paddingHorizontal: 14, paddingVertical: 10, gap: 8 },
+  chip: {
+    flexDirection: 'row', alignItems: 'center', gap: 6,
+    paddingVertical: 8, paddingHorizontal: 14,
+    borderRadius: 100, borderWidth: 1, borderColor: COLORS.gray300,
+    backgroundColor: COLORS.white,
+  },
+  chipActive: { backgroundColor: COLORS.green700, borderColor: COLORS.green700 },
+  label: { fontSize: 13, fontWeight: '600', color: COLORS.gray700 },
+  labelActive: { color: COLORS.white },
+  badge: {
+    minWidth: 22, paddingHorizontal: 6, paddingVertical: 1,
+    borderRadius: 100, backgroundColor: COLORS.gray200,
+    alignItems: 'center', justifyContent: 'center',
+  },
+  badgeActive: { backgroundColor: 'rgba(255,255,255,0.25)' },
+  badgeText: { fontSize: 11, fontWeight: '700', color: COLORS.gray700 },
+  badgeTextActive: { color: COLORS.white },
+});

--- a/frontend/src/components/reports/ConfirmResolutionButton.tsx
+++ b/frontend/src/components/reports/ConfirmResolutionButton.tsx
@@ -9,7 +9,7 @@ interface ConfirmResolutionButtonProps {
   reporterId: string;
   userUpvoted: boolean;
   currentUserId: string;
-  onResolved: () => void;
+  onResolved: (newStatus: string) => void;
 }
 
 export default function ConfirmResolutionButton({
@@ -29,7 +29,10 @@ export default function ConfirmResolutionButton({
     const res = await confirmResolution(reportId);
     setLoading(false);
     if (res.ok) {
-      onResolved();
+      // The server returns the *current* status — only CLOSED once the
+      // confirmation threshold is reached. Earlier confirmations leave the
+      // report in RESOLVED_AWAITING_VALIDATION, so we must reflect that.
+      onResolved(res.data.status || status);
     } else {
       Alert.alert('Something went wrong', 'Could not confirm resolution. Please try again.');
     }

--- a/frontend/src/components/reports/ConfirmResolutionButton.tsx
+++ b/frontend/src/components/reports/ConfirmResolutionButton.tsx
@@ -49,7 +49,7 @@ export default function ConfirmResolutionButton({
       // RESOLVED_AWAITING_VALIDATION, so we forward both the new status and
       // the new count to the parent screen.
       const newStatus = res.data.status || status;
-      const newCount = (res.data as any).confirmationCount ?? confirmationCount + 1;
+      const newCount = res.data.confirmationCount ?? confirmationCount + 1;
       onResolved(newStatus, newCount);
     } else {
       Alert.alert('Something went wrong', 'Could not confirm resolution. Please try again.');

--- a/frontend/src/components/reports/ConfirmResolutionButton.tsx
+++ b/frontend/src/components/reports/ConfirmResolutionButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { ActivityIndicator, Alert, StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { ActivityIndicator, Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../constants/theme';
 import { confirmResolution } from '../../api/interactions';
 
@@ -8,12 +9,15 @@ interface ConfirmResolutionButtonProps {
   status: string;
   reporterId: string;
   userUpvoted: boolean;
+  userConfirmed: boolean;
+  confirmationCount: number;
   currentUserId: string;
-  onResolved: (newStatus: string) => void;
+  onResolved: (newStatus: string, confirmationCount: number) => void;
 }
 
 export default function ConfirmResolutionButton({
-  reportId, status, reporterId, userUpvoted, currentUserId, onResolved,
+  reportId, status, reporterId, userUpvoted, userConfirmed, confirmationCount,
+  currentUserId, onResolved,
 }: ConfirmResolutionButtonProps) {
   const [loading, setLoading] = useState(false);
 
@@ -24,15 +28,29 @@ export default function ConfirmResolutionButton({
 
   if (!eligible) return null;
 
+  if (userConfirmed) {
+    return (
+      <View testID="confirm-resolution-recorded" style={s.recorded}>
+        <Ionicons name="checkmark-circle" size={18} color={COLORS.green700} />
+        <Text style={s.recordedText}>
+          Confirmation recorded — waiting for {confirmationCount === 1 ? 'others' : 'more citizens'} to confirm.
+        </Text>
+      </View>
+    );
+  }
+
   async function handlePress() {
     setLoading(true);
     const res = await confirmResolution(reportId);
     setLoading(false);
     if (res.ok) {
-      // The server returns the *current* status — only CLOSED once the
-      // confirmation threshold is reached. Earlier confirmations leave the
-      // report in RESOLVED_AWAITING_VALIDATION, so we must reflect that.
-      onResolved(res.data.status || status);
+      // Server returns the *current* status — only CLOSED once threshold is
+      // reached. Earlier confirmations leave the report in
+      // RESOLVED_AWAITING_VALIDATION, so we forward both the new status and
+      // the new count to the parent screen.
+      const newStatus = res.data.status || status;
+      const newCount = (res.data as any).confirmationCount ?? confirmationCount + 1;
+      onResolved(newStatus, newCount);
     } else {
       Alert.alert('Something went wrong', 'Could not confirm resolution. Please try again.');
     }
@@ -61,4 +79,16 @@ const s = StyleSheet.create({
     marginTop: 12,
   },
   text: { color: COLORS.white, fontWeight: '600', fontSize: 14 },
+  recorded: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: COLORS.green50,
+    borderColor: 'rgba(39,114,74,0.18)',
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    marginTop: 12,
+  },
+  recordedText: { flex: 1, fontSize: 13, color: COLORS.green700, fontWeight: '600' },
 });

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -57,8 +57,21 @@ export interface RegisterPayload { email: string; fullName: string; password: st
 export interface RegisterResponse { userId: string; email: string; fullName: string; status: string; trustScore: number; accessToken: string; refreshToken: string; createdAt: string; }
 export interface LoginPayload { email: string; password: string; }
 export interface LoginResponse { access: string; refresh: string; }
-export type UserRole = 'USER' | 'TRUSTED_CONTRIBUTOR' | 'ADMIN' | string;
+export type UserRole =
+  | 'REGISTERED_USER'
+  | 'TRUSTED_CONTRIBUTOR'
+  | 'INFRASTRUCTURE_AUTHORITY'
+  | 'ADMINISTRATOR'
+  | string;
 export interface UserProfile { userId: string; email: string; fullName: string; status: string; trustScore: number; role: UserRole; createdAt: string; notificationsEnabled?: boolean; }
+
+export function isAuthorityRole(role: UserRole | undefined | null): boolean {
+  return role === 'INFRASTRUCTURE_AUTHORITY';
+}
+
+export function landingRouteForRole(role: UserRole | undefined | null): string {
+  return isAuthorityRole(role) ? '/authority/dashboard' : '/tabs';
+}
 
 export function parseDRFError(data: any): string {
   if (!data) return 'Something went wrong.';


### PR DESCRIPTION
# Description

Adds the Authority Dashboard UI requested in #181 — a role-aware web/mobile screen where infrastructure-authority users can browse, filter, and resolve verified obstacle reports without touching the citizen tabs.

End-to-end loop now works in the app: a citizen reports → community upvotes verify → an authority resolves with a post-repair photo → reporter and upvoters get notified → citizens confirm → report closes once the threshold is reached.

## Type of Change

- `feat` — new feature (authority dashboard, resolve flow, role-aware redirect, citizen confirmation feedback)
- `fix` — bug fix (`/map/obstacles/{id}` 404'd on RESOLVED_AWAITING_VALIDATION; `Confirm Resolution` lied about CLOSED status)
- `chore` — maintenance (dev-only `promote_authority` command + Django admin registration)
- `test` — adding or updating tests (16 backend, 18 frontend)

## Changes

**Backend**
- `GET /api/authority/dashboard?status=&page=&size=` — paginated reports + status counts (Verified / Awaiting Validation / Closed). Authority-only.
- `PATCH /api/authority/reports/{id}/resolve` — switched from `repairPhotoUrl` (string) to `repairPhoto` (base64), uploaded via the same `save_photos` helper used by report creation. Matches the documented API contract.
- `GET /api/map/obstacles/{id}` now also returns `RESOLVED_AWAITING_VALIDATION` reports (was 404 — broke the citizen confirm-resolution flow that already shipped).
- `ObstacleDetailSerializer` exposes new `confirmationCount` and `userConfirmed` fields, mirroring the existing `userUpvoted` / `userFlagged` pattern. No new model fields, no migrations — both are computed live from `Interaction` rows filtered by `interaction_type`.
- `python manage.py promote_authority <email>` — dev-only command to flip a user's role until a real registration flow exists.
- Registered `User` and `MobilityProfile` in the Django admin so role can be changed from `/admin/` too.

**Frontend**
- New `/authority/*` route group with its own role guard layout: redirects unauthenticated users to login, citizen users to `/tabs`, and clears tokens on a 401.
- `/authority/dashboard` — counts strip, filter chips (All / Verified / Awaiting / Closed), per-report cards, pull-to-refresh.
- `/authority/report/[id]` — detail with photo carousel and a "Mark as Resolved" CTA visible only when status is VERIFIED.
- `ResolveModal` — reuses the existing `PhotoPicker` from the citizen report flow, validates that a photo is attached, surfaces 403/404/409 from the backend.
- Role-aware redirect on login and on root `/`: `INFRASTRUCTURE_AUTHORITY` lands on `/authority/dashboard`; everyone else lands on `/tabs`.
- `ConfirmResolutionButton` no longer fakes the report as CLOSED on every click — it forwards the server-returned status. Once a citizen confirms, the button is replaced by a recorded-state pill that survives reloads (driven by `userConfirmed` from the API).

## How to Test

1. `git checkout feature/authority-dashboard`
2. `docker compose up backend` — no DB migrations needed.
3. From the frontend folder: `npm run web`.
4. Register a normal account in the app, then promote it:
   ```
   docker compose exec backend python manage.py promote_authority you@example.com
   ```
   Or change the `role` to `INFRASTRUCTURE_AUTHORITY` from `/admin/` (or directly via `UPDATE users SET role = 'INFRASTRUCTURE_AUTHORITY' WHERE email = '…';`).
5. Sign out and sign back in — you should land on `/authority/dashboard`.
6. With another account, submit a report (defaults to VERIFIED). It should appear under the **Verified** filter on the authority dashboard.
7. Tap the report → **Mark as Resolved** → upload a photo via the same picker as the citizen report flow → submit. Status flips to **Awaiting Validation**, the report moves filters, and the original reporter gets a `REPORT_RESOLVED` notification.
8. Sign in as the reporter → tap the notification → **Confirm Resolution**. The button is replaced by a "Confirmation recorded" pill (and survives a reload). Once enough confirmations land, status flips to **Closed**.
9. Run the tests:
   - Backend: `cd backend && python -m pytest apps/authority/tests.py apps/map/tests.py::GetObstacleDetailTest` → 21 passing.
   - Frontend: `cd frontend && npx jest src/__tests__/Authority*.test.tsx src/__tests__/ResolveModal.test.tsx` → 18 passing.

To switch back: `python manage.py promote_authority you@example.com --role REGISTERED_USER`.

## Screenshots (if applicable)

To be added by reviewer when running locally — covers the dashboard, the resolve modal, and the citizen confirmation pill.

## Checklist

- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue

- Closes #181

## Notes

**No DB schema changes.** All new fields are computed in serializers from existing `Interaction` rows (filtered by `interaction_type`). No migrations to apply — pulling the branch and restarting the backend is sufficient.

**Out of scope (intentionally deferred):**
- Authority self-registration flow. Today the only ways to become an authority are the `promote_authority` command, the Django admin, or a direct DB update. A follow-up issue will be opened for a real registration/approval flow.
- Region/district scoping ("authority X only sees reports in region Y"). Not in the SRS or class diagram and would need a new model + admin assignment flow. Open another issue if/when we tackle it.
- Map-based dashboard view (the mockup's pin map). The list view satisfies #181's acceptance criteria; map view would be polish.

**Pre-existing test failures untouched:** the full backend `pytest` shows ~16 failures and the full `jest` run shows 4 — all of them existed on `main` before this branch (DB-leakage between test classes for the backend, missing native shims for `react-native-webview` for the frontend tests). Confirmed by stashing my changes and re-running. Worth a separate cleanup issue.