### PR TITLE
fix(frontend): unwrap backend error envelope in parseDRFError (#233)

### DIFF
--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -76,6 +76,14 @@ export function landingRouteForRole(role: UserRole | undefined | null): string {
 export function parseDRFError(data: any): string {
   if (!data) return 'Something went wrong.';
   if (data.detail) return data.detail;
+  // Backend's custom exception handler wraps errors as
+  //   { error: { detail: "..." } }  or  occasionally  { error: "..." }
+  // Unwrap here, otherwise the generic loop below stringifies the inner
+  // object as "[object Object]". (Issue #233)
+  if (data.error) {
+    if (typeof data.error === 'string') return data.error;
+    if (typeof data.error.detail === 'string') return data.error.detail;
+  }
   if (typeof data === 'string') return data;
   const msgs: string[] = [];
   for (const [, errors] of Object.entries(data)) {


### PR DESCRIPTION
Closes #233

## What
`parseDRFError` now unwraps the backend's custom error envelope (`{ error: { detail: "..." } }` or `{ error: "..." }`) before falling through to the existing logic. Previously these shapes hit the generic object-stringify path and rendered as `[object Object]` in the UI.

## Why
The backend's custom exception handler wraps every error in this envelope, so the bug affected login, profile, password reset, and register — not just registration. Reproducible by registering with the common password `asd12345`.

## Changes
- `frontend/src/services/auth.ts` — 8-line addition to `parseDRFError`, checking `data.error` before the generic loop. Existing fallback paths (`data.detail` → string-typed `data` → key-value loop → generic message) are untouched.

## Testing
Manually verified on web (`npx expo start` → `w`):
- Before: registering with `asd12345` showed `[object Object]`.
- After: it shows the unwrapped backend message instead of `[object Object]`.

## Acceptance Criteria
- [x] `parseDRFError` reads `data.error?.detail` before falling back to existing logic
- [x] Registering with a common password shows the real backend message, not `[object Object]`

## Note for reviewer
The backend's custom exception handler appears to `str()` Django validation errors into the `detail` field, so for field-level errors the `detail` string contains a Python repr like `{'password': [ErrorDetail(string='This password is too common.', code='password_too_common')]}` rather than a clean message. This is out of scope for #233 (which is purely about unwrapping the envelope on the frontend) and worth opening a separate backend issue for. The frontend fix here already replaces `[object Object]` with the unwrapped string, satisfying the acceptance criteria.