### PR TITLE
feat: show UNVERIFIED reports on the map (hollow + dashed) and submit reports as UNVERIFIED by default

### DIFF
--- a/backend/apps/map/selectors.py
+++ b/backend/apps/map/selectors.py
@@ -5,7 +5,7 @@ from apps.reports.models import InteractionType, Report, ReportStatus
 
 
 def get_obstacles_in_bbox(sw_lat, sw_lng, ne_lat, ne_lng, include_passive=False, status=None):
-    allowed_statuses = [ReportStatus.VERIFIED]
+    allowed_statuses = [ReportStatus.VERIFIED, ReportStatus.UNVERIFIED]
     if include_passive:
         allowed_statuses.append(ReportStatus.PASSIVE)
 
@@ -36,6 +36,7 @@ def get_obstacle_detail(report_id):
                 pk=report_id,
                 status__in=[
                     ReportStatus.VERIFIED,
+                    ReportStatus.UNVERIFIED,
                     ReportStatus.PASSIVE,
                     # Citizens need access to RESOLVED_AWAITING_VALIDATION reports so
                     # they can confirm the repair from a status-change notification,

--- a/backend/apps/map/tests.py
+++ b/backend/apps/map/tests.py
@@ -54,11 +54,12 @@ class GetObstaclesInBboxTest(TestCase):
         qs = get_obstacles_in_bbox(41.0820, 29.0490, 41.0850, 29.0530)
         self.assertEqual(qs.count(), 0)
 
-    def test_excludes_unverified_reports(self):
+    def test_includes_unverified_reports(self):
         from apps.map.selectors import get_obstacles_in_bbox
         make_report(self.user, report_status=ReportStatus.UNVERIFIED)
         qs = get_obstacles_in_bbox(41.0820, 29.0490, 41.0850, 29.0530)
-        self.assertEqual(qs.count(), 0)
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs.first().status, ReportStatus.UNVERIFIED)
 
     def test_excludes_passive_by_default(self):
         from apps.map.selectors import get_obstacles_in_bbox
@@ -108,11 +109,12 @@ class GetObstacleDetailTest(TestCase):
         result = get_obstacle_detail(report.pk)
         self.assertIsNotNone(result)
 
-    def test_returns_none_for_unverified(self):
+    def test_returns_unverified_report(self):
         from apps.map.selectors import get_obstacle_detail
         report = make_report(self.user, report_status=ReportStatus.UNVERIFIED)
         result = get_obstacle_detail(report.pk)
-        self.assertIsNone(result)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.pk, report.pk)
 
     def test_returns_resolved_awaiting_validation_report(self):
         # Citizens hitting "View report" from a status-change notification, and
@@ -276,10 +278,11 @@ class ObstacleDetailViewTest(TestCase):
         self.assertIn("lat", location)
         self.assertIn("lng", location)
 
-    def test_unverified_returns_404(self):
+    def test_unverified_returns_200(self):
         report = make_report(self.user, report_status=ReportStatus.UNVERIFIED)
         response = self.client.get(self._url(report.pk))
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], ReportStatus.UNVERIFIED)
 
     def test_nonexistent_returns_404(self):
         import uuid

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -55,7 +55,6 @@ def create_report(reporter, validated_data) -> Report:
                 context=validated_data["context"],
                 latitude=location["lat"],
                 longitude=location["lng"],
-                status=ReportStatus.VERIFIED,
             )
 
             photo_objects = []

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -54,7 +54,7 @@ class CreateReportServiceTest(TestCase):
 
         self.assertIsNotNone(report.pk)
         self.assertEqual(report.reporter, self.user)
-        self.assertEqual(report.status, ReportStatus.VERIFIED)
+        self.assertEqual(report.status, ReportStatus.UNVERIFIED)
         self.assertEqual(report.category, ObstacleCategory.BROKEN_RAMP)
 
     @patch("apps.reports.services._get_supabase_client")
@@ -235,7 +235,7 @@ class ReportCreateViewTest(TestCase):
         self.assertIn("autoVerified", data)
         self.assertIn("duplicateCandidate", data)
         self.assertIn("createdAt", data)
