### PR TITLE
fix(frontend): prefix mobility profile requests with /api/

### DIFF
--- a/frontend/src/__tests__/mobilityProfileApi.test.ts
+++ b/frontend/src/__tests__/mobilityProfileApi.test.ts
@@ -1,132 +1,142 @@
 /**
- * Unit tests for the mobility profile mock API service.
- * These tests exercise the mock path (MOCK = true) which is the active
- * code path until the backend implements the endpoints.
+ * Unit tests for the mobility profile API helpers.
+ * Exercises the real (non-mock) path: every helper is expected to hit
+ * `/api/users/me/mobility-profile` (issue #231 — the missing `/api/`
+ * prefix that caused 404s in the wild).
  */
 
 jest.mock('../services/auth', () => ({
   getAccessToken: () => 'mock-access-token',
 }));
 
-// Isolate module state between tests by re-importing after each reset
+jest.mock('../constants/theme', () => ({
+  API_BASE: 'http://test-host:8000',
+  COLORS: {},
+}));
+
 let api: typeof import('../api/mobilityProfile');
+let fetchMock: jest.Mock;
 
-beforeEach(() => {
-  jest.useFakeTimers();
-  jest.resetModules();
-  api = require('../api/mobilityProfile');
-});
+const SAMPLE_PROFILE = {
+  profileId: 'p-1',
+  mobilityAid: 'WHEELCHAIR',
+  avoidStairs: true,
+  avoidSteepSlopes: false,
+  maxSlopeGradient: null,
+  createdAt: '2026-05-10T12:00:00Z',
+};
 
-afterEach(() => {
-  jest.useRealTimers();
-});
+const EXPECTED_URL = 'http://test-host:8000/api/users/me/mobility-profile';
 
-async function flush() {
-  // Advance fake timers past the 400 ms mock delay and let promises settle
-  jest.runAllTimers();
-  await Promise.resolve();
+function mockResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
 }
 
+beforeEach(() => {
+  jest.resetModules();
+  fetchMock = jest.fn();
+  global.fetch = fetchMock as unknown as typeof fetch;
+  api = require('../api/mobilityProfile');
+  api.__resetMockForTest();
+});
+
 describe('getMobilityProfile', () => {
-  it('returns null when no profile has been created', async () => {
-    const promise = api.getMobilityProfile();
-    await flush();
-    const result = await promise;
+  it('hits /api/users/me/mobility-profile with auth header', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(200, SAMPLE_PROFILE));
+
+    await api.getMobilityProfile();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(EXPECTED_URL);
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: 'Bearer mock-access-token',
+    });
+  });
+
+  it('returns the parsed profile on 200', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(200, SAMPLE_PROFILE));
+    const result = await api.getMobilityProfile();
+    expect(result).toEqual(SAMPLE_PROFILE);
+  });
+
+  it('returns null on 404 (no profile yet)', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(404, { detail: 'not found' }));
+    const result = await api.getMobilityProfile();
     expect(result).toBeNull();
   });
 
