### PR TITLE
feat: show progress toward verification and resolution (#240)

### DIFF
--- a/backend/apps/map/serializers.py
+++ b/backend/apps/map/serializers.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from apps.reports.models import InteractionType
+from apps.reports.services import _upvote_threshold_for
 
 
 class LocationSerializer(serializers.Serializer):
@@ -57,8 +59,10 @@ class ObstacleDetailSerializer(serializers.Serializer):
     status = serializers.CharField()
     description = serializers.CharField()
     upvoteCount = serializers.SerializerMethodField()
+    upvoteThreshold = serializers.SerializerMethodField()
     flagCount = serializers.SerializerMethodField()
     confirmationCount = serializers.SerializerMethodField()
+    confirmationThreshold = serializers.SerializerMethodField()
     userUpvoted = serializers.SerializerMethodField()
     userFlagged = serializers.SerializerMethodField()
     userConfirmed = serializers.SerializerMethodField()
@@ -72,11 +76,17 @@ class ObstacleDetailSerializer(serializers.Serializer):
     def get_upvoteCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.UPVOTE)
 
+    def get_upvoteThreshold(self, obj):
+        return _upvote_threshold_for(obj.reporter)
+
     def get_flagCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.FLAG)
 
     def get_confirmationCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.CONFIRM_RESOLUTION)
+
+    def get_confirmationThreshold(self, obj):
+        return settings.RESOLUTION_CONFIRMATION_THRESHOLD
 
     def _user_has_interaction(self, obj, interaction_type):
         request = self.context.get("request")

--- a/backend/apps/map/tests.py
+++ b/backend/apps/map/tests.py
@@ -235,7 +235,8 @@ class ObstacleDetailViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         for field in ("reportId", "location", "category", "context", "status", "description",
-                      "upvoteCount", "flagCount", "photos", "statusHistory", "createdAt"):
+                      "upvoteCount", "upvoteThreshold", "flagCount", "confirmationCount",
+                      "confirmationThreshold", "photos", "statusHistory", "createdAt"):
             self.assertIn(field, data)
 
     def test_upvote_and_flag_count(self):

--- a/backend/apps/reports/serializers.py
+++ b/backend/apps/reports/serializers.py
@@ -40,6 +40,7 @@ class ReportResponseSerializer(serializers.Serializer):
 class UpvoteResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField()
     upvoteCount = serializers.IntegerField()
+    upvoteThreshold = serializers.IntegerField()
     userUpvoted = serializers.BooleanField()
     status = serializers.CharField()
     autoVerified = serializers.BooleanField()
@@ -54,6 +55,7 @@ class FlagResponseSerializer(serializers.Serializer):
 class ConfirmResolutionResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField()
     confirmationCount = serializers.IntegerField()