-        self.assertEqual(data["status"], ReportStatus.VERIFIED)
+        self.assertEqual(data["status"], ReportStatus.UNVERIFIED)
         self.assertFalse(data["autoVerified"])
         self.assertIsNone(data["duplicateCandidate"])
 

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -83,11 +83,15 @@ const MAP_HTML = `<!DOCTYPE html>
     obstacles.forEach(function(obs) {
       if (obs.isIndoor && currentZoom < ${HIGH_DETAIL_ZOOM}) return;
       var isPassive = obs.status === 'PASSIVE';
+      var isUnverified = obs.status === 'UNVERIFIED';
       var color = CATEGORY_COLOR[obs.category] || '#9CA3AF';
       var marker;
       if (obs.isIndoor) {
+        var indoorBg = isUnverified ? 'white' : color;
+        var indoorBorder = isUnverified ? ('3px dashed ' + color) : '3px solid white';
+        var indoorTextColor = isUnverified ? color : 'white';
         var indoorIcon = L.divIcon({
-          html: '<div style="width:22px;height:22px;border-radius:50%;background:' + color + ';border:3px solid white;box-shadow:0 3px 8px rgba(0,0,0,0.45);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:800;color:white;font-family:system-ui,sans-serif;line-height:1">i<\/div>',
+          html: '<div style="width:22px;height:22px;border-radius:50%;background:' + indoorBg + ';border:' + indoorBorder + ';box-shadow:0 3px 8px rgba(0,0,0,0.45);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:800;color:' + indoorTextColor + ';font-family:system-ui,sans-serif;line-height:1">i<\/div>',
           className: '',
           iconSize: [22, 22],
           iconAnchor: [11, 11]
@@ -98,9 +102,12 @@ const MAP_HTML = `<!DOCTYPE html>
         });
       } else {
         marker = L.circleMarker([obs.latitude, obs.longitude], {
-          radius: 10, color: color, fillColor: color,
-          fillOpacity: isPassive ? 0.4 : 0.85,
-          weight: isPassive ? 1 : 2, opacity: isPassive ? 0.5 : 1
+          radius: 10, color: color,
+          fillColor: isUnverified ? 'white' : color,
+          fillOpacity: isPassive ? 0.4 : (isUnverified ? 1 : 0.85),
+          weight: isPassive ? 1 : (isUnverified ? 3 : 2),
+          opacity: isPassive ? 0.5 : 1,
+          dashArray: isUnverified ? '4 3' : null
         });
       }
       var statusColor = STATUS_COLOR[obs.status] || '#9CA3AF';

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -61,15 +61,18 @@ const ORIGIN_ICON = makeCircleIcon(COLORS.green700);
 const DEST_ICON = makeCircleIcon(COLORS.red500);
 const SEARCH_PIN_ICON = makeCircleIcon(COLORS.red500);
 
