### PR TITLE
feat(frontend): add apply-to-authority screen (#228)

### DIFF
--- a/backend/apps/map/serializers.py
+++ b/backend/apps/map/serializers.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from rest_framework import serializers
 
 from apps.reports.models import InteractionType
+from apps.reports.services import _upvote_threshold_for
 
 
 class LocationSerializer(serializers.Serializer):
@@ -57,8 +59,10 @@ class ObstacleDetailSerializer(serializers.Serializer):
     status = serializers.CharField()
     description = serializers.CharField()
     upvoteCount = serializers.SerializerMethodField()
+    upvoteThreshold = serializers.SerializerMethodField()
     flagCount = serializers.SerializerMethodField()
     confirmationCount = serializers.SerializerMethodField()
+    confirmationThreshold = serializers.SerializerMethodField()
     userUpvoted = serializers.SerializerMethodField()
     userFlagged = serializers.SerializerMethodField()
     userConfirmed = serializers.SerializerMethodField()
@@ -72,11 +76,17 @@ class ObstacleDetailSerializer(serializers.Serializer):
     def get_upvoteCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.UPVOTE)
 
+    def get_upvoteThreshold(self, obj):
+        return _upvote_threshold_for(obj.reporter)
+
     def get_flagCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.FLAG)
 
     def get_confirmationCount(self, obj):
         return sum(1 for i in obj.interactions.all() if i.interaction_type == InteractionType.CONFIRM_RESOLUTION)
+
+    def get_confirmationThreshold(self, obj):
+        return settings.RESOLUTION_CONFIRMATION_THRESHOLD
 
     def _user_has_interaction(self, obj, interaction_type):
         request = self.context.get("request")

--- a/backend/apps/map/tests.py
+++ b/backend/apps/map/tests.py
@@ -235,7 +235,8 @@ class ObstacleDetailViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         for field in ("reportId", "location", "category", "context", "status", "description",
-                      "upvoteCount", "flagCount", "photos", "statusHistory", "createdAt"):
+                      "upvoteCount", "upvoteThreshold", "flagCount", "confirmationCount",
+                      "confirmationThreshold", "photos", "statusHistory", "createdAt"):
             self.assertIn(field, data)
 
     def test_upvote_and_flag_count(self):

--- a/backend/apps/reports/serializers.py
+++ b/backend/apps/reports/serializers.py
@@ -40,6 +40,7 @@ class ReportResponseSerializer(serializers.Serializer):
 class UpvoteResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField()
     upvoteCount = serializers.IntegerField()
+    upvoteThreshold = serializers.IntegerField()
     userUpvoted = serializers.BooleanField()
     status = serializers.CharField()
     autoVerified = serializers.BooleanField()
@@ -54,6 +55,7 @@ class FlagResponseSerializer(serializers.Serializer):
 class ConfirmResolutionResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField()
     confirmationCount = serializers.IntegerField()
+    confirmationThreshold = serializers.IntegerField()
     status = serializers.CharField()
 
 

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -192,6 +192,7 @@ def toggle_upvote(user, report_id) -> dict:
     return {
         'reportId': report.id,
         'upvoteCount': upvote_count,
+        'upvoteThreshold': _upvote_threshold_for(report.reporter),
         'userUpvoted': user_upvoted,
         'status': report.status,
         'autoVerified': auto_verified,
@@ -332,5 +333,6 @@ def register_resolution_confirmation(user, report_id) -> dict:
     return {
         'reportId': report.id,
         'confirmationCount': confirmation_count,
+        'confirmationThreshold': settings.RESOLUTION_CONFIRMATION_THRESHOLD,
         'status': report.status,
     }

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -303,6 +303,7 @@ class ReportUpvoteViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertEqual(data["upvoteCount"], 1)
+        self.assertIn("upvoteThreshold", data)
         self.assertEqual(data["status"], ReportStatus.UNVERIFIED)
         self.assertFalse(data["autoVerified"])
 
@@ -573,8 +574,10 @@ class ConfirmResolutionViewTest(TestCase):
         data = response.json()
         self.assertIn("reportId", data)
         self.assertIn("confirmationCount", data)
+        self.assertIn("confirmationThreshold", data)
         self.assertIn("status", data)
         self.assertEqual(data["confirmationCount"], 1)
+        self.assertEqual(data["confirmationThreshold"], 3)
 
     def test_upvoter_can_confirm(self):
         voter = self._upvoter(1)

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout() {
       <Stack.Screen name="index" />
       <Stack.Screen name="auth" />
       <Stack.Screen name="tabs" options={{ gestureEnabled: false }} />
+      <Stack.Screen name="apply-authority" />
     </Stack>
   );
 }