-  it('returns the stored profile after createMobilityProfile is called', async () => {
-    const createPromise = api.createMobilityProfile({
-      mobilityAid: 'WHEELCHAIR',
-      avoidStairs: true,
-      avoidSteepSlopes: false,
-      maxSlopeGradient: null,
-    });
-    await flush();
-    await createPromise;
-
-    const getPromise = api.getMobilityProfile();
-    await flush();
-    const result = await getPromise;
-
-    expect(result).not.toBeNull();
-    expect(result!.mobilityAid).toBe('WHEELCHAIR');
-    expect(result!.avoidStairs).toBe(true);
+  it('throws on other non-ok responses', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(500, {}));
+    await expect(api.getMobilityProfile()).rejects.toThrow();
   });
 });
 
 describe('createMobilityProfile', () => {
-  it('creates a profile with all provided fields', async () => {
-    const promise = api.createMobilityProfile({
-      mobilityAid: 'CRUTCHES',
-      avoidStairs: true,
-      avoidSteepSlopes: true,
-      maxSlopeGradient: 8,
-    });
-    await flush();
-    const result = await promise;
+  const payload = {
+    mobilityAid: 'CRUTCHES' as const,
+    avoidStairs: true,
+    avoidSteepSlopes: true,
+    maxSlopeGradient: 8,
+  };
 
-    expect(result.profileId).toBeDefined();
-    expect(result.mobilityAid).toBe('CRUTCHES');
-    expect(result.avoidStairs).toBe(true);
-    expect(result.avoidSteepSlopes).toBe(true);
-    expect(result.maxSlopeGradient).toBe(8);
-    expect(result.createdAt).toBeDefined();
+  it('POSTs to /api/users/me/mobility-profile with payload as JSON body', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(201, SAMPLE_PROFILE));
+
+    await api.createMobilityProfile(payload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(EXPECTED_URL);
+    expect((init as RequestInit).method).toBe('POST');
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual(payload);
+  });
+
+  it('returns the created profile from the response body', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(201, SAMPLE_PROFILE));
+    const result = await api.createMobilityProfile(payload);
+    expect(result).toEqual(SAMPLE_PROFILE);
+  });
+
+  it('throws on a non-ok response', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(400, { detail: 'bad' }));
+    await expect(api.createMobilityProfile(payload)).rejects.toThrow();
   });
 });
 
 describe('updateMobilityProfile', () => {
-  it('updates an existing profile and preserves profileId', async () => {
-    // First create
-    const createPromise = api.createMobilityProfile({
-      mobilityAid: 'WALKER',
-      avoidStairs: false,
-      avoidSteepSlopes: false,
-      maxSlopeGradient: null,
-    });
-    await flush();
-    const created = await createPromise;
+  const payload = {
+    mobilityAid: 'STROLLER' as const,
+    avoidStairs: true,
+    avoidSteepSlopes: true,
+    maxSlopeGradient: 5,
+  };
 
-    // Then update
-    const updatePromise = api.updateMobilityProfile({
-      mobilityAid: 'STROLLER',
-      avoidStairs: true,
-      avoidSteepSlopes: true,
-      maxSlopeGradient: 5,
-    });
-    await flush();
-    const updated = await updatePromise;
+  it('PUTs to /api/users/me/mobility-profile with payload as JSON body', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(200, { ...SAMPLE_PROFILE, ...payload }));
 
-    expect(updated.profileId).toBe(created.profileId);
-    expect(updated.mobilityAid).toBe('STROLLER');
-    expect(updated.avoidStairs).toBe(true);
-    expect(updated.maxSlopeGradient).toBe(5);
+    await api.updateMobilityProfile(payload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(EXPECTED_URL);
+    expect((init as RequestInit).method).toBe('PUT');
+    expect(JSON.parse(String((init as RequestInit).body))).toEqual(payload);
   });
 
-  it('reflects the update when getMobilityProfile is called afterwards', async () => {
-    const createPromise = api.createMobilityProfile({
-      mobilityAid: 'NONE',
-      avoidStairs: false,
-      avoidSteepSlopes: false,
-      maxSlopeGradient: null,
-    });
-    await flush();
-    await createPromise;
+  it('returns the updated profile from the response body', async () => {
+    const updated = { ...SAMPLE_PROFILE, ...payload };
+    fetchMock.mockResolvedValueOnce(mockResponse(200, updated));
+    const result = await api.updateMobilityProfile(payload);
+    expect(result).toEqual(updated);
+  });
 
-    const updatePromise = api.updateMobilityProfile({
-      mobilityAid: 'HAND_CART',
-      avoidStairs: false,
-      avoidSteepSlopes: true,
-      maxSlopeGradient: 10,
-    });
-    await flush();
-    await updatePromise;
-
-    const getPromise = api.getMobilityProfile();
-    await flush();
-    const result = await getPromise;
-
-    expect(result!.mobilityAid).toBe('HAND_CART');
-    expect(result!.maxSlopeGradient).toBe(10);
+  it('throws on a non-ok response', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(404, { detail: 'no profile' }));
+    await expect(api.updateMobilityProfile(payload)).rejects.toThrow();
   });
 });

--- a/frontend/src/api/mobilityProfile.ts
+++ b/frontend/src/api/mobilityProfile.ts
@@ -28,13 +28,13 @@ function mockDelay(): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, 400));
 }
 