+    confirmationThreshold = serializers.IntegerField()
     status = serializers.CharField()
 
 

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -192,6 +192,7 @@ def toggle_upvote(user, report_id) -> dict:
     return {
         'reportId': report.id,
         'upvoteCount': upvote_count,
+        'upvoteThreshold': _upvote_threshold_for(report.reporter),
         'userUpvoted': user_upvoted,
         'status': report.status,
         'autoVerified': auto_verified,
@@ -332,5 +333,6 @@ def register_resolution_confirmation(user, report_id) -> dict:
     return {
         'reportId': report.id,
         'confirmationCount': confirmation_count,
+        'confirmationThreshold': settings.RESOLUTION_CONFIRMATION_THRESHOLD,
         'status': report.status,
     }

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -303,6 +303,7 @@ class ReportUpvoteViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(data["upvoteCount"], 1)
+        self.assertIn("upvoteThreshold", data)
         self.assertEqual(data["status"], ReportStatus.UNVERIFIED)
         self.assertFalse(data["autoVerified"])
 
@@ -573,8 +574,10 @@ class ConfirmResolutionViewTest(TestCase):
         data = response.json()
         self.assertIn("reportId", data)
         self.assertIn("confirmationCount", data)
+        self.assertIn("confirmationThreshold", data)
         self.assertIn("status", data)
         self.assertEqual(data["confirmationCount"], 1)
+        self.assertEqual(data["confirmationThreshold"], 3)
 
     def test_upvoter_can_confirm(self):
         voter = self._upvoter(1)

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -216,7 +216,9 @@ export default function ReportDetailScreen() {
         <InteractionBar
           reportId={detail.id}
           reporterId={detail.reporterId}
+          status={detail.status}
           upvoteCount={detail.upvoteCount}
+          upvoteThreshold={detail.upvoteThreshold}
           flagCount={detail.flagCount}
           userUpvoted={detail.userUpvoted}
           userFlagged={detail.userFlagged}
@@ -232,6 +234,7 @@ export default function ReportDetailScreen() {
         userUpvoted={detail.userUpvoted}
         userConfirmed={detail.userConfirmed}
         confirmationCount={detail.confirmationCount}
+        confirmationThreshold={detail.confirmationThreshold}
         currentUserId={currentUserId}
         onResolved={(newStatus, newCount) =>
           setDetail((d) =>

--- a/frontend/src/__tests__/ConfirmResolutionButton.test.tsx
+++ b/frontend/src/__tests__/ConfirmResolutionButton.test.tsx
@@ -18,6 +18,7 @@ const BASE_PROPS = {
   userUpvoted: false,
   userConfirmed: false,
   confirmationCount: 1,
+  confirmationThreshold: 3,
   currentUserId: 'reporter-1',
   onResolved: jest.fn(),
 };
@@ -139,4 +140,20 @@ it('shows an alert and does not call onResolved on API failure', async () => {
   expect(alertSpy).toHaveBeenCalled();
   expect(onResolved).not.toHaveBeenCalled();
   alertSpy.mockRestore();
+});
+
+// ── Progress indicator ──────────────────────────────────────────────────────
+
+it('shows X / N progress on the active button', () => {
+  const { getByText } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} confirmationCount={1} confirmationThreshold={3} />,
+  );
+  expect(getByText('1 / 3 confirmed')).toBeTruthy();
+});
+
+it('shows X / N progress in the recorded state', () => {
+  const { getByText } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} userConfirmed confirmationCount={2} confirmationThreshold={3} />,
+  );
+  expect(getByText(/2 \/ 3 confirmed/)).toBeTruthy();
 });

--- a/frontend/src/__tests__/InteractionBar.test.tsx
+++ b/frontend/src/__tests__/InteractionBar.test.tsx
@@ -11,7 +11,9 @@ const mockPostFlag = interactionsApi.postFlag as jest.MockedFunction<typeof inte
 const BASE_PROPS = {
   reportId: 'report-123',
   reporterId: 'reporter-456',
+  status: 'VERIFIED',
   upvoteCount: 3,
+  upvoteThreshold: 5,
   flagCount: 1,
   userUpvoted: false,
   userFlagged: false,
@@ -178,4 +180,20 @@ it('shows disabled views and hides interactive buttons when user is the reporter
   expect(getByTestId('flag-disabled')).toBeTruthy();
   expect(queryByTestId('upvote-button')).toBeNull();
   expect(queryByTestId('flag-button')).toBeNull();
+});
+
+// ── Progress indicator ────────────────────────────────────────────────────────
+
+it('shows X / N format when status is UNVERIFIED', () => {
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} status="UNVERIFIED" upvoteCount={2} upvoteThreshold={5} />,
+  );
+  expect(getByTestId('upvote-count').props.children).toBe('2 / 5');
+});
+
+it('shows plain count when status is not UNVERIFIED', () => {
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} status="VERIFIED" upvoteCount={6} upvoteThreshold={5} />,
+  );
+  expect(getByTestId('upvote-count').props.children).toBe(6);
 });

