### PR TITLE
feat(frontend): add map preview to authority report detail (#238)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ package-lock.json
 Thumbs.db
 .vercel
 .env*.local
+.claude/

--- a/frontend/app/authority/report/[id].tsx
+++ b/frontend/app/authority/report/[id].tsx
@@ -13,6 +13,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../../src/constants/theme';
 import { fetchObstacleDetail, type ObstacleDetail } from '../../../src/api/map';
 import ResolveModal from '../../../src/components/authority/ResolveModal';
+import ReportMapPreview from '../../../src/components/map/ReportMapPreview';
 
 const STATUS_COLOR: Record<string, string> = {
   VERIFIED: COLORS.green600,
@@ -77,11 +78,14 @@ export default function AuthorityReportDetailScreen() {
 
         {!!detail.description && <Text style={s.description}>{detail.description}</Text>}
 
-        <View style={s.metaRow}>
-          <Ionicons name="location-outline" size={16} color={COLORS.gray500} />
-          <Text style={s.metaText}>
-            {detail.latitude.toFixed(5)}, {detail.longitude.toFixed(5)}
-          </Text>
+        <View style={s.mapBlock}>
+          <ReportMapPreview latitude={detail.latitude} longitude={detail.longitude} />
+          <View style={s.metaRow}>
+            <Ionicons name="location-outline" size={14} color={COLORS.gray500} />
+            <Text style={s.coordCaption}>
+              {detail.latitude.toFixed(5)}, {detail.longitude.toFixed(5)}
+            </Text>
+          </View>
         </View>
         <View style={s.metaRow}>
           <Ionicons name="thumbs-up-outline" size={16} color={COLORS.gray500} />
@@ -150,6 +154,8 @@ const s = StyleSheet.create({
   description: { fontSize: 14, color: COLORS.gray700, lineHeight: 20, marginBottom: 14 },
   metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 },
   metaText: { fontSize: 13, color: COLORS.gray600 },
+  mapBlock: { marginBottom: 10 },
+  coordCaption: { fontSize: 12, color: COLORS.gray500, marginTop: 6 },
   sectionLabel: { fontSize: 11, fontWeight: '700', color: COLORS.gray600, letterSpacing: 0.5, marginTop: 14, marginBottom: 8 },
   photoRow: { marginBottom: 8 },
   photo: { width: 200, height: 150, borderRadius: 8, marginRight: 8, backgroundColor: COLORS.gray200 },

--- a/frontend/src/components/map/ReportMapPreview.tsx
+++ b/frontend/src/components/map/ReportMapPreview.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import WebView from 'react-native-webview';
+import { COLORS } from '../../constants/theme';
+
+export interface ReportMapPreviewProps {
+  latitude: number;
+  longitude: number;
+  zoom?: number;
+  height?: number;
+  testID?: string;
+}
+
+/**
+ * Small, non-interactive Leaflet preview. Renders a single marker at the
+ * given coordinate inside a WebView. No search, no routing, no obstacle
+ * loading — intentionally NOT a thin wrapper around MapView, which is a
+ * full-screen app shell.
+ */
+export default function ReportMapPreview({
+  latitude,
+  longitude,
+  zoom = 16,
+  height = 170,
+  testID = 'report-map-preview',
+}: ReportMapPreviewProps) {
+  const html = useMemo(
+    () => `<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"><\/script>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body, #map { height: 100%; width: 100%; background: #e5e7eb; }
+  </style>
+</head>
+<body>
+<div id="map"></div>
+<script>
+  var map = L.map('map', {
+    zoomControl: false,
+    dragging: false,
+    scrollWheelZoom: false,
+    doubleClickZoom: false,
+    boxZoom: false,
+    keyboard: false,
+    touchZoom: false,
+    tap: false,
+    attributionControl: false
+  }).setView([${latitude}, ${longitude}], ${zoom});
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 20 }).addTo(map);
+  var pinIcon = L.divIcon({
+    html: '<div style="width:14px;height:14px;border-radius:50%;background:#EF4444;border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,0.35)"></div>',
+    className: '',
+    iconSize: [14, 14],
+    iconAnchor: [7, 7]
+  });
+  L.marker([${latitude}, ${longitude}], { icon: pinIcon, interactive: false, keyboard: false }).addTo(map);
+<\/script>
+</body>
+</html>`,
+    [latitude, longitude, zoom],
+  );
+
+  return (
+    <View style={[s.wrap, { height }]} testID={testID}>
+      <WebView
+        originWhitelist={['*']}
+        source={{ html }}
+        style={s.webview}
+        scrollEnabled={false}
+        pointerEvents="none"
+      />
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  wrap: {
+    width: '100%',
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: COLORS.gray200,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
+  webview: { flex: 1, backgroundColor: COLORS.gray200 },
+});

--- a/frontend/src/components/map/ReportMapPreview.web.tsx
+++ b/frontend/src/components/map/ReportMapPreview.web.tsx
@@ -1,0 +1,68 @@
+/// <reference lib="dom" />
+// @ts-ignore
+import 'leaflet/dist/leaflet.css';
+
+import L from 'leaflet';
+import { StyleSheet, View } from 'react-native';
+import { MapContainer, Marker, TileLayer } from 'react-leaflet';
+import { COLORS } from '../../constants/theme';
+
+export interface ReportMapPreviewProps {
+  latitude: number;
+  longitude: number;
+  zoom?: number;
+  height?: number;
+  testID?: string;
+}
+
+const PIN_ICON = L.divIcon({
+  html: `<div style="width:14px;height:14px;border-radius:50%;background:#EF4444;border:3px solid white;box-shadow:0 2px 6px rgba(0,0,0,0.35)"></div>`,
+  className: '',
+  iconSize: [14, 14],
+  iconAnchor: [7, 7],
+});
+
+/**
+ * Web counterpart of ReportMapPreview — same props, react-leaflet under
+ * the hood. Fully non-interactive: pan, zoom, double-click zoom, scroll
+ * wheel, keyboard, and touch zoom are all disabled.
+ */
+export default function ReportMapPreview({
+  latitude,
+  longitude,
+  zoom = 16,
+  height = 170,
+  testID = 'report-map-preview',
+}: ReportMapPreviewProps) {
+  return (
+    <View style={[s.wrap, { height }]} testID={testID}>
+      <MapContainer
+        center={[latitude, longitude]}
+        zoom={zoom}
+        zoomControl={false}
+        dragging={false}
+        scrollWheelZoom={false}
+        doubleClickZoom={false}
+        boxZoom={false}
+        keyboard={false}
+        touchZoom={false}
+        attributionControl={false}
+        style={{ width: '100%', height: '100%' }}
+      >
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        <Marker position={[latitude, longitude]} icon={PIN_ICON} interactive={false} />
+      </MapContainer>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  wrap: {
+    width: '100%',
+    borderRadius: 12,
+    overflow: 'hidden',
+    backgroundColor: COLORS.gray200,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
+});


### PR DESCRIPTION
Closes #238

## What
Adds a small, non-interactive Leaflet map preview to the authority report detail screen. The preview is centered on the report's coordinates with a single red marker.

## Why
Authorities physically go to fix obstacles — a 170px map preview is far more useful than a raw lat/lng pair. The existing coordinate text is retained as a small caption beneath the map.

## Approach
Did **not** reuse the full `MapView` component as a thin wrapper — `MapView.tsx` and `MapView.web.tsx` are self-driving full-screen shells with their own search bar, route panel, obstacle fetching, and location hooks. Embedding one as a 170px preview would pull all that machinery in.

Instead added a dedicated lightweight wrapper:
- `ReportMapPreview.tsx` (native): Leaflet inside a `WebView`, all interactions disabled (`dragging`, `scrollWheelZoom`, `doubleClickZoom`, `boxZoom`, `keyboard`, `touchZoom`, `tap`, `pointerEvents="none"`).
- `ReportMapPreview.web.tsx` (web): `react-leaflet` `MapContainer` with the same interactions disabled.

Same props on both platforms: `latitude`, `longitude` required; `zoom` (default 16), `height` (default 170), `testID` optional.

## Changes
- `frontend/src/components/map/ReportMapPreview.tsx` — new (native, WebView + Leaflet)
- `frontend/src/components/map/ReportMapPreview.web.tsx` — new (web, react-leaflet)
- `frontend/app/authority/report/[id].tsx` — replaced raw coordinate row with `<ReportMapPreview />` + a small coord caption underneath
- `.gitignore` — added `.claude/` (Claude Code local config, should not be tracked)

## Testing
Manually verified on both web (`npx expo start` → press `w`) and native (Expo Go on iOS):
- Map preview renders centered on `detail.latitude` / `detail.longitude` with a red marker.
- Map is non-interactive (no pan, no zoom).
- Existing coordinate text is retained as a caption below the map.
- No visual glitches, sizing matches the rest of the detail screen.

No unit tests added — component is presentational, behavior covered by visual check.

## Acceptance Criteria
- [x] Authority report detail shows a small map preview centered on `detail.latitude` / `detail.longitude` with a marker
- [x] Existing coordinate text remains (folded into a caption below the map)
- [x] Works on both native and web (separate `.tsx` / `.web.tsx` files, dependencies already in `package.json`: `leaflet`, `re