### PR TITLE
fix(deploy): install frontend deps before expo export to avoid npx pulling expo@55

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "installCommand": "cd frontend && npm install",
   "buildCommand": "cd frontend && npx expo export --platform web",
   "outputDirectory": "frontend/dist",
   "framework": null,


### PR DESCRIPTION
## Description

Vercel deployment was failing with:

```
CommandError: No platforms are configured to use the Metro bundler in the project Expo config.
Error: Command "cd frontend && npx expo export --platform web" exited with 1
```

Root cause: `vercel.json` had no `installCommand`, so Vercel never ran `npm install` inside `frontend/`. When `npx expo export` ran, it couldn't find expo in `node_modules` and downloaded the latest version (`expo@55.0.23`) instead of the project's `expo@~54.0.0`. Expo 55 changed its web config handling and rejected the existing `app.json` setup.

## Fix

Added `"installCommand": "cd frontend && npm install"` to `vercel.json` so the local `expo@54` is installed before the build runs.

## Related

Fixes the Vercel deployment error on main.