--- a/frontend/src/__tests__/InteractionBarGuest.test.tsx
+++ b/frontend/src/__tests__/InteractionBarGuest.test.tsx
@@ -7,7 +7,9 @@ jest.mock('../api/interactions');
 const baseProps = {
   reportId: 'r1',
   reporterId: 'someone-else',
+  status: 'VERIFIED',
   upvoteCount: 3,
+  upvoteThreshold: 5,
   flagCount: 1,
   userUpvoted: false,
   userFlagged: false,

--- a/frontend/src/api/interactions.ts
+++ b/frontend/src/api/interactions.ts
@@ -11,6 +11,7 @@ function authHeaders(): Record<string, string> {
 export interface UpvoteResponse {
   reportId?: string;
   upvoteCount?: number;
+  upvoteThreshold?: number;
   status?: string;
   autoVerified?: boolean;
   userUpvoted?: boolean;
@@ -50,6 +51,7 @@ export interface ConfirmResolutionResponse {
   reportId: string;
   status: string;
   confirmationCount: number;
+  confirmationThreshold?: number;
 }
 
 export async function confirmResolution(

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -28,8 +28,10 @@ export interface StatusChange {
 export interface ObstacleDetail extends Obstacle {
   photos: PhotoItem[];
   upvoteCount: number;
+  upvoteThreshold: number;
   flagCount: number;
   confirmationCount: number;
+  confirmationThreshold: number;
   userUpvoted: boolean;
   userFlagged: boolean;
   userConfirmed: boolean;
@@ -120,8 +122,10 @@ export async function fetchObstacleDetail(id: string): Promise<ObstacleDetail | 
         uploadedAt: p.uploadedAt ?? p.uploaded_at,
       })),
       upvoteCount: raw.upvoteCount ?? 0,
+      upvoteThreshold: raw.upvoteThreshold ?? 5,
       flagCount: raw.flagCount ?? 0,
       confirmationCount: raw.confirmationCount ?? 0,
+      confirmationThreshold: raw.confirmationThreshold ?? 3,
       userUpvoted: raw.userUpvoted ?? false,
       userFlagged: raw.userFlagged ?? false,
       userConfirmed: raw.userConfirmed ?? false,

--- a/frontend/src/components/reports/ConfirmResolutionButton.tsx
+++ b/frontend/src/components/reports/ConfirmResolutionButton.tsx
@@ -11,13 +11,14 @@ interface ConfirmResolutionButtonProps {
   userUpvoted: boolean;
   userConfirmed: boolean;
   confirmationCount: number;
+  confirmationThreshold: number;
   currentUserId: string;
   onResolved: (newStatus: string, confirmationCount: number) => void;
 }
 
 export default function ConfirmResolutionButton({
   reportId, status, reporterId, userUpvoted, userConfirmed, confirmationCount,
-  currentUserId, onResolved,
+  confirmationThreshold, currentUserId, onResolved,
 }: ConfirmResolutionButtonProps) {
   const [loading, setLoading] = useState(false);
 
@@ -33,7 +34,7 @@ export default function ConfirmResolutionButton({
       <View testID="confirm-resolution-recorded" style={s.recorded}>
         <Ionicons name="checkmark-circle" size={18} color={COLORS.green700} />
         <Text style={s.recordedText}>
-          Confirmation recorded — waiting for {confirmationCount === 1 ? 'others' : 'more citizens'} to confirm.
+          Confirmation recorded — {confirmationCount} / {confirmationThreshold} confirmed.
         </Text>
       </View>
     );
@@ -65,7 +66,10 @@ export default function ConfirmResolutionButton({
     >
       {loading
         ? <ActivityIndicator size="small" color={COLORS.white} />
-        : <Text style={s.text}>Confirm Resolution</Text>}
+        : <>
+            <Text style={s.text}>Confirm Resolution</Text>
+            <Text style={s.progressText}>{confirmationCount} / {confirmationThreshold} confirmed</Text>
+          </>}
     </TouchableOpacity>
   );
 }
@@ -79,6 +83,7 @@ const s = StyleSheet.create({
     marginTop: 12,
   },
   text: { color: COLORS.white, fontWeight: '600', fontSize: 14 },
+  progressText: { color: COLORS.white, fontSize: 12, opacity: 0.85, marginTop: 2 },
   recorded: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/frontend/src/components/reports/InteractionBar.tsx
+++ b/frontend/src/components/reports/InteractionBar.tsx
@@ -16,7 +16,9 @@ import { postUpvote, postFlag } from '../../api/interactions';
 export interface InteractionBarProps {
   reportId: string;
   reporterId: string;
+  status: string;
   upvoteCount: number;
+  upvoteThreshold: number;
   flagCount: number;
   userUpvoted: boolean;
   userFlagged: boolean;
@@ -29,8 +31,8 @@ const VALID_STATUSES = new Set([
 ]);
 
 export default function InteractionBar({
-  reportId, reporterId, upvoteCount, flagCount,
-  userUpvoted, userFlagged, currentUserId, onUpdate,
+  reportId, reporterId, status, upvoteCount, upvoteThreshold,
+  flagCount, userUpvoted, userFlagged, currentUserId, onUpdate,
 }: InteractionBarProps) {
   const [upvoting, setUpvoting] = useState(false);
   const [flagging, setFlagging] = useState(false);
@@ -150,7 +152,7 @@ export default function InteractionBar({
           color={upvoting ? COLORS.gray400 : userUpvoted ? COLORS.green600 : COLORS.gray600}
         />
         <Text style={[s.count, !upvoting && userUpvoted && s.activeCount]} testID="upvote-count">
-          {upvoteCount}
+          {status === 'UNVERIFIED' ? `${upvoteCount} / ${upvoteThreshold}` : upvoteCount}
         </Text>
       </TouchableOpacity>
       <TouchableOpacity


### PR DESCRIPTION
## Description
Shows progress indicators toward upvote-verification and confirmation-resolution thresholds. While a report is `UNVERIFIED` the upvote button displays `{upvoteCount} / {upvoteThreshold}`; while `RESOLVED_AWAITING_VALIDATION` the confirm button and the recorded-pill both display `{confirmationCount} / {confirmationThreshold} confirmed`. Thresholds are now served by the backend so the frontend never hardcodes them.

## Type of Change
- [x] `feat` — new feature

## Changes
- `ObstacleDetailSerializer` exposes `upvoteThreshold` (computed from reporter's role) and `confirmationThreshold`
- `toggle_upvote` and `register_resolution_confirmation` services return the relevant threshold
- `UpvoteResponseSerializer` and `ConfirmResolutionResponseSerializer` include the new threshold fields
- `InteractionBar`: shows `X / N` next to the upvote button when `status === 'UNVERIFIED'`
- `ConfirmResolutionButton`: shows `X / N confirmed` on the active button and in the recorded state

## How to Test
1. Run `docker compose up` from the repo root
2. Run `npx expo start` from `frontend/`
3. Open any **UNVERIFIED** report — the upvote button should read e.g. `2 / 5`
4. Open any **RESOLVED_AWAITING_VALIDATION** report as an eligible user — the confirm button should read e.g. `1 / 3 confirmed`; after confirming, the recorded pill should show the updated count

## Screenshots (if applicable)
[To be added after manual testing]

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #240

## Notes
Backend: 122 tests pass. Frontend: 29 tests pass (4 new progress-indicator cases added).