-/** Indoor obstacle: circle with a small white 'i' badge — same colour coding as outdoor. */
-const makeIndoorCircleIcon = (color: string) =>
+/** Indoor obstacle: circle with a small white 'i' badge — same colour coding as outdoor.
+ *  When `hollow` is true (unverified), inverts to white background +
+ *  dashed category-colored border + category-colored 'i'. */
+const makeIndoorCircleIcon = (color: string, hollow = false) =>
   L.divIcon({
     html: `<div style="
       width:22px;height:22px;border-radius:50%;
-      background:${color};border:3px solid white;
+      background:${hollow ? 'white' : color};
+      border:3px ${hollow ? 'dashed' : 'solid'} ${hollow ? color : 'white'};
       box-shadow:0 3px 8px rgba(0,0,0,0.45);
       display:flex;align-items:center;justify-content:center;
-      font-size:11px;font-weight:800;color:white;
+      font-size:11px;font-weight:800;color:${hollow ? color : 'white'};
       font-family:system-ui,sans-serif;line-height:1;
     ">i</div>`,
     className: '',
@@ -523,6 +526,7 @@ export default function MapView() {
           {filterVisibleObstacles(obstacles).map((obs) => {
             if (obs.isIndoor && zoom < HIGH_DETAIL_ZOOM) return null;
             const isPassive = obs.status === 'PASSIVE';
+            const isUnverified = obs.status === 'UNVERIFIED';
             const color = CATEGORY_COLOR[obs.category] ?? COLORS.gray500;
             const cached = detailMap[obs.id];
             const detail = cached && cached !== 'loading' ? (cached as ObstacleDetail) : undefined;
@@ -533,7 +537,7 @@ export default function MapView() {
                 <Marker
                   key={obs.id}
                   position={[obs.latitude, obs.longitude]}
-                  icon={makeIndoorCircleIcon(color)}
+                  icon={makeIndoorCircleIcon(color, isUnverified)}
                   opacity={isPassive ? 0.5 : 1}
                   eventHandlers={{ click: () => handlePinClick(obs.id) }}
                 >
@@ -555,10 +559,12 @@ export default function MapView() {
                 center={[obs.latitude, obs.longitude]}
                 radius={10}
                 pathOptions={{
-                  color, fillColor: color,
-                  fillOpacity: isPassive ? 0.4 : 0.85,
-                  weight: isPassive ? 1 : 2,
+                  color,
+                  fillColor: isUnverified ? 'white' : color,
+                  fillOpacity: isPassive ? 0.4 : (isUnverified ? 1 : 0.85),
+                  weight: isPassive ? 1 : (isUnverified ? 3 : 2),
                   opacity: isPassive ? 0.5 : 1,
+                  dashArray: isUnverified ? '4 3' : undefined,
                 }}
                 eventHandlers={{ click: () => handlePinClick(obs.id) }}
               >


### PR DESCRIPTION
## Description

Reverts the dev shortcut that auto-verified every new report on submit. New reports now start as `UNVERIFIED` and are promoted to `VERIFIED` via the existing upvote-threshold path. The map now shows unverified reports too, with a clearly distinct visual style so they're never confused with verified ones.

Routing is unchanged — verified obstacles are still actively avoided, unverified ones still only generate "nearby" warnings (`apps/routing/services.py`).

## Type of Change
- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes
- **Backend (`reports`):** drop `status=ReportStatus.VERIFIED` in `create_report`; the model default (`UNVERIFIED`) now applies. Existing auto-verify-at-threshold logic in `toggle_upvote` is unchanged.
- **Backend (`map`):** include `UNVERIFIED` in `get_obstacles_in_bbox` allowed_statuses so the map endpoint returns them, and in `get_obstacle_detail` so tapping an unverified marker loads the detail screen instead of returning 404.
- **Frontend (`MapView`):** UNVERIFIED markers render as **hollow** (white fill, category-colored dashed border, weight 3) on both native (`MapView.tsx`, WebView Leaflet HTML) and web (`MapView.web.tsx`, react-leaflet). Indoor unverified flips the "i" pin to white background with category-colored "i" and a dashed border. Verified keeps its solid colored fill; PASSIVE opacity treatment is preserved on top so all three states stay visually distinct.
- **Tests:** `apps/reports/tests.py` `test_creates_report_in_db` now asserts `UNVERIFIED`; `test_create_report_returns_201` asserts the API responds with `UNVERIFIED`. `apps/map/tests.py`: `test_excludes_unverified_reports` → `test_includes_unverified_reports`, `test_returns_none_for_unverified` → `test_returns_unverified_report`, `test_unverified_returns_404` → `test_unverified_returns_200`.

## How to Test
1. Start the stack: `docker compose up -d`.
2. Backend tests: `docker exec bounswe2026group3-backend-1 python manage.py test apps.reports apps.map --settings=config.test_settings` → 105 / 105 pass.
3. Frontend tests: `cd frontend && npx jest` → 138 / 142 pass (4 pre-existing failures in `mobilityProfileApi.test.ts` and `ReportForm.test.tsx`, unrelated, also fail on `main`).
4. Manual:
   - Submit a new report → it appears as a hollow, dashed marker (category color preserved).
   - Tap the unverified marker → detail screen loads, status reads "Unverified".
   - To trigger auto-promote without 5 upvotes, set `AUTO_VERIFY_UPVOTE_THRESHOLD=0` in the root `.env` and `docker compose restart backend`. Upvote once from a different account → marker switches to solid fill on next refresh, status becomes "Verified".
   - Routing past an unverified obstacle should produce a "nearby" warning, not avoidance.

## Screenshots (if applicable)
_See manual test results from reviewer; main visual change is the hollow + dashed marker for UNVERIFIED reports._

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #235

## Notes
The detail-selector change (including `UNVERIFIED` in `get_obstacle_detail`) wasn't explicit in the issue's acceptance criteria but is required for the feature to work end-to-end — without it, tapping a now-visible unverified marker would 404.