### PR TITLE
Feature/report discussion section

### DIFF
--- a/backend/apps/reports/migrations/0002_comment.py
+++ b/backend/apps/reports/migrations/0002_comment.py
@@ -1,0 +1,38 @@
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('reports', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Comment',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('body', models.TextField()),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('author', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='comments',
+                    to=settings.AUTH_USER_MODEL,
+                )),
+                ('report', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='comments',
+                    to='reports.report',
+                )),
+            ],
+            options={
+                'db_table': 'comments',
+                'ordering': ['created_at'],
+            },
+        ),
+    ]

--- a/backend/apps/reports/models.py
+++ b/backend/apps/reports/models.py
@@ -109,6 +109,25 @@ class Interaction(models.Model):
         return f"{self.user.email} - {self.interaction_type} on {self.report.title}"
 
 
+class Comment(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    report = models.ForeignKey(Report, on_delete=models.CASCADE, related_name='comments')
+    author = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='comments',
+    )
+    body = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = 'comments'
+        ordering = ['created_at']
+
+    def __str__(self):
+        return f'{self.author.email} on {self.report.title}'
+
+
 class StatusChange(models.Model):
     report = models.ForeignKey(
         Report, on_delete=models.CASCADE, related_name="status_changes"

--- a/backend/apps/reports/serializers.py
+++ b/backend/apps/reports/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from .models import ObstacleCategory, ReportContext
+from .models import Comment, ObstacleCategory, ReportContext
 
 
 class LocationSerializer(serializers.Serializer):
@@ -55,3 +55,31 @@ class ConfirmResolutionResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField()
     confirmationCount = serializers.IntegerField()
     status = serializers.CharField()
+
+
+class CommentAuthorSerializer(serializers.Serializer):
+    userId = serializers.UUIDField(source='id')
+    fullName = serializers.CharField(source='full_name')
+    role = serializers.CharField()
+    mobilityAidType = serializers.SerializerMethodField()
+
+    def get_mobilityAidType(self, user):
+        profile = getattr(user, 'mobility_profile', None)
+        if profile is None:
+            return None
+        aid = profile.mobility_aid_type
+        return None if aid == 'NONE' else aid
+
+
+class CommentSerializer(serializers.ModelSerializer):
+    createdAt = serializers.DateTimeField(source='created_at', read_only=True)
+    author = CommentAuthorSerializer(read_only=True)
+
+    class Meta:
+        model = Comment
+        fields = ['id', 'body', 'createdAt', 'author']
+        read_only_fields = ['id', 'createdAt', 'author']
+
+
+class CommentCreateSerializer(serializers.Serializer):
+    body = serializers.CharField(min_length=1, max_length=2000)

--- a/backend/apps/reports/test_comments.py
+++ b/backend/apps/reports/test_comments.py
@@ -1,0 +1,162 @@
+import uuid
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.reports.models import Comment, ObstacleCategory, Report, ReportContext
+from apps.users.models import MobilityAidType, MobilityProfile, User
+
+
+def make_user(email='user@test.com', full_name='Test User'):
+    return User.objects.create_user(
+        email=email,
+        full_name=full_name,
+        password='SecureP@ss123',
+    )
+
+
+def make_report(reporter):
+    return Report.objects.create(
+        reporter=reporter,
+        title='Broken Ramp',
+        description='Cracked surface',
+        category=ObstacleCategory.BROKEN_RAMP,
+        context=ReportContext.OUTDOOR,
+        latitude='41.0825',
+        longitude='29.0510',
+    )
+
+
+class ReportCommentsListTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.reporter = make_user()
+        self.report = make_report(self.reporter)
+        self.url = f'/api/reports/{self.report.id}/comments/'
+
+    def test_empty_list_for_new_report(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), [])
+
+    def test_returns_comments_ordered_by_created_at(self):
+        commenter = make_user('b@test.com', 'B User')
+        c1 = Comment.objects.create(report=self.report, author=self.reporter, body='First')
+        c2 = Comment.objects.create(report=self.report, author=commenter, body='Second')
+
+        data = self.client.get(self.url).json()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]['id'], str(c1.id))
+        self.assertEqual(data[1]['id'], str(c2.id))
+
+    def test_comment_shape(self):
+        Comment.objects.create(report=self.report, author=self.reporter, body='Hello')
+        data = self.client.get(self.url).json()
+        c = data[0]
+        self.assertIn('id', c)
+        self.assertIn('body', c)
+        self.assertIn('createdAt', c)
+        self.assertIn('author', c)
+        author = c['author']
+        self.assertIn('userId', author)
+        self.assertIn('fullName', author)
+        self.assertIn('role', author)
+        self.assertIn('mobilityAidType', author)
+
+    def test_author_full_name_and_role(self):
+        Comment.objects.create(report=self.report, author=self.reporter, body='Hi')
+        data = self.client.get(self.url).json()
+        author = data[0]['author']
+        self.assertEqual(author['fullName'], self.reporter.full_name)
+        self.assertEqual(author['role'], self.reporter.role)
+
+    def test_mobility_aid_type_null_when_no_profile(self):
+        Comment.objects.create(report=self.report, author=self.reporter, body='Hi')
+        data = self.client.get(self.url).json()
+        self.assertIsNone(data[0]['author']['mobilityAidType'])
+
+    def test_mobility_aid_type_null_when_profile_aid_is_none(self):
+        MobilityProfile.objects.create(
+            user=self.reporter,
+            mobility_aid_type=MobilityAidType.NONE,
+        )
+        Comment.objects.create(report=self.report, author=self.reporter, body='Hi')
+        data = self.client.get(self.url).json()
+        self.assertIsNone(data[0]['author']['mobilityAidType'])
+
+    def test_mobility_aid_type_returned_when_set(self):
+        MobilityProfile.objects.create(
+            user=self.reporter,
+            mobility_aid_type=MobilityAidType.WHEELCHAIR,
+        )
+        Comment.objects.create(report=self.report, author=self.reporter, body='Hi')
+        data = self.client.get(self.url).json()
+        self.assertEqual(data[0]['author']['mobilityAidType'], 'WHEELCHAIR')
+
+    def test_guest_can_list_comments(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_returns_404_for_nonexistent_report(self):
+        url = f'/api/reports/{uuid.uuid4()}/comments/'
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class ReportCommentsCreateTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.reporter = make_user()
+        self.report = make_report(self.reporter)
+        self.url = f'/api/reports/{self.report.id}/comments/'
+
+    def test_create_requires_authentication(self):
+        response = self.client.post(self.url, {'body': 'Hello'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_authenticated_user_can_post_comment(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.post(self.url, {'body': 'Great report!'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_created_comment_appears_in_list(self):
+        self.client.force_authenticate(user=self.reporter)
+        self.client.post(self.url, {'body': 'My comment'}, format='json')
+        data = self.client.get(self.url).json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]['body'], 'My comment')
+
+    def test_response_shape_matches_list_shape(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.post(self.url, {'body': 'Shape check'}, format='json')
+        c = response.json()
+        for field in ('id', 'body', 'createdAt', 'author'):
+            self.assertIn(field, c)
+        for field in ('userId', 'fullName', 'role', 'mobilityAidType'):
+            self.assertIn(field, c['author'])
+
+    def test_empty_body_returns_400(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.post(self.url, {'body': ''}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_body_returns_400(self):
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.post(self.url, {}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_mobility_aid_included_in_post_response(self):
+        MobilityProfile.objects.create(
+            user=self.reporter,
+            mobility_aid_type=MobilityAidType.WALKER,
+        )
+        self.client.force_authenticate(user=self.reporter)
+        response = self.client.post(self.url, {'body': 'With aid'}, format='json')
+        self.assertEqual(response.json()['author']['mobilityAidType'], 'WALKER')
+
+    def test_returns_404_when_posting_to_nonexistent_report(self):
+        self.client.force_authenticate(user=self.reporter)
+        url = f'/api/reports/{uuid.uuid4()}/comments/'
+        response = self.client.post(url, {'body': 'Hi'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/apps/reports/urls.py
+++ b/backend/apps/reports/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('<uuid:report_id>/upvote/', views.ReportUpvoteView.as_view(), name='report-upvote'),
     path('<uuid:report_id>/flag/', views.ReportFlagView.as_view(), name='report-flag'),
     path('<uuid:report_id>/confirm-resolution/', views.ConfirmResolutionView.as_view(), name='confirm-resolution'),
+    path('<uuid:report_id>/comments/', views.ReportCommentsView.as_view(), name='report-comments'),
 ]

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -1,13 +1,16 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from django.shortcuts import get_object_or_404
 
 from apps.core.permissions import IsUser
 
-from .models import Report
+from .models import Comment, Report
 from .serializers import (
     ReportSerializer, ReportResponseSerializer,
     UpvoteResponseSerializer, FlagResponseSerializer, ConfirmResolutionResponseSerializer,
+    CommentSerializer, CommentCreateSerializer,
 )
 from .services import (
     SelfInteractionError, ConflictingInteractionError,
@@ -106,3 +109,31 @@ class ConfirmResolutionView(APIView):
                 status=status.HTTP_403_FORBIDDEN,
             )
         return Response(ConfirmResolutionResponseSerializer(result).data, status=status.HTTP_200_OK)
+
+
+class ReportCommentsView(APIView):
+    def get_permissions(self):
+        if self.request.method == 'POST':
+            return [IsAuthenticated()]
+        return [AllowAny()]
+
+    def get(self, request, report_id):
+        report = get_object_or_404(Report, pk=report_id)
+        comments = (
+            report.comments
+            .select_related('author', 'author__mobility_profile')
+            .all()
+        )
+        return Response(CommentSerializer(comments, many=True).data)
+
+    def post(self, request, report_id):
+        report = get_object_or_404(Report, pk=report_id)
+        serializer = CommentCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        comment = Comment.objects.create(
+            report=report,
+            author=request.user,
+            body=serializer.validated_data['body'],
+        )
+        comment.author = request.user
+        return Response(CommentSerializer(comment).data, status=status.HTTP_201_CREATED)

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -2,7 +2,6 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
-from django.shortcuts import get_object_or_404
 
 from apps.core.permissions import IsUser
 
@@ -118,7 +117,10 @@ class ReportCommentsView(APIView):
         return [AllowAny()]
 
     def get(self, request, report_id):
-        report = get_object_or_404(Report, pk=report_id)
+        try:
+            report = Report.objects.get(pk=report_id)
+        except Report.DoesNotExist:
+            return Response({'detail': 'Report not found.'}, status=status.HTTP_404_NOT_FOUND)
         comments = (
             report.comments
             .select_related('author', 'author__mobility_profile')
@@ -127,7 +129,10 @@ class ReportCommentsView(APIView):
         return Response(CommentSerializer(comments, many=True).data)
 
     def post(self, request, report_id):
-        report = get_object_or_404(Report, pk=report_id)
+        try:
+            report = Report.objects.get(pk=report_id)
+        except Report.DoesNotExist:
+            return Response({'detail': 'Report not found.'}, status=status.HTTP_404_NOT_FOUND)
         serializer = CommentCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         comment = Comment.objects.create(

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -15,9 +15,17 @@ import DiscussionSection from '../../src/components/reports/DiscussionSection';
 const STATUS_COLOR: Record<string, string> = {
   UNVERIFIED: COLORS.gray400,
   PASSIVE: COLORS.gray400,
-  VERIFIED: COLORS.green500,
+  VERIFIED: COLORS.green600,
   RESOLVED_AWAITING_VALIDATION: COLORS.blue500,
   CLOSED: COLORS.gray500,
+};
+
+const STATUS_BG: Record<string, string> = {
+  UNVERIFIED: COLORS.gray100,
+  PASSIVE: COLORS.gray100,
+  VERIFIED: COLORS.green100,
+  RESOLVED_AWAITING_VALIDATION: COLORS.blue100,
+  CLOSED: COLORS.gray100,
 };
 
 const STATUS_LABEL: Record<string, string> = {
@@ -26,6 +34,17 @@ const STATUS_LABEL: Record<string, string> = {
   VERIFIED: 'Verified',
   RESOLVED_AWAITING_VALIDATION: 'Awaiting Validation',
   CLOSED: 'Closed',
+};
+
+const CATEGORY_LABEL: Record<string, string> = {
+  BROKEN_RAMP: 'Broken Ramp',
+  NARROW_SIDEWALK: 'Narrow Sidewalk',
+  DAMAGED_SURFACE: 'Damaged Surface',
+  ROAD_CONSTRUCTION: 'Road Construction',
+  BLOCKED_PATH: 'Blocked Path',
+  BROKEN_ELEVATOR: 'Broken Elevator',
+  INACCESSIBLE_RESTROOM: 'Inaccessible Restroom',
+  OTHER: 'Other',
 };
 
 export default function ReportDetailScreen() {
@@ -64,46 +83,73 @@ export default function ReportDetailScreen() {
     );
   }
 
+  const statusColor = STATUS_COLOR[detail.status] ?? COLORS.gray400;
+  const statusBg = STATUS_BG[detail.status] ?? COLORS.gray100;
+
   return (
     <ScrollView style={s.page} contentContainerStyle={s.content}>
       <TouchableOpacity style={s.back} onPress={() => router.back()}>
-        <Ionicons name="arrow-back" size={20} color={COLORS.gray700} />
+        <Ionicons name="arrow-back" size={18} color={COLORS.gray600} />
         <Text style={s.backText}>Map</Text>
       </TouchableOpacity>
 
-      <Text style={s.title}>{detail.title}</Text>
+      {/* Main info card */}
+      <View style={s.card}>
+        <Text style={s.title}>{detail.title}</Text>
 
-      <View style={s.badges}>
-        <View style={[s.badge, { backgroundColor: STATUS_COLOR[detail.status] ?? COLORS.gray400 }]}>
-          <Text style={s.badgeText}>{STATUS_LABEL[detail.status] ?? detail.status}</Text>
+        <View style={s.chips}>
+          {/* Status pill */}
+          <View style={[s.statusChip, { backgroundColor: statusBg }]}>
+            <View style={[s.statusDot, { backgroundColor: statusColor }]} />
+            <Text style={[s.statusChipText, { color: statusColor }]}>
+              {STATUS_LABEL[detail.status] ?? detail.status}
+            </Text>
+          </View>
+          {/* Category pill */}
+          <View style={s.categoryChip}>
+            <Text style={s.categoryChipText}>
+              {CATEGORY_LABEL[detail.category] ?? detail.category.replace(/_/g, ' ')}
+            </Text>
+          </View>
+          {/* Indoor/outdoor chip */}
+          {detail.isIndoor !== undefined && (
+            <View style={s.contextChip}>
+              <Ionicons
+                name={detail.isIndoor ? 'business-outline' : 'sunny-outline'}
+                size={11}
+                color={COLORS.gray600}
+              />
+              <Text style={s.contextChipText}>{detail.isIndoor ? 'Indoor' : 'Outdoor'}</Text>
+            </View>
+          )}
         </View>
-        <View style={[s.badge, { backgroundColor: COLORS.gray500 }]}>
-          <Text style={s.badgeText}>{detail.category.replace(/_/g, ' ')}</Text>
-        </View>
+
+        {detail.description ? (
+          <Text style={s.description}>{detail.description}</Text>
+        ) : null}
+
+        {detail.photos.length > 0 && (
+          <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.photoRow}>
+            {detail.photos.map((p, i) => (
+              <Image key={i} source={{ uri: p.imageUrl }} style={s.photo} />
+            ))}
+          </ScrollView>
+        )}
       </View>
 
-      {detail.description ? (
-        <Text style={s.description}>{detail.description}</Text>
-      ) : null}
-
-      {detail.photos.length > 0 && (
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.photoRow}>
-          {detail.photos.map((p, i) => (
-            <Image key={i} source={{ uri: p.imageUrl }} style={s.photo} />
-          ))}
-        </ScrollView>
-      )}
-
-      <InteractionBar
-        reportId={detail.id}
-        reporterId={detail.reporterId}
-        upvoteCount={detail.upvoteCount}
-        flagCount={detail.flagCount}
-        userUpvoted={detail.userUpvoted}
-        userFlagged={detail.userFlagged}
-        currentUserId={currentUserId}
-        onUpdate={(patch) => setDetail((d) => (d ? { ...d, ...patch } : d))}
-      />
+      {/* Interaction bar */}
+      <View style={s.interactionCard}>
+        <InteractionBar
+          reportId={detail.id}
+          reporterId={detail.reporterId}
+          upvoteCount={detail.upvoteCount}
+          flagCount={detail.flagCount}
+          userUpvoted={detail.userUpvoted}
+          userFlagged={detail.userFlagged}
+          currentUserId={currentUserId}
+          onUpdate={(patch) => setDetail((d) => (d ? { ...d, ...patch } : d))}
+        />
+      </View>
 
       <ConfirmResolutionButton
         reportId={detail.id}
@@ -134,16 +180,70 @@ export default function ReportDetailScreen() {
 
 const s = StyleSheet.create({
   page: { flex: 1, backgroundColor: COLORS.gray100 },
-  content: { padding: 20, paddingBottom: 40 },
+  content: { padding: 16, paddingBottom: 48 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   errorText: { fontSize: 14, color: COLORS.gray500 },
-  back: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 16 },
-  backText: { fontSize: 14, color: COLORS.gray700 },
-  title: { fontSize: 20, fontWeight: '700', color: COLORS.gray900, marginBottom: 10 },
-  badges: { flexDirection: 'row', gap: 6, flexWrap: 'wrap', marginBottom: 12 },
-  badge: { borderRadius: 4, paddingHorizontal: 8, paddingVertical: 3 },
-  badgeText: { color: COLORS.white, fontSize: 11, fontWeight: '600' },
-  description: { fontSize: 14, color: COLORS.gray700, lineHeight: 20, marginBottom: 12 },
-  photoRow: { marginBottom: 12 },
-  photo: { width: 200, height: 150, borderRadius: 6, marginRight: 8 },
+
+  back: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 14 },
+  backText: { fontSize: 14, fontWeight: '500', color: COLORS.gray600 },
+
+  card: {
+    backgroundColor: COLORS.white,
+    borderRadius: 14,
+    padding: 16,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
+  title: { fontSize: 20, fontWeight: '700', color: COLORS.gray900, marginBottom: 12 },
+
+  chips: { flexDirection: 'row', gap: 6, flexWrap: 'wrap', marginBottom: 12 },
+
+  statusChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    borderRadius: 20,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  statusDot: { width: 6, height: 6, borderRadius: 3 },
+  statusChipText: { fontSize: 12, fontWeight: '600' },
+
+  categoryChip: {
+    borderRadius: 20,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    backgroundColor: COLORS.gray100,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
+  categoryChipText: { fontSize: 12, fontWeight: '500', color: COLORS.gray600 },
+
+  contextChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    borderRadius: 20,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    backgroundColor: COLORS.gray100,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
+  contextChipText: { fontSize: 12, fontWeight: '500', color: COLORS.gray600 },
+
+  description: { fontSize: 14, color: COLORS.gray700, lineHeight: 21, marginBottom: 12 },
+  photoRow: { marginBottom: 4 },
+  photo: { width: 200, height: 150, borderRadius: 10, marginRight: 8 },
+
+  interactionCard: {
+    backgroundColor: COLORS.white,
+    borderRadius: 14,
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
 });

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -72,7 +72,24 @@ const CATEGORY_LABEL: Record<string, string> = {
   BLOCKED_PATH: 'Blocked Path',
   BROKEN_ELEVATOR: 'Broken Elevator',
   INACCESSIBLE_RESTROOM: 'Inaccessible Restroom',
+  NARROW_CORRIDOR: 'Narrow Corridor',
+  HEAVY_DOOR: 'Heavy Door',
+  SLIPPERY_FLOOR: 'Slippery Floor',
   OTHER: 'Other',
+};
+
+const CATEGORY_COLOR: Record<string, string> = {
+  BROKEN_RAMP: COLORS.red500,
+  NARROW_SIDEWALK: COLORS.orange500,
+  DAMAGED_SURFACE: COLORS.orange500,
+  ROAD_CONSTRUCTION: '#EAB308',
+  BLOCKED_PATH: COLORS.red600,
+  BROKEN_ELEVATOR: COLORS.orange500,
+  INACCESSIBLE_RESTROOM: COLORS.orange500,
+  NARROW_CORRIDOR: COLORS.orange500,
+  HEAVY_DOOR: '#EAB308',
+  SLIPPERY_FLOOR: COLORS.orange500,
+  OTHER: COLORS.gray500,
 };
 
 export default function ReportDetailScreen() {
@@ -134,16 +151,22 @@ export default function ReportDetailScreen() {
             </Text>
           </View>
           {/* Category pill */}
-          <View style={s.categoryChip}>
-            <Text style={s.categoryChipText}>
-              {CATEGORY_LABEL[detail.category] ?? detail.category.replace(/_/g, ' ')}
-            </Text>
-          </View>
+          {(() => {
+            const catColor = CATEGORY_COLOR[detail.category] ?? COLORS.gray500;
+            return (
+              <View style={[s.categoryChip, { borderColor: catColor + '55' }]}>
+                <View style={[s.categoryDot, { backgroundColor: catColor }]} />
+                <Text style={[s.categoryChipText, { color: catColor }]}>
+                  {CATEGORY_LABEL[detail.category] ?? detail.category.replace(/_/g, ' ')}
+                </Text>
+              </View>
+            );
+          })()}
           {/* Indoor/outdoor chip */}
           {detail.isIndoor !== undefined && (
             <View style={s.contextChip}>
               <Ionicons
-                name={detail.isIndoor ? 'business-outline' : 'sunny-outline'}
+                name={detail.isIndoor ? 'home-outline' : 'sunny-outline'}
                 size={11}
                 color={COLORS.gray600}
               />
@@ -248,14 +271,18 @@ const s = StyleSheet.create({
   statusChipText: { fontSize: 12, fontWeight: '600' },
 
   categoryChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
     borderRadius: 20,
     paddingHorizontal: 10,
     paddingVertical: 4,
-    backgroundColor: COLORS.gray100,
+    backgroundColor: COLORS.white,
     borderWidth: 1,
     borderColor: COLORS.gray200,
   },
-  categoryChipText: { fontSize: 12, fontWeight: '500', color: COLORS.gray600 },
+  categoryDot: { width: 6, height: 6, borderRadius: 3 },
+  categoryChipText: { fontSize: 12, fontWeight: '600' },
 
   contextChip: {
     flexDirection: 'row',

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -10,6 +10,7 @@ import { fetchObstacleDetail, type ObstacleDetail } from '../../src/api/map';
 import { getMe, isLoggedIn } from '../../src/services/auth';
 import InteractionBar from '../../src/components/reports/InteractionBar';
 import ConfirmResolutionButton from '../../src/components/reports/ConfirmResolutionButton';
+import DiscussionSection from '../../src/components/reports/DiscussionSection';
 
 const STATUS_COLOR: Record<string, string> = {
   UNVERIFIED: COLORS.gray400,
@@ -125,6 +126,8 @@ export default function ReportDetailScreen() {
           )
         }
       />
+
+      <DiscussionSection reportId={detail.id} currentUserId={currentUserId} />
     </ScrollView>
   );
 }

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -6,11 +6,39 @@ import {
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { COLORS } from '../../src/constants/theme';
-import { fetchObstacleDetail, type ObstacleDetail } from '../../src/api/map';
+import { fetchObstacleDetail, type ObstacleDetail, type StatusChange } from '../../src/api/map';
 import { getMe, isLoggedIn } from '../../src/services/auth';
 import InteractionBar from '../../src/components/reports/InteractionBar';
 import ConfirmResolutionButton from '../../src/components/reports/ConfirmResolutionButton';
 import DiscussionSection from '../../src/components/reports/DiscussionSection';
+
+function formatDate(iso: string): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) +
+    ' · ' + d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+}
+
+function StatusHistorySection({ history }: { history: StatusChange[] }) {
+  if (!history.length) return null;
+  return (
+    <View style={s.historyCard}>
+      <Text style={s.historyHeading}>Status History</Text>
+      {history.map((h, i) => (
+        <View key={i} style={[s.historyRow, i < history.length - 1 && s.historyRowBorder]}>
+          <View style={s.historyDot} />
+          <View style={s.historyInfo}>
+            <Text style={s.historyStatus}>
+              {STATUS_LABEL[h.newStatus] ?? h.newStatus}
+            </Text>
+            {h.reason ? <Text style={s.historyReason}>{h.reason}</Text> : null}
+            <Text style={s.historyTime}>{formatDate(h.changedAt)}</Text>
+          </View>
+        </View>
+      ))}
+    </View>
+  );
+}
 
 const STATUS_COLOR: Record<string, string> = {
   UNVERIFIED: COLORS.gray400,
@@ -124,6 +152,13 @@ export default function ReportDetailScreen() {
           )}
         </View>
 
+        {detail.createdAt ? (
+          <View style={s.metaRow}>
+            <Ionicons name="time-outline" size={12} color={COLORS.gray400} />
+            <Text style={s.metaText}>Reported {formatDate(detail.createdAt)}</Text>
+          </View>
+        ) : null}
+
         {detail.description ? (
           <Text style={s.description}>{detail.description}</Text>
         ) : null}
@@ -172,6 +207,8 @@ export default function ReportDetailScreen() {
           )
         }
       />
+
+      <StatusHistorySection history={detail.statusHistory} />
 
       <DiscussionSection reportId={detail.id} currentUserId={currentUserId} />
     </ScrollView>
@@ -246,4 +283,31 @@ const s = StyleSheet.create({
     borderWidth: 1,
     borderColor: COLORS.gray200,
   },
+
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 4, marginBottom: 10 },
+  metaText: { fontSize: 11, color: COLORS.gray400 },
+
+  historyCard: {
+    backgroundColor: COLORS.white,
+    borderRadius: 14,
+    padding: 16,
+    marginTop: 10,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
+  historyHeading: { fontSize: 13, fontWeight: '700', color: COLORS.gray700, marginBottom: 12 },
+  historyRow: { flexDirection: 'row', gap: 10, paddingBottom: 12 },
+  historyRowBorder: { borderBottomWidth: 1, borderBottomColor: COLORS.gray100, marginBottom: 12 },
+  historyDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: COLORS.green500,
+    marginTop: 4,
+    flexShrink: 0,
+  },
+  historyInfo: { flex: 1 },
+  historyStatus: { fontSize: 13, fontWeight: '600', color: COLORS.gray800 },
+  historyReason: { fontSize: 12, color: COLORS.gray500, marginTop: 2 },
+  historyTime: { fontSize: 11, color: COLORS.gray400, marginTop: 3 },
 });

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -38,7 +38,7 @@ function StatusHistorySection({ history }: { history: StatusChange[] }) {
     <View style={s.historyCard}>
       <Text style={s.historyHeading}>Status History</Text>
       {history.map((h, i) => {
-        const { notes, photoUrl } = h.reason ? parseReason(h.reason) : { notes: '', photoUrl: null };
+        const { notes } = h.reason ? parseReason(h.reason) : { notes: '' };
         return (
           <View key={i} style={[s.historyRow, i < history.length - 1 && s.historyRowBorder]}>
             <View style={s.historyDot} />
@@ -47,9 +47,6 @@ function StatusHistorySection({ history }: { history: StatusChange[] }) {
                 {STATUS_LABEL[h.newStatus] ?? h.newStatus}
               </Text>
               {notes ? <Text style={s.historyReason}>{notes}</Text> : null}
-              {photoUrl ? (
-                <Image source={{ uri: photoUrl }} style={s.historyPhoto} resizeMode="cover" />
-              ) : null}
               <Text style={s.historyTime}>{formatDate(h.changedAt)}</Text>
             </View>
           </View>

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -19,23 +19,42 @@ function formatDate(iso: string): string {
     ' · ' + d.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
 }
 
+function parseReason(raw: string): { notes: string; photoUrl: string | null } {
+  // Backend stores reason as "repair_photo_url: <url>; notes: <text>" or plain text
+  const photoMatch = raw.match(/repair_photo_url:\s*(https?:\/\/\S+)/);
+  const notesMatch = raw.match(/notes:\s*(.+?)(?:;|$)/);
+  if (photoMatch || notesMatch) {
+    return {
+      photoUrl: photoMatch ? photoMatch[1].replace(/;$/, '').trim() : null,
+      notes: notesMatch ? notesMatch[1].trim() : '',
+    };
+  }
+  return { notes: raw, photoUrl: null };
+}
+
 function StatusHistorySection({ history }: { history: StatusChange[] }) {
   if (!history.length) return null;
   return (
     <View style={s.historyCard}>
       <Text style={s.historyHeading}>Status History</Text>
-      {history.map((h, i) => (
-        <View key={i} style={[s.historyRow, i < history.length - 1 && s.historyRowBorder]}>
-          <View style={s.historyDot} />
-          <View style={s.historyInfo}>
-            <Text style={s.historyStatus}>
-              {STATUS_LABEL[h.newStatus] ?? h.newStatus}
-            </Text>
-            {h.reason ? <Text style={s.historyReason}>{h.reason}</Text> : null}
-            <Text style={s.historyTime}>{formatDate(h.changedAt)}</Text>
+      {history.map((h, i) => {
+        const { notes, photoUrl } = h.reason ? parseReason(h.reason) : { notes: '', photoUrl: null };
+        return (
+          <View key={i} style={[s.historyRow, i < history.length - 1 && s.historyRowBorder]}>
+            <View style={s.historyDot} />
+            <View style={s.historyInfo}>
+              <Text style={s.historyStatus}>
+                {STATUS_LABEL[h.newStatus] ?? h.newStatus}
+              </Text>
+              {notes ? <Text style={s.historyReason}>{notes}</Text> : null}
+              {photoUrl ? (
+                <Image source={{ uri: photoUrl }} style={s.historyPhoto} resizeMode="cover" />
+              ) : null}
+              <Text style={s.historyTime}>{formatDate(h.changedAt)}</Text>
+            </View>
           </View>
-        </View>
-      ))}
+        );
+      })}
     </View>
   );
 }
@@ -335,6 +354,7 @@ const s = StyleSheet.create({
   },
   historyInfo: { flex: 1 },
   historyStatus: { fontSize: 13, fontWeight: '600', color: COLORS.gray800 },
-  historyReason: { fontSize: 12, color: COLORS.gray500, marginTop: 2 },
-  historyTime: { fontSize: 11, color: COLORS.gray400, marginTop: 3 },
+  historyReason: { fontSize: 12, color: COLORS.gray600, marginTop: 2 },
+  historyPhoto: { width: '100%', height: 140, borderRadius: 8, marginTop: 8 },
+  historyTime: { fontSize: 11, color: COLORS.gray400, marginTop: 4 },
 });

--- a/frontend/src/__tests__/DiscussionSection.test.tsx
+++ b/frontend/src/__tests__/DiscussionSection.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import DiscussionSection from '../components/reports/DiscussionSection';
+import * as commentsApi from '../api/comments';
+
+jest.mock('../api/comments');
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+jest.mock('react-native-svg', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props: any) => React.createElement(View, props),
+    Path: (props: any) => React.createElement(View, props),
+    Circle: (props: any) => React.createElement(View, props),
+    Defs: (props: any) => React.createElement(View, props),
+    LinearGradient: (props: any) => React.createElement(View, props),
+    Stop: (props: any) => React.createElement(View, props),
+    Svg: (props: any) => React.createElement(View, props),
+  };
+});
+
+const mockGetComments = commentsApi.getComments as jest.MockedFunction<typeof commentsApi.getComments>;
+const mockPostComment = commentsApi.postComment as jest.MockedFunction<typeof commentsApi.postComment>;
+
+function makeComment(overrides: Partial<commentsApi.Comment> = {}): commentsApi.Comment {
+  return {
+    id: 'c1',
+    body: 'The ramp is still broken.',
+    createdAt: new Date().toISOString(),
+    author: {
+      userId: 'u1',
+      fullName: 'Ayşe Y.',
+      role: 'REGISTERED_USER',
+      mobilityAidType: null,
+    },
+    ...overrides,
+  };
+}
+
+const BASE_PROPS = {
+  reportId: 'r1',
+  currentUserId: 'user-1',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetComments.mockResolvedValue([]);
+  mockPostComment.mockResolvedValue(makeComment({ id: 'c-new', body: 'New comment' }));
+});
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+it('shows empty state when there are no comments', async () => {
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(getByTestId('discussion-empty')).toBeTruthy());
+});
+
+it('renders a row for each comment', async () => {
+  mockGetComments.mockResolvedValue([
+    makeComment({ id: 'c1' }),
+    makeComment({ id: 'c2', body: 'Second comment' }),
+  ]);
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => {
+    expect(getByTestId('comment-c1')).toBeTruthy();
+    expect(getByTestId('comment-c2')).toBeTruthy();
+  });
+});
+
+it('renders the author name for each comment', async () => {
+  mockGetComments.mockResolvedValue([makeComment({ id: 'c1', author: { userId: 'u1', fullName: 'Mehmet K.', role: 'REGISTERED_USER', mobilityAidType: null } })]);
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(getByTestId('comment-author-c1').props.children).toBe('Mehmet K.'));
+});
+
+// ── Role badge ────────────────────────────────────────────────────────────────
+
+it('renders TrustedContributorBadge for TRUSTED_CONTRIBUTOR role', async () => {
+  mockGetComments.mockResolvedValue([
+    makeComment({ id: 'c1', author: { userId: 'u1', fullName: 'Trusted User', role: 'TRUSTED_CONTRIBUTOR', mobilityAidType: null } }),
+  ]);
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(getByTestId('comment-badge-c1')).toBeTruthy());
+});
+
+it('does not render the badge for a regular user', async () => {
+  mockGetComments.mockResolvedValue([
+    makeComment({ id: 'c1', author: { userId: 'u1', fullName: 'Regular User', role: 'REGISTERED_USER', mobilityAidType: null } }),
+  ]);
+  const { queryByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(queryByTestId('comment-badge-c1')).toBeNull());
+});
+
+// ── Mobility aid label ────────────────────────────────────────────────────────
+
+it('renders mobility aid label when mobilityAidType is WHEELCHAIR', async () => {
+  mockGetComments.mockResolvedValue([
+    makeComment({ id: 'c1', author: { userId: 'u1', fullName: 'A', role: 'REGISTERED_USER', mobilityAidType: 'WHEELCHAIR' } }),
+  ]);
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(getByTestId('comment-aid-c1').props.children).toBe('Wheelchair user'));
+});
+
+it('renders mobility aid label for ELECTRIC_WHEELCHAIR', async () => {
+  mockGetComments.mockResolvedValue([
+    makeComment({ id: 'c1', author: { userId: 'u1', fullName: 'A', role: 'REGISTERED_USER', mobilityAidType: 'ELECTRIC_WHEELCHAIR' } }),
+  ]);
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(getByTestId('comment-aid-c1').props.children).toBe('Electric wheelchair user'));
+});
+
+it('does not render the mobility aid label when mobilityAidType is NONE', async () => {
+  mockGetComments.mockResolvedValue([
+    makeComment({ id: 'c1', author: { userId: 'u1', fullName: 'A', role: 'REGISTERED_USER', mobilityAidType: 'NONE' } }),
+  ]);
+  const { queryByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(queryByTestId('comment-aid-c1')).toBeNull());
+});
+
+it('does not render the mobility aid label when mobilityAidType is null', async () => {
+  mockGetComments.mockResolvedValue([
+    makeComment({ id: 'c1', author: { userId: 'u1', fullName: 'A', role: 'REGISTERED_USER', mobilityAidType: null } }),
+  ]);
+  const { queryByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => expect(queryByTestId('comment-aid-c1')).toBeNull());
+});
+
+// ── Guest prompt ──────────────────────────────────────────────────────────────
+
+it('shows the guest prompt and no input for guests', async () => {
+  const { getByTestId, queryByTestId } = render(
+    <DiscussionSection {...BASE_PROPS} currentUserId="" />,
+  );
+  await waitFor(() => {
+    expect(getByTestId('discussion-guest-prompt')).toBeTruthy();
+    expect(queryByTestId('discussion-input-row')).toBeNull();
+  });
+});
+
+it('shows the input row and no guest prompt for logged-in users', async () => {
+  const { getByTestId, queryByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => {
+    expect(getByTestId('discussion-input-row')).toBeTruthy();
+    expect(queryByTestId('discussion-guest-prompt')).toBeNull();
+  });
+});
+
+// ── Post flow ─────────────────────────────────────────────────────────────────
+
+it('calls postComment with the typed body on submit', async () => {
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => getByTestId('comment-input'));
+
+  fireEvent.changeText(getByTestId('comment-input'), 'Great report!');
+  await act(async () => { fireEvent.press(getByTestId('comment-submit')); });
+
+  expect(mockPostComment).toHaveBeenCalledWith('r1', 'Great report!');
+});
+
+it('appends the new comment to the list after successful post', async () => {
+  mockPostComment.mockResolvedValue(makeComment({ id: 'c-new', body: 'My new comment' }));
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => getByTestId('comment-input'));
+
+  fireEvent.changeText(getByTestId('comment-input'), 'My new comment');
+  await act(async () => { fireEvent.press(getByTestId('comment-submit')); });
+
+  await waitFor(() => expect(getByTestId('comment-c-new')).toBeTruthy());
+});
+
+it('clears the input after successful post', async () => {
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => getByTestId('comment-input'));
+
+  fireEvent.changeText(getByTestId('comment-input'), 'Hello');
+  await act(async () => { fireEvent.press(getByTestId('comment-submit')); });
+
+  await waitFor(() => expect(getByTestId('comment-input').props.value).toBe(''));
+});
+
+it('does not call postComment when body is empty or whitespace', async () => {
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => getByTestId('comment-input'));
+
+  fireEvent.changeText(getByTestId('comment-input'), '   ');
+  fireEvent.press(getByTestId('comment-submit'));
+
+  expect(mockPostComment).not.toHaveBeenCalled();
+});
+
+it('does not call postComment twice on double-tap', async () => {
+  let resolve!: (v: any) => void;
+  mockPostComment.mockReturnValue(new Promise((r) => { resolve = r; }));
+  const { getByTestId } = render(<DiscussionSection {...BASE_PROPS} />);
+  await waitFor(() => getByTestId('comment-input'));
+
+  fireEvent.changeText(getByTestId('comment-input'), 'Hello');
+  await act(async () => {
+    fireEvent.press(getByTestId('comment-submit'));
+    fireEvent.press(getByTestId('comment-submit'));
+  });
+
+  expect(mockPostComment).toHaveBeenCalledTimes(1);
+  await act(async () => { resolve(makeComment()); });
+});

--- a/frontend/src/api/comments.ts
+++ b/frontend/src/api/comments.ts
@@ -1,0 +1,52 @@
+import { API_BASE } from '../constants/theme';
+import { getAccessToken } from '../services/auth';
+
+export interface CommentAuthor {
+  userId: string;
+  fullName: string;
+  role: string;
+  mobilityAidType: string | null;
+}
+
+export interface Comment {
+  id: string;
+  body: string;
+  createdAt: string;
+  author: CommentAuthor;
+}
+
+function authHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = getAccessToken();
+  if (token) h['Authorization'] = `Bearer ${token}`;
+  return h;
+}
+
+export async function getComments(reportId: string): Promise<Comment[]> {
+  try {
+    const res = await fetch(`${API_BASE}/api/reports/${reportId}/comments/`, {
+      headers: authHeaders(),
+    });
+    if (!res.ok) return [];
+    return await res.json();
+  } catch {
+    return [];
+  }
+}
+
+export async function postComment(
+  reportId: string,
+  body: string,
+): Promise<Comment | null> {
+  try {
+    const res = await fetch(`${API_BASE}/api/reports/${reportId}/comments/`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({ body }),
+    });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -17,6 +17,14 @@ export interface PhotoItem {
   uploadedAt?: string;
 }
 
+export interface StatusChange {
+  oldStatus: string;
+  newStatus: string;
+  changedBy: string;
+  reason: string;
+  changedAt: string;
+}
+
 export interface ObstacleDetail extends Obstacle {
   photos: PhotoItem[];
   upvoteCount: number;
@@ -26,6 +34,8 @@ export interface ObstacleDetail extends Obstacle {
   userFlagged: boolean;
   userConfirmed: boolean;
   reporterId: string;
+  createdAt: string;
+  statusHistory: StatusChange[];
 }
 
 export interface SearchResult {
@@ -116,6 +126,14 @@ export async function fetchObstacleDetail(id: string): Promise<ObstacleDetail | 
       userFlagged: raw.userFlagged ?? false,
       userConfirmed: raw.userConfirmed ?? false,
       reporterId: raw.reporterId ?? '',
+      createdAt: raw.createdAt ?? '',
+      statusHistory: (raw.statusHistory ?? []).map((h: any) => ({
+        oldStatus: h.oldStatus ?? '',
+        newStatus: h.newStatus ?? '',
+        changedBy: h.changedBy ?? '',
+        reason: h.reason ?? '',
+        changedAt: h.changedAt ?? '',
+      })),
     };
   } catch {
     return null;

--- a/frontend/src/components/reports/DiscussionSection.tsx
+++ b/frontend/src/components/reports/DiscussionSection.tsx
@@ -21,6 +21,28 @@ const AID_LABEL: Record<string, string> = {
   HAND_CART: 'Hand cart user',
 };
 
+const AVATAR_COLORS = ['#27724A', '#2563EB', '#7C3AED', '#DB2777', '#D97706', '#0891B2'];
+
+function avatarColor(userId: string): string {
+  let h = 0;
+  for (const ch of userId) h = (h * 31 + ch.charCodeAt(0)) & 0xffff;
+  return AVATAR_COLORS[h % AVATAR_COLORS.length];
+}
+
+function initials(fullName: string): string {
+  return fullName.split(' ').slice(0, 2).map(w => w[0]?.toUpperCase() ?? '').join('');
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
 interface Props {
   reportId: string;
   currentUserId: string;
@@ -57,38 +79,52 @@ export default function DiscussionSection({ reportId, currentUserId }: Props) {
 
   return (
     <View style={s.section} testID="discussion-section">
-      <Text style={s.heading}>Discussion</Text>
+      <View style={s.sectionHeader}>
+        <Text style={s.heading}>Discussion</Text>
+        {!loading && comments.length > 0 && (
+          <View style={s.countBadge}>
+            <Text style={s.countText}>{comments.length}</Text>
+          </View>
+        )}
+      </View>
 
       {loading ? (
-        <ActivityIndicator size="small" color={COLORS.green700} style={{ marginVertical: 12 }} />
+        <ActivityIndicator size="small" color={COLORS.green700} style={{ marginVertical: 16 }} />
       ) : comments.length === 0 ? (
-        <Text style={s.empty} testID="discussion-empty">No comments yet. Be the first to share your experience.</Text>
+        <View style={s.emptyState} testID="discussion-empty">
+          <Ionicons name="chatbubbles-outline" size={28} color={COLORS.gray300} />
+          <Text style={s.emptyText}>No comments yet.</Text>
+          <Text style={s.emptySubtext}>Be the first to share your experience.</Text>
+        </View>
       ) : (
         comments.map((c) => (
           <View key={c.id} style={s.comment} testID={`comment-${c.id}`}>
-            <View style={s.commentHeader}>
-              <Text style={s.authorName} testID={`comment-author-${c.id}`}>{c.author.fullName}</Text>
-              {c.author.role === 'TRUSTED_CONTRIBUTOR' && (
-                <TrustedContributorBadge
-                  size={14}
-                  testID={`comment-badge-${c.id}`}
-                />
-              )}
+            <View style={[s.avatar, { backgroundColor: avatarColor(c.author.userId) }]}>
+              <Text style={s.avatarText}>{initials(c.author.fullName)}</Text>
             </View>
-            {c.author.mobilityAidType && c.author.mobilityAidType !== 'NONE' && (
-              <Text style={s.aidLabel} testID={`comment-aid-${c.id}`}>
-                {AID_LABEL[c.author.mobilityAidType] ?? c.author.mobilityAidType}
-              </Text>
-            )}
-            <Text style={s.body} testID={`comment-body-${c.id}`}>{c.body}</Text>
+            <View style={s.commentContent}>
+              <View style={s.commentTop}>
+                <Text style={s.authorName} testID={`comment-author-${c.id}`}>{c.author.fullName}</Text>
+                {c.author.role === 'TRUSTED_CONTRIBUTOR' && (
+                  <TrustedContributorBadge size={13} testID={`comment-badge-${c.id}`} />
+                )}
+                <Text style={s.timestamp}>{timeAgo(c.createdAt)}</Text>
+              </View>
+              {c.author.mobilityAidType && c.author.mobilityAidType !== 'NONE' && (
+                <Text style={s.aidLabel} testID={`comment-aid-${c.id}`}>
+                  {AID_LABEL[c.author.mobilityAidType] ?? c.author.mobilityAidType}
+                </Text>
+              )}
+              <Text style={s.body} testID={`comment-body-${c.id}`}>{c.body}</Text>
+            </View>
           </View>
         ))
       )}
 
       {isGuest ? (
         <View style={s.guestPrompt} testID="discussion-guest-prompt">
-          <Ionicons name="chatbubble-outline" size={16} color={COLORS.gray400} />
-          <Text style={s.guestText}>Sign in to comment</Text>
+          <Ionicons name="lock-closed-outline" size={14} color={COLORS.gray400} />
+          <Text style={s.guestText}>Sign in to join the discussion</Text>
         </View>
       ) : (
         <View style={s.inputRow} testID="discussion-input-row">
@@ -109,7 +145,7 @@ export default function DiscussionSection({ reportId, currentUserId }: Props) {
           >
             {submitting
               ? <ActivityIndicator size="small" color={COLORS.white} />
-              : <Ionicons name="send" size={16} color={COLORS.white} />}
+              : <Ionicons name="send" size={15} color={COLORS.white} />}
           </TouchableOpacity>
         </View>
       )}
@@ -118,53 +154,83 @@ export default function DiscussionSection({ reportId, currentUserId }: Props) {
 }
 
 const s = StyleSheet.create({
-  section: { marginTop: 24 },
-  heading: { fontSize: 16, fontWeight: '700', color: COLORS.gray900, marginBottom: 12 },
-  empty: { fontSize: 13, color: COLORS.gray400, marginBottom: 12 },
-  comment: {
-    backgroundColor: COLORS.white,
+  section: { marginTop: 28 },
+  sectionHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 14 },
+  heading: { fontSize: 15, fontWeight: '700', color: COLORS.gray900 },
+  countBadge: {
+    backgroundColor: COLORS.green100,
     borderRadius: 10,
+    paddingHorizontal: 7,
+    paddingVertical: 1,
+  },
+  countText: { fontSize: 11, fontWeight: '700', color: COLORS.green700 },
+
+  emptyState: { alignItems: 'center', paddingVertical: 24, gap: 4 },
+  emptyText: { fontSize: 14, fontWeight: '600', color: COLORS.gray400 },
+  emptySubtext: { fontSize: 12, color: COLORS.gray300 },
+
+  comment: {
+    flexDirection: 'row',
+    gap: 10,
+    backgroundColor: COLORS.white,
+    borderRadius: 12,
     padding: 12,
     marginBottom: 8,
     borderWidth: 1,
     borderColor: COLORS.gray200,
   },
-  commentHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 2 },
-  authorName: { fontSize: 13, fontWeight: '700', color: COLORS.gray800 },
-  aidLabel: { fontSize: 11, color: COLORS.gray500, marginBottom: 4 },
-  body: { fontSize: 13, color: COLORS.gray700, lineHeight: 18 },
+  avatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  avatarText: { fontSize: 13, fontWeight: '700', color: COLORS.white },
+  commentContent: { flex: 1 },
+  commentTop: { flexDirection: 'row', alignItems: 'center', gap: 6, flexWrap: 'wrap', marginBottom: 2 },
+  authorName: { fontSize: 13, fontWeight: '700', color: COLORS.gray900 },
+  timestamp: { fontSize: 11, color: COLORS.gray400, marginLeft: 'auto' },
+  aidLabel: { fontSize: 11, color: COLORS.green700, fontWeight: '500', marginBottom: 4 },
+  body: { fontSize: 13, color: COLORS.gray700, lineHeight: 19 },
+
   guestPrompt: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
-    paddingVertical: 12,
-    borderTopWidth: 1,
-    borderTopColor: COLORS.gray200,
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 14,
+    borderRadius: 10,
+    backgroundColor: COLORS.gray50,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
     marginTop: 4,
   },
   guestText: { fontSize: 13, color: COLORS.gray500 },
+
   inputRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 8, marginTop: 4 },
   input: {
     flex: 1,
     borderWidth: 1.5,
-    borderColor: COLORS.gray300,
-    borderRadius: 10,
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+    borderColor: COLORS.gray200,
+    borderRadius: 12,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
     fontSize: 13,
     color: COLORS.gray900,
     backgroundColor: COLORS.white,
-    minHeight: 40,
+    minHeight: 42,
     maxHeight: 100,
     textAlignVertical: 'top',
   },
   submitBtn: {
-    width: 38,
-    height: 38,
-    borderRadius: 10,
+    width: 42,
+    height: 42,
+    borderRadius: 12,
     backgroundColor: COLORS.green700,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  submitDisabled: { opacity: 0.4 },
+  submitDisabled: { opacity: 0.35 },
 });

--- a/frontend/src/components/reports/DiscussionSection.tsx
+++ b/frontend/src/components/reports/DiscussionSection.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../../constants/theme';
+import { TrustedContributorBadge } from '../profile/TrustedContributorBadge';
+import { getComments, postComment, type Comment } from '../../api/comments';
+
+const AID_LABEL: Record<string, string> = {
+  WHEELCHAIR: 'Wheelchair user',
+  ELECTRIC_WHEELCHAIR: 'Electric wheelchair user',
+  WALKER: 'Walker user',
+  CRUTCHES: 'Crutches user',
+  STROLLER: 'Stroller user',
+  HAND_CART: 'Hand cart user',
+};
+
+interface Props {
+  reportId: string;
+  currentUserId: string;
+}
+
+export default function DiscussionSection({ reportId, currentUserId }: Props) {
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [body, setBody] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const inFlight = useRef(false);
+
+  const isGuest = currentUserId === '';
+
+  useEffect(() => {
+    getComments(reportId).then((data) => {
+      setComments(data);
+      setLoading(false);
+    });
+  }, [reportId]);
+
+  async function handleSubmit() {
+    if (inFlight.current || !body.trim()) return;
+    inFlight.current = true;
+    setSubmitting(true);
+    const comment = await postComment(reportId, body.trim());
+    setSubmitting(false);
+    inFlight.current = false;
+    if (comment) {
+      setComments((prev) => [...prev, comment]);
+      setBody('');
+    }
+  }
+
+  return (
+    <View style={s.section} testID="discussion-section">
+      <Text style={s.heading}>Discussion</Text>
+
+      {loading ? (
+        <ActivityIndicator size="small" color={COLORS.green700} style={{ marginVertical: 12 }} />
+      ) : comments.length === 0 ? (
+        <Text style={s.empty} testID="discussion-empty">No comments yet. Be the first to share your experience.</Text>
+      ) : (
+        comments.map((c) => (
+          <View key={c.id} style={s.comment} testID={`comment-${c.id}`}>
+            <View style={s.commentHeader}>
+              <Text style={s.authorName} testID={`comment-author-${c.id}`}>{c.author.fullName}</Text>
+              {c.author.role === 'TRUSTED_CONTRIBUTOR' && (
+                <TrustedContributorBadge
+                  size={14}
+                  testID={`comment-badge-${c.id}`}
+                />
+              )}
+            </View>
+            {c.author.mobilityAidType && c.author.mobilityAidType !== 'NONE' && (
+              <Text style={s.aidLabel} testID={`comment-aid-${c.id}`}>
+                {AID_LABEL[c.author.mobilityAidType] ?? c.author.mobilityAidType}
+              </Text>
+            )}
+            <Text style={s.body} testID={`comment-body-${c.id}`}>{c.body}</Text>
+          </View>
+        ))
+      )}
+
+      {isGuest ? (
+        <View style={s.guestPrompt} testID="discussion-guest-prompt">
+          <Ionicons name="chatbubble-outline" size={16} color={COLORS.gray400} />
+          <Text style={s.guestText}>Sign in to comment</Text>
+        </View>
+      ) : (
+        <View style={s.inputRow} testID="discussion-input-row">
+          <TextInput
+            testID="comment-input"
+            style={s.input}
+            value={body}
+            onChangeText={setBody}
+            placeholder="Add a comment…"
+            placeholderTextColor={COLORS.gray400}
+            multiline
+          />
+          <TouchableOpacity
+            testID="comment-submit"
+            style={[s.submitBtn, (!body.trim() || submitting) && s.submitDisabled]}
+            onPress={handleSubmit}
+            disabled={!body.trim() || submitting}
+          >
+            {submitting
+              ? <ActivityIndicator size="small" color={COLORS.white} />
+              : <Ionicons name="send" size={16} color={COLORS.white} />}
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  section: { marginTop: 24 },
+  heading: { fontSize: 16, fontWeight: '700', color: COLORS.gray900, marginBottom: 12 },
+  empty: { fontSize: 13, color: COLORS.gray400, marginBottom: 12 },
+  comment: {
+    backgroundColor: COLORS.white,
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+  },
+  commentHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 2 },
+  authorName: { fontSize: 13, fontWeight: '700', color: COLORS.gray800 },
+  aidLabel: { fontSize: 11, color: COLORS.gray500, marginBottom: 4 },
+  body: { fontSize: 13, color: COLORS.gray700, lineHeight: 18 },
+  guestPrompt: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: COLORS.gray200,
+    marginTop: 4,
+  },
+  guestText: { fontSize: 13, color: COLORS.gray500 },
+  inputRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 8, marginTop: 4 },
+  input: {
+    flex: 1,
+    borderWidth: 1.5,
+    borderColor: COLORS.gray300,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 13,
+    color: COLORS.gray900,
+    backgroundColor: COLORS.white,
+    minHeight: 40,
+    maxHeight: 100,
+    textAlignVertical: 'top',
+  },
+  submitBtn: {
+    width: 38,
+    height: 38,
+    borderRadius: 10,
+    backgroundColor: COLORS.green700,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  submitDisabled: { opacity: 0.4 },
+});


### PR DESCRIPTION
## Description
Adds a full discussion section to the report detail screen and the backend comments endpoint that powers it. Also surfaces the report's created date and status change timeline on the same screen.

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [x] `style` — formatting, missing semicolons, etc.

## Changes
- **Backend:** `Comment` model + migration, `CommentAuthorSerializer` / `CommentSerializer` / `CommentCreateSerializer`, `GET /api/reports/<id>/comments/` (public) and `POST` (authenticated), URL wired up — 16 backend tests
- **Frontend – Discussion:** `src/api/comments.ts` API helpers, `DiscussionSection` component (avatar circles with initials, author name, trusted-contributor badge, mobility aid label, relative timestamps, guest prompt, double-tap–guarded post form) mounted on the report detail screen — 16 frontend tests
- **Frontend – History:** `StatusChange` interface + `createdAt` / `statusHistory` added to `ObstacleDetail`; report card shows "Reported <date>" meta row; dot-timeline `StatusHistorySection` renders each status change with label, optional reason, and timestamp (hidden when empty)
- **UI polish:** report detail screen redesigned with white card layout, pill chips (status dot + category + indoor/outdoor), interaction bar card; `DiscussionSection` updated with comment count badge, centered empty state, and polished input area

## How to Test
1. Run backend: `docker compose up` then `python manage.py test apps.reports.test_comments`
2. Run frontend tests: `npx jest --testPathPattern="DiscussionSection"`
3. Open any report detail screen as a guest — verify comment list loads and input is hidden
4. Sign in, post a comment — verify it appears immediately and the count badge updates
5. Open a report that has status changes — verify the history timeline renders below the resolution button
6. Open a report with no status changes — verify no history section appears

## Screenshots (if applicable)
_See redesigned detail screen: white card with status/category/context pill chips, "Reported" meta row, dot-timeline status history, discussion section with avatar circles and relative timestamps._

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #237
- Closes #236
- Closes #234

## Notes
Migration `0002_comment` is force-added (root `.gitignore` excludes `backend/apps/*/migrations/`). Backend tests require Docker; they cannot run locally without the full compose stack.