-// ── GET /users/me/mobility-profile ─────────────────────────────────────────
+// ── GET /api/users/me/mobility-profile ─────────────────────────────────────────
 export async function getMobilityProfile(): Promise<MobilityProfile | null> {
   if (MOCK) {
     await mockDelay();
     return _mockProfile;
   }
-  const res = await fetch(`${API_BASE}/users/me/mobility-profile`, {
+  const res = await fetch(`${API_BASE}/api/users/me/mobility-profile`, {
     headers: authHeaders(),
   });
   if (res.status === 404) return null;
@@ -42,7 +42,7 @@ export async function getMobilityProfile(): Promise<MobilityProfile | null> {
   return res.json();
 }
 
-// ── POST /users/me/mobility-profile ────────────────────────────────────────
+// ── POST /api/users/me/mobility-profile ────────────────────────────────────────
 export async function createMobilityProfile(
   payload: MobilityProfilePayload,
 ): Promise<MobilityProfile> {
@@ -55,7 +55,7 @@ export async function createMobilityProfile(
     };
     return _mockProfile;
   }
-  const res = await fetch(`${API_BASE}/users/me/mobility-profile`, {
+  const res = await fetch(`${API_BASE}/api/users/me/mobility-profile`, {
     method: 'POST',
     headers: authHeaders(),
     body: JSON.stringify(payload),
@@ -64,7 +64,7 @@ export async function createMobilityProfile(
   return res.json();
 }
 
-// ── PUT /users/me/mobility-profile ─────────────────────────────────────────
+// ── PUT /api/users/me/mobility-profile ─────────────────────────────────────────
 export async function updateMobilityProfile(
   payload: MobilityProfilePayload,
 ): Promise<MobilityProfile> {
@@ -73,7 +73,7 @@ export async function updateMobilityProfile(
     _mockProfile = { ..._mockProfile!, ...payload };
     return _mockProfile;
   }
-  const res = await fetch(`${API_BASE}/users/me/mobility-profile`, {
+  const res = await fetch(`${API_BASE}/api/users/me/mobility-profile`, {
     method: 'PUT',
     headers: authHeaders(),
     body: JSON.stringify(payload),


### PR DESCRIPTION
## Description
Saving or loading a mobility profile from the app failed with `404 Not Found`. The three helpers in `frontend/src/api/mobilityProfile.ts` were calling `${API_BASE}/users/me/mobility-profile`, but the backend route is mounted at `/api/users/me/mobility-profile` (`backend/config/urls.py:23`). Adds the missing `/api/` prefix and rewrites the test suite so this kind of regression is caught next time.

## Type of Change
- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [x] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes
- `frontend/src/api/mobilityProfile.ts`: GET / POST / PUT now hit `${API_BASE}/api/users/me/mobility-profile`. Section comments updated to match.
- `frontend/src/__tests__/mobilityProfileApi.test.ts`: rewritten. The previous suite exercised only the in-memory `MOCK = true` path, which was disabled in production when the backend went live, so all 5 tests were silently failing on `main`. New suite mocks `global.fetch` and asserts each helper hits `/api/users/me/mobility-profile` with the right method, body, and `Authorization` header. Adds explicit coverage for the 404-returns-null and error-throws paths.

## How to Test
1. `docker compose up -d` and the frontend (`cd frontend && npx expo start`).
2. Open the profile screen as an existing user → mobility profile loads (was 404 before).
3. Edit + save the profile → success, no "Failed to save" banner. Backend log shows `200 /api/users/me/mobility-profile`.
4. As a new user with no profile → screen loads gracefully (helper returns `null` on 404).
5. Submit a profile for the first time → `201 POST` on the same path.
6. Tests: `cd frontend && npx jest --testPathPattern="mobilityProfileApi"` → 10/10 pass. Full suite: 147/147 tests pass (1 unrelated suite — `ReportForm.test.tsx` — fails to **load** due to a pre-existing `react-native-webview` TurboModule issue that also fails on `main`).

## Screenshots (if applicable)
_No UI changes. Backend log goes from `404 GET /users/me/mobility-profile` to `200 GET /api/users/me/mobility-profile`._

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #231

## Notes
The `MOCK` constant and the `__resetMockForTest` helper in `mobilityProfile.ts` are kept as-is — out of scope for this PR. They're effectively dead code right now (`MOCK = false`), but leaving them lets the team flip back to a stub if they ever need to develop the profile screen offline.