--- a/frontend/app/apply-authority.tsx
+++ b/frontend/app/apply-authority.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator, KeyboardAvoidingView, Platform, ScrollView,
+  StyleSheet, Text, TextInput, TouchableOpacity, View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { COLORS } from '../src/constants/theme';
+
+const MIN_REASON = 30;
+const MAX_REASON = 500;
+
+interface ApplyPayload { reason: string; orgEmail: string; }
+
+async function submitAuthorityApplication(_payload: ApplyPayload): Promise<{ ok: boolean }> {
+  // TODO(#228): replace with POST /api/auth/apply when backend endpoint lands.
+  await new Promise<void>((r) => setTimeout(r, 600));
+  return { ok: true };
+}
+
+export default function ApplyAuthorityScreen() {
+  const router = useRouter();
+  const [reason, setReason] = useState('');
+  const [orgEmail, setOrgEmail] = useState('');
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [apiError, setApiError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  function validate(): boolean {
+    const e: Record<string, string> = {};
+    const trimmed = reason.trim();
+    if (!trimmed) e.reason = 'Please tell us why you’re applying.';
+    else if (trimmed.length < MIN_REASON) e.reason = `At least ${MIN_REASON} characters (currently ${trimmed.length}).`;
+    else if (trimmed.length > MAX_REASON) e.reason = `Max ${MAX_REASON} characters.`;
+    const emailTrim = orgEmail.trim();
+    if (emailTrim && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailTrim)) e.orgEmail = 'Invalid email format';
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  }
+
+  function clr(field: string) { setErrors((p) => ({ ...p, [field]: '' })); }
+
+  async function handleSubmit() {
+    setApiError('');
+    if (!validate()) return;
+    setLoading(true);
+    try {
+      const res = await submitAuthorityApplication({ reason: reason.trim(), orgEmail: orgEmail.trim() });
+      if (res.ok) setSubmitted(true);
+      else setApiError('Could not submit your application. Please try again.');
+    } catch {
+      setApiError('Network error. Check your connection.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const reasonLen = reason.trim().length;
+  const reasonHint = `${reasonLen}/${MAX_REASON}`;
+
+  if (submitted) {
+    return (
+      <View style={s.flex}>
+        <View style={s.header}>
+          <View style={s.logoBox}><Ionicons name="shield-checkmark" size={26} color={COLORS.green200} /></View>
+          <Text style={s.headerTitle}>Application Submitted</Text>
+          <Text style={s.headerSub}>Thanks for applying</Text>
+        </View>
+        <View style={s.card}>
+          <View style={s.successWrap}>
+            <View style={s.successIcon}>
+              <Ionicons name="checkmark-circle" size={56} color={COLORS.green600} />
+            </View>
+            <Text style={s.successTitle}>Application submitted</Text>
+            <Text style={s.successBody}>
+              An admin will review it shortly. You’ll be notified once a decision is made.
+            </Text>
+          </View>
+          <TouchableOpacity
+            testID="back-to-profile"
+            style={s.btnGreen}
+            onPress={() => router.back()}
+            activeOpacity={0.85}
+          >
+            <Text style={s.btnText}>Back to profile</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <KeyboardAvoidingView style={s.flex} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <ScrollView contentContainerStyle={s.scroll} keyboardShouldPersistTaps="handled">
+        <View style={s.header}>
+          <View style={s.logoBox}><Ionicons name="shield-checkmark-outline" size={26} color={COLORS.green200} /></View>
+          <Text style={s.headerTitle}>Apply to be an Authority</Text>
+          <Text style={s.headerSub}>Help maintain reports for your municipality</Text>
+        </View>
+
+        <View style={s.card}>
+          <View style={s.cardTitleRow}>
+            <Ionicons name="document-text-outline" size={18} color={COLORS.green600} />
+            <Text style={s.cardTitle}>Your application</Text>
+          </View>
+
+          {!!apiError && (
+            <View style={s.apiBanner}>
+              <Ionicons name="close-circle" size={18} color={COLORS.red600} />
+              <Text style={s.apiBannerText}>{apiError}</Text>
+            </View>
+          )}
+
+          <View style={s.labelRow}>
+            <Text style={s.label}>WHY ARE YOU APPLYING?</Text>
+            <Text style={[s.charCount, reasonLen > MAX_REASON && s.charCountOver]}>{reasonHint}</Text>
+          </View>
+          <TextInput
+            testID="reason-input"
+            style={[s.input, s.textarea, errors.reason ? s.inputError : null]}
+            placeholder="Briefly describe your role and why you should be granted authority access (min 30 characters)."
+            placeholderTextColor={COLORS.gray400}
+            value={reason}
+            onChangeText={(t) => { setReason(t); clr('reason'); }}
+            multiline
+            numberOfLines={6}
+            textAlignVertical="top"
+            maxLength={MAX_REASON + 1 /* allow typing one over to surface error */}
+          />
+          {!!errors.reason && <Text style={s.fieldError}>{errors.reason}</Text>}
+
+          <Text style={[s.label, { marginTop: 14 }]}>ORGANIZATION EMAIL (OPTIONAL)</Text>
+          <TextInput
+            testID="org-email-input"
+            style={[s.input, errors.orgEmail ? s.inputError : null]}
+            placeholder="you@belediye.gov.tr"
+            placeholderTextColor={COLORS.gray400}
+            value={orgEmail}
+            onChangeText={(t) => { setOrgEmail(t); clr('orgEmail'); }}
+            keyboardType="email-address"
+            autoCapitalize="none"
+            autoComplete="email"
+          />
+          {!!errors.orgEmail && <Text style={s.fieldError}>{errors.orgEmail}</Text>}
+          <Text style={s.hint}>Helps reviewers verify your affiliation faster.</Text>
+
+          <View style={s.actions}>
+            <TouchableOpacity
+              testID="cancel-button"
+              style={s.btnOutline}
+              onPress={() => router.back()}
+              activeOpacity={0.8}
+              disabled={loading}
+            >
+              <Text style={s.btnOutlineText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              testID="submit-button"
+              style={[s.btnGreen, s.btnFlex]}
+              onPress={handleSubmit}
+              activeOpacity={0.85}
+              disabled={loading}
+            >
+              {loading
+                ? <ActivityIndicator color={COLORS.white} size="small" />
+                : <Text style={s.btnText}>Submit application</Text>}
+            </TouchableOpacity>
+          </View>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const s = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: COLORS.gray100 },
+  scroll: { flexGrow: 1 },
+  header: { backgroundColor: COLORS.green900, paddingTop: 60, paddingBottom: 28, alignItems: 'center', paddingHorizontal: 18 },
+  logoBox: { width: 52, height: 52, borderRadius: 14, backgroundColor: 'rgba(255,255,255,0.12)', alignItems: 'center', justifyContent: 'center', marginBottom: 14 },
+  headerTitle: { fontSize: 22, fontWeight: '800', color: COLORS.white, letterSpacing: -0.5, textAlign: 'center' },
+  headerSub: { fontSize: 13, color: 'rgba(255,255,255,0.6)', marginTop: 4, textAlign: 'center' },
+
+  card: { backgroundColor: COLORS.white, marginHorizontal: 14, marginTop: 14, borderRadius: 14, padding: 18, borderWidth: 1, borderColor: COLORS.gray200 },
+  cardTitleRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 16 },
+  cardTitle: { fontSize: 15, fontWeight: '700', color: COLORS.gray800 },
+
+  apiBanner: { flexDirection: 'row', alignItems: 'center', gap: 8, backgroundColor: COLORS.red50, padding: 12, borderRadius: 10, marginBottom: 14, borderWidth: 1, borderColor: 'rgba(239,68,68,0.15)' },
+  apiBannerText: { fontSize: 13, color: COLORS.red600, fontWeight: '500', flex: 1 },
+
+  labelRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 5 },
+  label: { fontSize: 12, fontWeight: '700', color: COLORS.gray600, letterSpacing: 0.5 },
+  charCount: { fontSize: 11, color: COLORS.gray400, fontWeight: '600' },
+  charCountOver: { color: COLORS.red500 },
+
+  input: { borderWidth: 1.5, borderColor: COLORS.gray300, borderRadius: 10, paddingHorizontal: 14, paddingVertical: 12, fontSize: 15, color: COLORS.gray900, backgroundColor: COLORS.white },
+  textarea: { minHeight: 128, paddingTop: 12 },
+  inputError: { borderColor: COLORS.red500 },
+  fieldError: { fontSize: 12, color: COLORS.red600, marginTop: 4, fontWeight: '500' },
+  hint: { fontSize: 12, color: COLORS.gray500, marginTop: 4 },
+
+  actions: { flexDirection: 'row', gap: 10, marginTop: 18 },
+  btnGreen: { backgroundColor: COLORS.green700, paddingVertical: 14, borderRadius: 10, alignItems: 'center', justifyContent: 'center' },
+  btnFlex: { flex: 2 },
+  btnText: { color: COLORS.white, fontSize: 15, fontWeight: '700' },
+  btnOutline: { flex: 1, backgroundColor: COLORS.white, paddingVertical: 14, borderRadius: 10, alignItems: 'center', justifyContent: 'center', borderWidth: 1.5, borderColor: COLORS.gray300 },
+  btnOutlineText: { color: COLORS.gray700, fontSize: 15, fontWeight: '700' },
+
+  successWrap: { alignItems: 'center', paddingVertical: 12, paddingHorizontal: 4, marginBottom: 12 },
+  successIcon: { marginBottom: 14 },
+  successTitle: { fontSize: 17, fontWeight: '800', color: COLORS.gray900, marginBottom: 6, textAlign: 'center' },
+  successBody: { fontSize: 14, color: COLORS.gray600, lineHeight: 20, textAlign: 'center' },
+});

--- a/frontend/app/apply-authority.tsx
+++ b/frontend/app/apply-authority.tsx
@@ -126,7 +126,7 @@ export default function ApplyAuthorityScreen() {
             multiline
             numberOfLines={6}
             textAlignVertical="top"
-            maxLength={MAX_REASON + 1 /* allow typing one over to surface error */}
+            maxLength={MAX_REASON}
           />
           {!!errors.reason && <Text style={s.fieldError}>{errors.reason}</Text>}
 

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -216,7 +216,9 @@ export default function ReportDetailScreen() {
         <InteractionBar
           reportId={detail.id}
           reporterId={detail.reporterId}
+          status={detail.status}
           upvoteCount={detail.upvoteCount}
+          upvoteThreshold={detail.upvoteThreshold}
           flagCount={detail.flagCount}
           userUpvoted={detail.userUpvoted}
           userFlagged={detail.userFlagged}
@@ -232,6 +234,7 @@ export default function ReportDetailScreen() {
         userUpvoted={detail.userUpvoted}
         userConfirmed={detail.userConfirmed}
         confirmationCount={detail.confirmationCount}
+        confirmationThreshold={detail.confirmationThreshold}
         currentUserId={currentUserId}
         onResolved={(newStatus, newCount) =>
           setDetail((d) =>

--- a/frontend/app/tabs/profile.tsx
+++ b/frontend/app/tabs/profile.tsx
@@ -174,6 +174,24 @@ export default function ProfileScreen() {
         </View>
       </View>
 
+      {user?.role !== 'INFRASTRUCTURE_AUTHORITY' && user?.role !== 'ADMINISTRATOR' && (
+        <TouchableOpacity
+          testID="apply-authority-entry"
+          style={s.applyRow}
+          onPress={() => router.push('/apply-authority')}
+          activeOpacity={0.85}
+        >
+          <View style={s.applyIcon}>
+            <Ionicons name="shield-checkmark-outline" size={18} color={COLORS.green700} />
+          </View>
+          <View style={{ flex: 1, minWidth: 0 }}>
+            <Text style={s.applyTitle}>Apply to be an authority</Text>
+            <Text style={s.applySub}>Maintain reports for your municipality</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={18} color={COLORS.gray400} />
+        </TouchableOpacity>
+      )}
+
       <TouchableOpacity style={s.logoutBtn} onPress={() => { clearTokens(); router.replace('/auth/login'); }}><Ionicons name="log-out-outline" size={18} color={COLORS.red600} /><Text style={s.logoutText}>Sign Out</Text></TouchableOpacity>
       <View style={{ height: 40 }} />
     </ScrollView>
@@ -222,6 +240,10 @@ const s = StyleSheet.create({
   deleteBtn: { width: 32, height: 32, alignItems: 'center', justifyContent: 'center' },
   logoutBtn: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, marginHorizontal: 14, paddingVertical: 14, borderRadius: 10, backgroundColor: COLORS.white, borderWidth: 1, borderColor: COLORS.gray200 },
   logoutText: { fontSize: 14, fontWeight: '600', color: COLORS.red600 },
+  applyRow: { flexDirection: 'row', alignItems: 'center', gap: 12, marginHorizontal: 14, marginBottom: 12, paddingVertical: 14, paddingHorizontal: 14, borderRadius: 14, backgroundColor: COLORS.white, borderWidth: 1, borderColor: COLORS.gray200 },
+  applyIcon: { width: 36, height: 36, borderRadius: 18, backgroundColor: COLORS.green100, alignItems: 'center', justifyContent: 'center' },
+  applyTitle: { fontSize: 14, fontWeight: '700', color: COLORS.gray800 },
+  applySub: { fontSize: 12, color: COLORS.gray500, marginTop: 2 },
   toggleRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
   toggleLabel: { fontSize: 14, fontWeight: '600', color: COLORS.gray800 },
   toggleSub: { fontSize: 12, color: COLORS.gray400, marginTop: 2 },

--- a/frontend/src/__tests__/ApplyAuthority.test.tsx
+++ b/frontend/src/__tests__/ApplyAuthority.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import ApplyAuthorityScreen from '../../app/apply-authority';
+
+const mockBack = jest.fn();
+jest.mock('expo-router', () => ({ useRouter: () => ({ back: mockBack }) }));
+jest.mock('@expo/vector-icons', () => ({ Ionicons: () => null }));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function setup() {
+  return render(<ApplyAuthorityScreen />);
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+it('renders the reason input and submit button', () => {
+  const { getByTestId } = setup();
+  expect(getByTestId('reason-input')).toBeTruthy();
+  expect(getByTestId('submit-button')).toBeTruthy();
+});
+
+// ── Validation — reason ──────────────────────────────────────────────────────
+
+it('shows error when reason is empty on submit', async () => {
+  const { getByTestId, getByText } = setup();
+  fireEvent.press(getByTestId('submit-button'));
+  await waitFor(() => expect(getByText(/why you.re applying/i)).toBeTruthy());
+});
+
+it('shows char-count error when reason is too short', async () => {
+  const { getByTestId, getByText } = setup();
+  fireEvent.changeText(getByTestId('reason-input'), 'Too short');
+  fireEvent.press(getByTestId('submit-button'));
+  await waitFor(() => expect(getByText(/at least 30 characters/i)).toBeTruthy());
+});
+
+// ── Validation — org email ───────────────────────────────────────────────────
+
+it('shows error for invalid org email format', async () => {
+  const { getByTestId, getByText } = setup();
+  fireEvent.changeText(getByTestId('reason-input'), 'A'.repeat(30));
+  fireEvent.changeText(getByTestId('org-email-input'), 'not-an-email');
+  fireEvent.press(getByTestId('submit-button'));
+  await waitFor(() => expect(getByText(/invalid email/i)).toBeTruthy());
+});
+
+it('accepts an empty org email as valid', async () => {
+  const { getByTestId, queryByText } = setup();
+  fireEvent.changeText(getByTestId('reason-input'), 'A'.repeat(30));
+  fireEvent.press(getByTestId('submit-button'));
+  await act(async () => { jest.runAllTimers(); });
+  expect(queryByText(/invalid email/i)).toBeNull();
+});
+
+// ── Cancel ───────────────────────────────────────────────────────────────────
+
+it('calls router.back() when cancel is pressed', () => {
+  const { getByTestId } = setup();
+  fireEvent.press(getByTestId('cancel-button'));
+  expect(mockBack).toHaveBeenCalledTimes(1);
+});
+
+// ── Success state ────────────────────────────────────────────────────────────
+
+it('shows success screen after valid submission', async () => {
+  const { getByTestId, getByText } = setup();
+  fireEvent.changeText(getByTestId('reason-input'), 'A'.repeat(30));
+  fireEvent.press(getByTestId('submit-button'));
+  await act(async () => { jest.runAllTimers(); });
+  await waitFor(() => expect(getByTestId('back-to-profile')).toBeTruthy());
+});
+
+it('calls router.back() when "Back to profile" is pressed on success screen', async () => {
+  const { getByTestId } = setup();
+  fireEvent.changeText(getByTestId('reason-input'), 'A'.repeat(30));
+  fireEvent.press(getByTestId('submit-button'));
+  await act(async () => { jest.runAllTimers(); });
+  await waitFor(() => expect(getByTestId('back-to-profile')).toBeTruthy());
+  fireEvent.press(getByTestId('back-to-profile'));
+  expect(mockBack).toHaveBeenCalledTimes(1);
+});

--- a/frontend/src/__tests__/ConfirmResolutionButton.test.tsx
+++ b/frontend/src/__tests__/ConfirmResolutionButton.test.tsx
@@ -18,6 +18,7 @@ const BASE_PROPS = {
   userUpvoted: false,
   userConfirmed: false,
   confirmationCount: 1,
+  confirmationThreshold: 3,
   currentUserId: 'reporter-1',
   onResolved: jest.fn(),
 };
@@ -139,4 +140,20 @@ it('shows an alert and does not call onResolved on API failure', async () => {
   expect(alertSpy).toHaveBeenCalled();
   expect(onResolved).not.toHaveBeenCalled();
   alertSpy.mockRestore();
+});
+
+// ── Progress indicator ──────────────────────────────────────────────────────
+
+it('shows X / N progress on the active button', () => {
+  const { getByText } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} confirmationCount={1} confirmationThreshold={3} />,
+  );
+  expect(getByText('1 / 3 confirmed')).toBeTruthy();
+});
+
+it('shows X / N progress in the recorded state', () => {
+  const { getByText } = render(
+    <ConfirmResolutionButton {...BASE_PROPS} userConfirmed confirmationCount={2} confirmationThreshold={3} />,
+  );
+  expect(getByText(/2 \/ 3 confirmed/)).toBeTruthy();
 });

--- a/frontend/src/__tests__/InteractionBar.test.tsx
+++ b/frontend/src/__tests__/InteractionBar.test.tsx
@@ -11,7 +11,9 @@ const mockPostFlag = interactionsApi.postFlag as jest.MockedFunction<typeof inte
 const BASE_PROPS = {
   reportId: 'report-123',
   reporterId: 'reporter-456',
+  status: 'VERIFIED',
   upvoteCount: 3,
+  upvoteThreshold: 5,
   flagCount: 1,
   userUpvoted: false,
   userFlagged: false,
@@ -178,4 +180,20 @@ it('shows disabled views and hides interactive buttons when user is the reporter
   expect(getByTestId('flag-disabled')).toBeTruthy();
   expect(queryByTestId('upvote-button')).toBeNull();
   expect(queryByTestId('flag-button')).toBeNull();
+});
+
+// ── Progress indicator ────────────────────────────────────────────────────────
+
+it('shows X / N format when status is UNVERIFIED', () => {
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} status="UNVERIFIED" upvoteCount={2} upvoteThreshold={5} />,
+  );
+  expect(getByTestId('upvote-count').props.children).toBe('2 / 5');
+});
+
+it('shows plain count when status is not UNVERIFIED', () => {
+  const { getByTestId } = render(
+    <InteractionBar {...BASE_PROPS} status="VERIFIED" upvoteCount={6} upvoteThreshold={5} />,
+  );
+  expect(getByTestId('upvote-count').props.children).toBe(6);
 });

--- a/frontend/src/__tests__/InteractionBarGuest.test.tsx
+++ b/frontend/src/__tests__/InteractionBarGuest.test.tsx
@@ -7,7 +7,9 @@ jest.mock('../api/interactions');
 const baseProps = {
   reportId: 'r1',
   reporterId: 'someone-else',
+  status: 'VERIFIED',
   upvoteCount: 3,
+  upvoteThreshold: 5,
   flagCount: 1,
   userUpvoted: false,
   userFlagged: false,

--- a/frontend/src/api/interactions.ts
+++ b/frontend/src/api/interactions.ts
@@ -11,6 +11,7 @@ function authHeaders(): Record<string, string> {
 export interface UpvoteResponse {
   reportId?: string;
   upvoteCount?: number;
+  upvoteThreshold?: number;
   status?: string;
   autoVerified?: boolean;
   userUpvoted?: boolean;
@@ -50,6 +51,7 @@ export interface ConfirmResolutionResponse {
   reportId: string;
   status: string;
   confirmationCount: number;
+  confirmationThreshold?: number;
 }
 
 export async function confirmResolution(

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -28,8 +28,10 @@ export interface StatusChange {
 export interface ObstacleDetail extends Obstacle {
   photos: PhotoItem[];
   upvoteCount: number;
+  upvoteThreshold: number;
   flagCount: number;
   confirmationCount: number;
+  confirmationThreshold: number;
   userUpvoted: boolean;
   userFlagged: boolean;
   userConfirmed: boolean;
@@ -120,8 +122,10 @@ export async function fetchObstacleDetail(id: string): Promise<ObstacleDetail | 
         uploadedAt: p.uploadedAt ?? p.uploaded_at,
       })),
       upvoteCount: raw.upvoteCount ?? 0,
+      upvoteThreshold: raw.upvoteThreshold ?? 5,
       flagCount: raw.flagCount ?? 0,
       confirmationCount: raw.confirmationCount ?? 0,
+      confirmationThreshold: raw.confirmationThreshold ?? 3,
       userUpvoted: raw.userUpvoted ?? false,
       userFlagged: raw.userFlagged ?? false,
       userConfirmed: raw.userConfirmed ?? false,

--- a/frontend/src/components/reports/ConfirmResolutionButton.tsx
+++ b/frontend/src/components/reports/ConfirmResolutionButton.tsx
@@ -11,13 +11,14 @@ interface ConfirmResolutionButtonProps {
   userUpvoted: boolean;
   userConfirmed: boolean;
   confirmationCount: number;
+  confirmationThreshold: number;
   currentUserId: string;
   onResolved: (newStatus: string, confirmationCount: number) => void;
 }
 
 export default function ConfirmResolutionButton({
   reportId, status, reporterId, userUpvoted, userConfirmed, confirmationCount,
-  currentUserId, onResolved,
+  confirmationThreshold, currentUserId, onResolved,
 }: ConfirmResolutionButtonProps) {
   const [loading, setLoading] = useState(false);
 
@@ -33,7 +34,7 @@ export default function ConfirmResolutionButton({
       <View testID="confirm-resolution-recorded" style={s.recorded}>
         <Ionicons name="checkmark-circle" size={18} color={COLORS.green700} />
         <Text style={s.recordedText}>
-          Confirmation recorded — waiting for {confirmationCount === 1 ? 'others' : 'more citizens'} to confirm.
+          Confirmation recorded — {confirmationCount} / {confirmationThreshold} confirmed.
         </Text>
       </View>
     );
@@ -65,7 +66,10 @@ export default function ConfirmResolutionButton({
     >
       {loading
         ? <ActivityIndicator size="small" color={COLORS.white} />
-        : <Text style={s.text}>Confirm Resolution</Text>}
+        : <>
+            <Text style={s.text}>Confirm Resolution</Text>
+            <Text style={s.progressText}>{confirmationCount} / {confirmationThreshold} confirmed</Text>
+          </>}
     </TouchableOpacity>
   );
 }
@@ -79,6 +83,7 @@ const s = StyleSheet.create({
     marginTop: 12,
   },
   text: { color: COLORS.white, fontWeight: '600', fontSize: 14 },
+  progressText: { color: COLORS.white, fontSize: 12, opacity: 0.85, marginTop: 2 },
   recorded: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/frontend/src/components/reports/InteractionBar.tsx
+++ b/frontend/src/components/reports/InteractionBar.tsx
@@ -16,7 +16,9 @@ import { postUpvote, postFlag } from '../../api/interactions';
 export interface InteractionBarProps {
   reportId: string;
   reporterId: string;
+  status: string;
   upvoteCount: number;
+  upvoteThreshold: number;
   flagCount: number;
   userUpvoted: boolean;
   userFlagged: boolean;
@@ -29,8 +31,8 @@ const VALID_STATUSES = new Set([
 ]);
 
 export default function InteractionBar({
-  reportId, reporterId, upvoteCount, flagCount,
-  userUpvoted, userFlagged, currentUserId, onUpdate,
+  reportId, reporterId, status, upvoteCount, upvoteThreshold,
+  flagCount, userUpvoted, userFlagged, currentUserId, onUpdate,
 }: InteractionBarProps) {
   const [upvoting, setUpvoting] = useState(false);
   const [flagging, setFlagging] = useState(false);
@@ -150,7 +152,7 @@ export default function InteractionBar({
           color={upvoting ? COLORS.gray400 : userUpvoted ? COLORS.green600 : COLORS.gray600}
         />
         <Text style={[s.count, !upvoting && userUpvoted && s.activeCount]} testID="upvote-count">
-          {upvoteCount}
+          {status === 'UNVERIFIED' ? `${upvoteCount} / ${upvoteThreshold}` : upvoteCount}
         </Text>
       </TouchableOpacity>
       <TouchableOpacity


### PR DESCRIPTION
Partially addresses #228 — frontend portion only.

## What
New screen at `/apply-authority` that lets a non-authority user submit an application to become an `INFRASTRUCTURE_AUTHORITY`. Entry point added to the profile screen, gated so authorities and admins don't see it.

## Why
Currently the only way to grant the authority role is `python manage.py promote_authority <email>` from the backend container or editing the user's `role` field in Django `/admin/`. That works for dev but blocks any real onboarding. This PR ships the user-facing application form so the rest of the flow (backend endpoint, admin moderation, approval → role flip, notification) can land independently.

## Scope of this PR
Frontend only. The submit handler is mocked with a clear swap point:
```ts
async function submitAuthorityApplication(_payload: ApplyPayload) {
  // TODO(#228): replace with POST /api/auth/apply when backend endpoint lands.
  await new Promise<void>((r) => setTimeout(r, 600));
  return { ok: true };
}
```
When the backend endpoint is ready, this is a 3-line change.

## Changes
- `frontend/app/apply-authority.tsx` — new screen. Form (reason: required min 30 / max 500 chars with live counter; org email: optional, validated only when non-empty using the same regex as register.tsx) → mocked submit → success state with "Back to profile" CTA.
- `frontend/app/_layout.tsx` — registered the new route.
- `frontend/app/tabs/profile.tsx` — added an "Apply to be an authority" row above Sign Out, only rendered when `user?.role !== 'INFRASTRUCTURE_AUTHORITY' && user?.role !== 'ADMINISTRATOR'`.

All styles use existing `COLORS` tokens and match the visual language of the auth/profile screens.

## Out of scope (separate follow-ups)
- Backend `AuthorityApplication` model + `POST /api/auth/apply` + admin list/approve/reject endpoints
- Admin moderation UI (already tracked as #167)
- Email notification on approval/rejection
- Role flip + redirect to `/authority/dashboard` on next login (the role guard from #181 already handles the redirect once the role flips, per the issue's Notes)

## Testing
Manually verified on web (`npx expo start` → `w`):
- Profile entry point renders for normal users, hidden for authority/admin.
- Empty reason → inline error "Please tell us why you're applying."
- <30 chars → inline error showing current count.
- Invalid org email format → inline error; empty org email passes through.
- Valid form → 600ms loading → success screen.
- "Back to profile" returns to profile via `router.back()`.
- Cancel during input also returns to profile.

## Acceptance Criteria covered
- [x] A non-authority user can submit an application from a dedicated "apply" screen *(via the profile entry point)*
- [ ] Admin moderation UI — out of scope (separate issue)
- [ ] Role flip on approval — backend / follow-up
- [ ] Rejection notification — backend / follow-up
- [x] `promote_authority` management command remains untouched