### PR TITLE
Feat/per trip route avoidance

### DIFF
--- a/backend/apps/routing/serializers.py
+++ b/backend/apps/routing/serializers.py
@@ -15,10 +15,20 @@ class RouteRequestSerializer(serializers.Serializer):
     preferences = PreferencesSerializer(required=False)
 
 
-class RouteResponseSerializer(serializers.Serializer):
+class RouteLegSerializer(serializers.Serializer):
     waypoints = serializers.ListField()
     distanceMeters = serializers.FloatField()
     estimatedTimeSeconds = serializers.FloatField()
+
+
+class RouteResponseSerializer(serializers.Serializer):
+    # Backward-compat: mirror of the chosen route (alternative if returned, else baseline).
+    waypoints = serializers.ListField()
+    distanceMeters = serializers.FloatField()
+    estimatedTimeSeconds = serializers.FloatField()
+    # Per-trip routes. alternativeRoute is null when avoidance didn't improve on baseline.
+    baselineRoute = RouteLegSerializer()
+    alternativeRoute = RouteLegSerializer(allow_null=True)
     avoidedObstaclesCount = serializers.IntegerField()
     warnings = serializers.ListField(child=serializers.CharField())
     isAccessible = serializers.BooleanField()

--- a/backend/apps/routing/services.py
+++ b/backend/apps/routing/services.py
@@ -119,47 +119,81 @@ def _call_valhalla(origin, destination, exclude_locations=None):
     return waypoints, distance_m, duration_s
 
 
+def _route_payload(waypoints, distance, duration):
+    return {
+        'waypoints': waypoints,
+        'distanceMeters': round(distance, 1),
+        'estimatedTimeSeconds': round(duration),
+    }
+
+
 def calculate_route(origin_lat, origin_lng, dest_lat, dest_lng, preferences):
     """
-    Pedestrian route using Valhalla.
-    - Passes verified obstacles as exclude_locations so Valhalla avoids them.
-    - Falls back to direct route if avoidance fails.
-    - Warns about unverified obstacles near the final route.
+    Pedestrian route using Valhalla, computed in two passes:
+      1. baseline route with no exclusions → obstacles that lie on it (on_baseline)
+      2. if on_baseline is non-empty, avoidance route excluding only those obstacles
+         → obstacles still on it (on_avoidance)
+    avoidedObstaclesCount = len(on_baseline) - len(on_avoidance), so it only counts
+    obstacles relevant to *this* trip.
+
+    Returns baselineRoute always, and alternativeRoute only when the second pass
+    actually improves on the baseline (fewer obstacles on the path).
+    Warnings and isAccessible are derived from the chosen route.
     """
     origin = [origin_lat, origin_lng]
     destination = [dest_lat, dest_lng]
 
     verified_obstacles = _get_verified_obstacles()
-
-    # Try routing with obstacle avoidance
-    avoided_count = 0
-    try:
-        waypoints, distance, duration = _call_valhalla(
-            origin, destination,
-            exclude_locations=verified_obstacles if verified_obstacles else None,
-        )
-    except ValueError:
-        # Avoidance route failed — fall back to direct route
-        waypoints, distance, duration = _call_valhalla(origin, destination)
-
-    # Check which verified obstacles are still on the final route
-    on_route = _obstacles_on_route(waypoints, verified_obstacles, OBSTACLE_PROXIMITY_RADIUS_M)
-    avoided_count = len(verified_obstacles) - len(on_route)
-
-    # Build warnings
-    warnings = []
-    for obs in on_route:
-        warnings.append(f"Verified obstacle on route: {obs['title']} ({obs['category']})")
-
     unverified = _get_unverified_obstacles()
-    for obs in _obstacles_on_route(waypoints, unverified, UNVERIFIED_WARNING_RADIUS_M):
+
+    # 1) Baseline: shortest route, no exclusions.
+    baseline_waypoints, baseline_distance, baseline_duration = _call_valhalla(origin, destination)
+    on_baseline = _obstacles_on_route(
+        baseline_waypoints, verified_obstacles, OBSTACLE_PROXIMITY_RADIUS_M
+    )
+
+    baseline_route = _route_payload(baseline_waypoints, baseline_distance, baseline_duration)
+    alternative_route = None
+    chosen_waypoints = baseline_waypoints
+    on_chosen = on_baseline
+
+    # 2) Try avoidance only if the baseline actually hits obstacles.
+    if on_baseline:
+        try:
+            alt_waypoints, alt_distance, alt_duration = _call_valhalla(
+                origin, destination, exclude_locations=on_baseline,
+            )
+            on_avoidance = _obstacles_on_route(
+                alt_waypoints, verified_obstacles, OBSTACLE_PROXIMITY_RADIUS_M
+            )
+            # Only surface the alternative if it genuinely improves on baseline.
+            if len(on_avoidance) < len(on_baseline):
+                alternative_route = _route_payload(alt_waypoints, alt_distance, alt_duration)
+                chosen_waypoints = alt_waypoints
+                on_chosen = on_avoidance
+        except ValueError:
+            # Avoidance failed — stick with baseline.
+            pass
+
+    avoided_count = len(on_baseline) - len(on_chosen)
+
+    warnings = [
+        f"Verified obstacle on route: {obs['title']} ({obs['category']})"
+        for obs in on_chosen
+    ]
+    for obs in _obstacles_on_route(chosen_waypoints, unverified, UNVERIFIED_WARNING_RADIUS_M):
         warnings.append(f"Unverified obstacle nearby: {obs['title']}")
 
+    chosen_route = alternative_route or baseline_route
     return {
-        'waypoints': waypoints,
-        'distanceMeters': round(distance, 1),
-        'estimatedTimeSeconds': round(duration),
+        # Backward-compat: top-level mirrors the chosen route.
+        'waypoints': chosen_route['waypoints'],
+        'distanceMeters': chosen_route['distanceMeters'],
+        'estimatedTimeSeconds': chosen_route['estimatedTimeSeconds'],
+        # New per-trip routes.
+        'baselineRoute': baseline_route,
+        'alternativeRoute': alternative_route,
         'avoidedObstaclesCount': avoided_count,
         'warnings': warnings,
-        'isAccessible': len(on_route) == 0,
+        'isAccessible': len(on_chosen) == 0,
     }

--- a/backend/apps/routing/services.py
+++ b/backend/apps/routing/services.py
@@ -19,6 +19,30 @@ def haversine(lat1, lng1, lat2, lng2):
     return EARTH_RADIUS_M * 2 * math.asin(math.sqrt(a))
 
 
+_M_PER_DEG = math.pi * EARTH_RADIUS_M / 180.0
+
+
+def _point_to_segment_distance_m(p_lat, p_lng, a_lat, a_lng, b_lat, b_lng):
+    """Distance in meters from point P to segment AB using a local
+    equirectangular projection around A. Accurate for short segments (<~few km)."""
+    cos_lat = math.cos(math.radians(a_lat))
+    dx_p = (p_lng - a_lng) * cos_lat
+    dy_p = (p_lat - a_lat)
+    dx_b = (b_lng - a_lng) * cos_lat
+    dy_b = (b_lat - a_lat)
+
+    seg_sq = dx_b * dx_b + dy_b * dy_b
+    if seg_sq == 0:
+        # Zero-length segment — fall back to point-to-point.
+        return math.hypot(dx_p, dy_p) * _M_PER_DEG
+
+    t = (dx_p * dx_b + dy_p * dy_b) / seg_sq
+    t = max(0.0, min(1.0, t))
+    cx = t * dx_b
+    cy = t * dy_b
+    return math.hypot(dx_p - cx, dy_p - cy) * _M_PER_DEG
+
+
 def _decode_polyline(encoded, precision=6):
     """Decode a Valhalla encoded polyline into a list of [lat, lng] pairs."""
     inv = 10 ** -precision
@@ -59,16 +83,29 @@ def _get_unverified_obstacles():
 
 
 def _obstacles_on_route(waypoints, obstacles, radius_m):
-    """Return obstacles within radius_m of any waypoint. Each obstacle returned once."""
+    """Return obstacles within radius_m of the route polyline (any segment between
+    consecutive waypoints). Each obstacle returned once."""
+    if not waypoints:
+        return []
     nearby = []
     seen = set()
     for obs in obstacles:
+        if obs['id'] in seen:
+            continue
         obs_lat, obs_lng = float(obs['latitude']), float(obs['longitude'])
-        for wp in waypoints:
+        if len(waypoints) == 1:
+            wp = waypoints[0]
             if haversine(wp[0], wp[1], obs_lat, obs_lng) <= radius_m:
-                if obs['id'] not in seen:
-                    nearby.append(obs)
-                    seen.add(obs['id'])
+                nearby.append(obs)
+                seen.add(obs['id'])
+            continue
+        for i in range(len(waypoints) - 1):
+            a, b = waypoints[i], waypoints[i + 1]
+            if _point_to_segment_distance_m(
+                obs_lat, obs_lng, a[0], a[1], b[0], b[1]
+            ) <= radius_m:
+                nearby.append(obs)
+                seen.add(obs['id'])
                 break
     return nearby
 
@@ -131,14 +168,19 @@ def calculate_route(origin_lat, origin_lng, dest_lat, dest_lng, preferences):
     """
     Pedestrian route using Valhalla, computed in two passes:
       1. baseline route with no exclusions → obstacles that lie on it (on_baseline)
-      2. if on_baseline is non-empty, avoidance route excluding only those obstacles
-         → obstacles still on it (on_avoidance)
-    avoidedObstaclesCount = len(on_baseline) - len(on_avoidance), so it only counts
-    obstacles relevant to *this* trip.
+      2. if on_baseline is non-empty, avoidance route with ALL verified obstacles
+         passed to Valhalla as exclude_locations (not just on_baseline) so the
+         alternative doesn't end up routing through a different verified obstacle
+         that simply wasn't on the original baseline.
 
-    Returns baselineRoute always, and alternativeRoute only when the second pass
-    actually improves on the baseline (fewer obstacles on the path).
-    Warnings and isAccessible are derived from the chosen route.
+    avoidedObstaclesCount = |on_baseline_ids - on_chosen_ids|  (set diff). This
+    counts only the baseline-blocking obstacles we actually got rid of, and isn't
+    confused by new obstacles the alternative happens to pass near.
+
+    Returns baselineRoute always, and alternativeRoute only when it strictly
+    improves on the baseline (avoidedObstaclesCount > 0).
+    Warnings and isAccessible are derived from all verified obstacles on the
+    chosen route.
     """
     origin = [origin_lat, origin_lng]
     destination = [dest_lat, dest_lng]
@@ -151,6 +193,7 @@ def calculate_route(origin_lat, origin_lng, dest_lat, dest_lng, preferences):
     on_baseline = _obstacles_on_route(
         baseline_waypoints, verified_obstacles, OBSTACLE_PROXIMITY_RADIUS_M
     )
+    on_baseline_ids = {obs['id'] for obs in on_baseline}
 
     baseline_route = _route_payload(baseline_waypoints, baseline_distance, baseline_duration)
     alternative_route = None
@@ -161,21 +204,24 @@ def calculate_route(origin_lat, origin_lng, dest_lat, dest_lng, preferences):
     if on_baseline:
         try:
             alt_waypoints, alt_distance, alt_duration = _call_valhalla(
-                origin, destination, exclude_locations=on_baseline,
+                origin, destination, exclude_locations=verified_obstacles,
             )
-            on_avoidance = _obstacles_on_route(
+            on_alternative = _obstacles_on_route(
                 alt_waypoints, verified_obstacles, OBSTACLE_PROXIMITY_RADIUS_M
             )
-            # Only surface the alternative if it genuinely improves on baseline.
-            if len(on_avoidance) < len(on_baseline):
+            on_alternative_ids = {obs['id'] for obs in on_alternative}
+            # Only surface the alternative if it removes at least one of the
+            # baseline-blocking obstacles.
+            if on_baseline_ids - on_alternative_ids:
                 alternative_route = _route_payload(alt_waypoints, alt_distance, alt_duration)
                 chosen_waypoints = alt_waypoints
-                on_chosen = on_avoidance
+                on_chosen = on_alternative
         except ValueError:
             # Avoidance failed — stick with baseline.
             pass
 
-    avoided_count = len(on_baseline) - len(on_chosen)
+    on_chosen_ids = {obs['id'] for obs in on_chosen}
+    avoided_count = len(on_baseline_ids - on_chosen_ids)
 
     warnings = [
         f"Verified obstacle on route: {obs['title']} ({obs['category']})"

--- a/backend/apps/routing/tests.py
+++ b/backend/apps/routing/tests.py
@@ -35,6 +35,24 @@ def mock_call_valhalla_failure(origin, destination, exclude_locations=None):
     raise ValueError('Routing service unavailable.')
 
 
+# Far enough from MOCK_WAYPOINTS that no obstacle near the baseline lands within
+# OBSTACLE_PROXIMITY_RADIUS_M of this alternative path.
+MOCK_ALT_WAYPOINTS = [
+    [41.1000, 29.0700],
+    [41.1010, 29.0710],
+    [41.1020, 29.0720],
+    [41.1030, 29.0730],
+]
+
+
+def mock_call_valhalla_two_route(origin, destination, exclude_locations=None):
+    """Return MOCK_WAYPOINTS for the baseline call, MOCK_ALT_WAYPOINTS when
+    exclude_locations is provided (i.e. the avoidance pass)."""
+    if exclude_locations:
+        return MOCK_ALT_WAYPOINTS, MOCK_DISTANCE + 100, MOCK_DURATION + 90
+    return MOCK_WAYPOINTS, MOCK_DISTANCE, MOCK_DURATION
+
+
 def make_reporter():
     return User.objects.create_user(
         email='reporter@test.com',
@@ -164,6 +182,87 @@ class CalculateRouteViewTest(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
+@patch('apps.routing.services._get_unverified_obstacles', return_value=[])
+class PerTripAvoidanceTest(TestCase):
+    """Acceptance tests for per-trip baseline/alternative routing."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.url = '/api/routes/calculate'
+
+    @patch('apps.routing.services._get_verified_obstacles', return_value=[
+        # Far from MOCK_WAYPOINTS — not on the baseline.
+        {'id': 99, 'latitude': 41.2000, 'longitude': 29.2000,
+         'title': 'Distant obstacle', 'category': 'BLOCKED_PATH'},
+    ])
+    @patch('apps.routing.services._call_valhalla', side_effect=mock_call_valhalla)
+    def test_no_nearby_obstacles_returns_one_route(
+        self, mock_valhalla, mock_verified, mock_unverified,
+    ):
+        response = self.client.post(self.url, make_valid_payload(), format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data['avoidedObstaclesCount'], 0)
+        self.assertTrue(data['isAccessible'])
+        self.assertIsNotNone(data['baselineRoute'])
+        self.assertIsNone(data['alternativeRoute'])
+        # Only the baseline Valhalla call should have happened.
+        self.assertEqual(mock_valhalla.call_count, 1)
+
+    @patch('apps.routing.services._get_verified_obstacles', return_value=[
+        # Within OBSTACLE_PROXIMITY_RADIUS_M of MOCK_WAYPOINTS — on the baseline.
+        {'id': 1, 'latitude': 41.0835, 'longitude': 29.0505,
+         'title': 'Blocked path', 'category': 'BLOCKED_PATH'},
+    ])
+    @patch('apps.routing.services._call_valhalla', side_effect=mock_call_valhalla_two_route)
+    def test_baseline_obstacle_diverted_returns_two_routes(
+        self, mock_valhalla, mock_verified, mock_unverified,
+    ):
+        response = self.client.post(self.url, make_valid_payload(), format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        # Both routes returned.
+        self.assertIsNotNone(data['baselineRoute'])
+        self.assertIsNotNone(data['alternativeRoute'])
+        self.assertEqual(len(data['baselineRoute']['waypoints']), len(MOCK_WAYPOINTS))
+        self.assertEqual(len(data['alternativeRoute']['waypoints']), len(MOCK_ALT_WAYPOINTS))
+
+        # Per-trip count: 1 obstacle on baseline, 0 on alternative.
+        self.assertEqual(data['avoidedObstaclesCount'], 1)
+        self.assertTrue(data['isAccessible'])
+        # No warning about the obstacle since the chosen (alternative) route avoids it.
+        self.assertFalse(any('Blocked path' in w for w in data['warnings']))
+        # Top-level fields mirror the chosen (alternative) route.
+        self.assertEqual(data['waypoints'], data['alternativeRoute']['waypoints'])
+        # Two Valhalla calls: baseline + avoidance.
+        self.assertEqual(mock_valhalla.call_count, 2)
+
+    @patch('apps.routing.services._get_verified_obstacles', return_value=[
+        {'id': 1, 'latitude': 41.0835, 'longitude': 29.0505,
+         'title': 'Blocked path', 'category': 'BLOCKED_PATH'},
+    ])
+    @patch('apps.routing.services._call_valhalla', side_effect=mock_call_valhalla)
+    def test_unchanged_avoidance_returns_one_route(
+        self, mock_valhalla, mock_verified, mock_unverified,
+    ):
+        """Both passes return the same waypoints, so on_baseline == on_avoidance —
+        the alternative is suppressed."""
+        response = self.client.post(self.url, make_valid_payload(), format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertIsNotNone(data['baselineRoute'])
+        self.assertIsNone(data['alternativeRoute'])
+        self.assertEqual(data['avoidedObstaclesCount'], 0)
+        # Chosen route is baseline; obstacle still on it → not accessible, warned.
+        self.assertFalse(data['isAccessible'])
+        self.assertTrue(any('Blocked path' in w for w in data['warnings']))
+        # Two Valhalla calls (baseline + attempted avoidance), but only one route surfaced.
+        self.assertEqual(mock_valhalla.call_count, 2)
+
+
 class CalculateRouteFailureTest(TestCase):
     def setUp(self):
         self.client = APIClient()
@@ -240,10 +339,17 @@ class RouteResponseSerializerTest(TestCase):
     """Unit tests for RouteResponseSerializer field types and values (Issue #201)."""
 
     def _make_data(self, **overrides):
-        data = {
+        baseline = {
             'waypoints': [[41.0825, 29.0510], [41.0865, 29.0445]],
             'distanceMeters': 620.5,
             'estimatedTimeSeconds': 558,
+        }
+        data = {
+            'waypoints': baseline['waypoints'],
+            'distanceMeters': baseline['distanceMeters'],
+            'estimatedTimeSeconds': baseline['estimatedTimeSeconds'],
+            'baselineRoute': baseline,
+            'alternativeRoute': None,
             'avoidedObstaclesCount': 2,
             'warnings': ['Unverified obstacle nearby: Pothole'],
             'isAccessible': True,

--- a/backend/apps/routing/tests.py
+++ b/backend/apps/routing/tests.py
@@ -5,7 +5,12 @@ from rest_framework import status
 from rest_framework.test import APIClient
 
 from apps.routing.serializers import RouteResponseSerializer
-from apps.routing.services import WALKING_SPEED_MS
+from apps.routing.services import (
+    OBSTACLE_PROXIMITY_RADIUS_M,
+    WALKING_SPEED_MS,
+    _obstacles_on_route,
+    _point_to_segment_distance_m,
+)
 from apps.users.models import MobilityProfile, User
 
 
@@ -402,6 +407,41 @@ class RouteResponseSerializerTest(TestCase):
     def test_is_accessible_false_when_obstacles_on_route(self):
         s = RouteResponseSerializer(self._make_data(isAccessible=False))
         self.assertFalse(s.data['isAccessible'])
+
+
+class ObstacleOnRouteGeometryTest(TestCase):
+    """Direct unit tests for _obstacles_on_route's point-to-segment proximity check."""
+
+    def test_point_to_segment_perpendicular_distance(self):
+        # Segment ~177m long between MOCK_WAYPOINTS[4] and [5]. Midpoint sits between
+        # the two waypoints at ~88m from each — outside a 40m waypoint-only check,
+        # but 0m from the segment itself.
+        a_lat, a_lng = 41.0850, 29.0490
+        b_lat, b_lng = 41.0855, 29.0470
+        mid_lat = (a_lat + b_lat) / 2
+        mid_lng = (a_lng + b_lng) / 2
+        d = _point_to_segment_distance_m(mid_lat, mid_lng, a_lat, a_lng, b_lat, b_lng)
+        self.assertLess(d, 1.0)  # essentially on the segment
+
+    def test_obstacle_between_waypoints_is_detected(self):
+        # Obstacle sits near the midpoint of segment 4↔5 of MOCK_WAYPOINTS, far
+        # enough from both endpoints that the old waypoint-only check missed it.
+        obstacles = [
+            {'id': 1, 'latitude': 41.08525, 'longitude': 29.0480,
+             'title': 'Mid-segment', 'category': 'BLOCKED_PATH'},
+        ]
+        on_route = _obstacles_on_route(MOCK_WAYPOINTS, obstacles, OBSTACLE_PROXIMITY_RADIUS_M)
+        self.assertEqual(len(on_route), 1)
+        self.assertEqual(on_route[0]['id'], 1)
+
+    def test_obstacle_far_from_segment_is_not_detected(self):
+        # Same midpoint but pushed far enough perpendicular to be > 40m off the segment.
+        obstacles = [
+            {'id': 2, 'latitude': 41.0860, 'longitude': 29.0480,
+             'title': 'Off-segment', 'category': 'BLOCKED_PATH'},
+        ]
+        on_route = _obstacles_on_route(MOCK_WAYPOINTS, obstacles, OBSTACLE_PROXIMITY_RADIUS_M)
+        self.assertEqual(on_route, [])
 
 
 class WalkingSpeedFallbackTest(TestCase):

--- a/frontend/src/api/routes.ts
+++ b/frontend/src/api/routes.ts
@@ -15,10 +15,20 @@ export interface RouteRequest {
   preferences?: GuestPreferences;
 }
 
-export interface RouteResult {
+export interface RouteLeg {
   waypoints: [number, number][];
   distanceMeters: number;
   estimatedTimeSeconds: number;
+}
+
+export interface RouteResult {
+  // Mirrors the chosen route (alternative if present, else baseline).
+  waypoints: [number, number][];
+  distanceMeters: number;
+  estimatedTimeSeconds: number;
+  // Per-trip routes. alternativeRoute is null when avoidance didn't improve on baseline.
+  baselineRoute?: RouteLeg;
+  alternativeRoute?: RouteLeg | null;
   avoidedObstaclesCount?: number;
   warnings?: string[];
   isAccessible?: boolean;
@@ -39,6 +49,15 @@ function normalizeWaypoints(raw: any[]): [number, number][] {
   });
 }
 
+function normalizeLeg(raw: any): RouteLeg | undefined {
+  if (!raw) return undefined;
+  return {
+    waypoints: normalizeWaypoints(raw.waypoints ?? []),
+    distanceMeters: raw.distanceMeters,
+    estimatedTimeSeconds: raw.estimatedTimeSeconds,
+  };
+}
+
 export async function calculateRoute(req: RouteRequest): Promise<RouteResult | null> {
   try {
     const res = await fetch(`${API_BASE}/api/routes/calculate`, {
@@ -49,7 +68,12 @@ export async function calculateRoute(req: RouteRequest): Promise<RouteResult | n
     if (!res.ok) return null;
     const data = await res.json().catch(() => null);
     if (!data) return null;
-    return { ...data, waypoints: normalizeWaypoints(data.waypoints ?? []) };
+    return {
+      ...data,
+      waypoints: normalizeWaypoints(data.waypoints ?? []),
+      baselineRoute: normalizeLeg(data.baselineRoute),
+      alternativeRoute: data.alternativeRoute ? normalizeLeg(data.alternativeRoute) : null,
+    };
   } catch {
     return null;
   }

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -152,7 +152,7 @@ const MAP_HTML = `<!DOCTYPE html>
   // ── Route planning additions ──────────────────────────────────────────────
 
   var pinMode = null;
-  var originMarker = null, destMarker = null, routeLine = null;
+  var originMarker = null, destMarker = null, routeLine = null, baselineLine = null;
   var searchPin = null;
 
   function makeIcon(color) {
@@ -200,16 +200,27 @@ const MAP_HTML = `<!DOCTYPE html>
     if (searchPin) { map.removeLayer(searchPin); searchPin = null; }
   };
 
-  window.showRoute = function(waypointsJson) {
-    if (routeLine) map.removeLayer(routeLine);
+  window.showRoute = function(waypointsJson, baselineWaypointsJson) {
+    if (routeLine) { map.removeLayer(routeLine); routeLine = null; }
+    if (baselineLine) { map.removeLayer(baselineLine); baselineLine = null; }
     var waypoints = JSON.parse(waypointsJson);
     if (waypoints.length < 2) return;
-    routeLine = L.polyline(waypoints, { color: '#3B82F6', weight: 5, opacity: 0.85 }).addTo(map);
-    map.fitBounds(routeLine.getBounds(), { padding: [40, 40] });
+    var baseline = baselineWaypointsJson ? JSON.parse(baselineWaypointsJson) : null;
+    if (baseline && baseline.length > 1) {
+      baselineLine = L.polyline(baseline, {
+        color: '#6B7280', weight: 4, opacity: 0.7, dashArray: '8 8'
+      }).addTo(map);
+    }
+    routeLine = L.polyline(waypoints, { color: '#3B82F6', weight: 5, opacity: 0.9 }).addTo(map);
+    var fitGroup = baselineLine
+      ? L.featureGroup([baselineLine, routeLine])
+      : routeLine;
+    map.fitBounds(fitGroup.getBounds(), { padding: [40, 40] });
   };
 
   window.clearRoute = function() {
     if (routeLine) { map.removeLayer(routeLine); routeLine = null; }
+    if (baselineLine) { map.removeLayer(baselineLine); baselineLine = null; }
   };
 
   window.clearMarkers = function() {
@@ -488,8 +499,14 @@ export default function MapView() {
     if (result) {
       setRoute(result);
       if (result.waypoints.length > 1) {
+        // Pass the baseline as a second arg only when an alternative is also being shown,
+        // so the WebView draws baseline (dashed) underneath alternative (solid).
+        const baselineArg =
+          result.alternativeRoute && result.baselineRoute
+            ? JSON.stringify(JSON.stringify(result.baselineRoute.waypoints))
+            : 'null';
         webViewRef.current?.injectJavaScript(
-          `window.showRoute(${JSON.stringify(JSON.stringify(result.waypoints))}); true;`
+          `window.showRoute(${JSON.stringify(JSON.stringify(result.waypoints))}, ${baselineArg}); true;`
         );
       }
     } else {

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -208,7 +208,7 @@ const MAP_HTML = `<!DOCTYPE html>
     var baseline = baselineWaypointsJson ? JSON.parse(baselineWaypointsJson) : null;
     if (baseline && baseline.length > 1) {
       baselineLine = L.polyline(baseline, {
-        color: '#6B7280', weight: 4, opacity: 0.7, dashArray: '8 8'
+        color: '#F97316', weight: 5, opacity: 0.9, dashArray: '10 8'
       }).addTo(map);
     }
     routeLine = L.polyline(waypoints, { color: '#3B82F6', weight: 5, opacity: 0.9 }).addTo(map);
@@ -845,6 +845,15 @@ export default function MapView() {
                       <Text style={s.summaryLabel}>Avoided</Text>
                     </View>
                   </View>
+                  {route.alternativeRoute && route.baselineRoute && (
+                    <View style={s.baselineCompareRow}>
+                      <View style={s.baselineSwatch} />
+                      <Text style={s.baselineCompareLabel}>Direct (no avoidance):</Text>
+                      <Text style={s.baselineCompareValue}>
+                        {formatDistance(route.baselineRoute.distanceMeters)} · {formatTime(route.baselineRoute.estimatedTimeSeconds)}
+                      </Text>
+                    </View>
+                  )}
                 </View>
               )}
             </View>
@@ -1129,6 +1138,23 @@ const s = StyleSheet.create({
   summaryDivider: { width: 1, height: 32, backgroundColor: COLORS.green200 },
   summaryValue: { fontSize: 14, fontWeight: '700', color: COLORS.gray800 },
   summaryLabel: { fontSize: 10, color: COLORS.gray400, fontWeight: '500' },
+  baselineCompareRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 8,
+    paddingTop: 6,
+    borderTopWidth: 1,
+    borderTopColor: COLORS.green200,
+  },
+  baselineSwatch: {
+    width: 20,
+    height: 3,
+    backgroundColor: COLORS.orange500,
+    borderRadius: 1.5,
+  },
+  baselineCompareLabel: { fontSize: 11, color: COLORS.gray500, fontWeight: '500' },
+  baselineCompareValue: { fontSize: 11, color: COLORS.gray800, fontWeight: '600' },
 
   // ── Pin mode banner ────────────────────────────────────────────────────────
   pinBanner: {

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -603,11 +603,11 @@ export default function MapView() {
                 <Polyline
                   positions={route.baselineRoute.waypoints}
                   pathOptions={{
-                    color: COLORS.gray500,
-                    weight: 4,
-                    opacity: 0.7,
+                    color: COLORS.orange500,
+                    weight: 5,
+                    opacity: 0.9,
                     lineJoin: 'round',
-                    dashArray: '8 8',
+                    dashArray: '10 8',
                   }}
                 />
               )}
@@ -868,6 +868,15 @@ export default function MapView() {
                       <Text style={s.summaryLabel}>Avoided</Text>
                     </View>
                   </View>
+                  {route.alternativeRoute && route.baselineRoute && (
+                    <View style={s.baselineCompareRow}>
+                      <View style={s.baselineSwatch} />
+                      <Text style={s.baselineCompareLabel}>Direct (no avoidance):</Text>
+                      <Text style={s.baselineCompareValue}>
+                        {formatDistance(route.baselineRoute.distanceMeters)} · {formatTime(route.baselineRoute.estimatedTimeSeconds)}
+                      </Text>
+                    </View>
+                  )}
                 </View>
               )}
             </View>
@@ -1146,6 +1155,23 @@ const s = StyleSheet.create({
   summaryDivider: { width: 1, height: 32, backgroundColor: COLORS.green200 },
   summaryValue: { fontSize: 14, fontWeight: '700', color: COLORS.gray800 },
   summaryLabel: { fontSize: 10, color: COLORS.gray400, fontWeight: '500' },
+  baselineCompareRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 8,
+    paddingTop: 6,
+    borderTopWidth: 1,
+    borderTopColor: COLORS.green200,
+  },
+  baselineSwatch: {
+    width: 20,
+    height: 3,
+    backgroundColor: COLORS.orange500,
+    borderRadius: 1.5,
+  },
+  baselineCompareLabel: { fontSize: 11, color: COLORS.gray500, fontWeight: '500' },
+  baselineCompareValue: { fontSize: 11, color: COLORS.gray800, fontWeight: '600' },
 
   // ── Pin mode banner ──────────────────────────────────────────────────────
   pinBanner: {

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -143,14 +143,17 @@ function FlyTo({ target }: { target: [number, number] | null }) {
   return null;
 }
 
-function FitRoute({ waypoints }: { waypoints: [number, number][] | null }) {
+function FitRoute({ route }: { route: RouteResult | null }) {
   const map = useMap();
   useEffect(() => {
-    if (waypoints && waypoints.length > 1) {
-      map.fitBounds(waypoints as L.LatLngBoundsExpression, { padding: [60, 60] });
+    const baseline = route?.baselineRoute?.waypoints ?? route?.waypoints ?? [];
+    const alternative = route?.alternativeRoute?.waypoints ?? [];
+    const combined = [...baseline, ...alternative];
+    if (combined.length > 1) {
+      map.fitBounds(combined as L.LatLngBoundsExpression, { padding: [60, 60] });
       setTimeout(() => map.invalidateSize(), 100);
     }
-  }, [waypoints]);
+  }, [route]);
   return null;
 }
 
@@ -522,7 +525,7 @@ export default function MapView() {
           <BoundsWatcher onChange={handleBoundsChange} />
           <ClickHandler active={!!pinMode} onPick={handleMapClick} />
           <FlyTo target={flyTarget} />
-          <FitRoute waypoints={route?.waypoints ?? null} />
+          <FitRoute route={route} />
 
           {/* Obstacle markers — re-applied every render so an in-session
               status update to CLOSED removes the marker without a reload. */}
@@ -592,8 +595,30 @@ export default function MapView() {
           {routePanelOpen && originLL && <Marker position={originLL} icon={ORIGIN_ICON} />}
           {routePanelOpen && destLL && <Marker position={destLL} icon={DEST_ICON} />}
 
-          {/* Route polyline */}
-          {route && route.waypoints.length > 1 && (
+          {/* Route polylines: when an alternative was returned, draw the
+              baseline (dashed, secondary) underneath the alternative (solid). */}
+          {route?.alternativeRoute && route.alternativeRoute.waypoints.length > 1 && (
+            <>
+              {route.baselineRoute && route.baselineRoute.waypoints.length > 1 && (
+                <Polyline
+                  positions={route.baselineRoute.waypoints}
+                  pathOptions={{
+                    color: COLORS.gray500,
+                    weight: 4,
+                    opacity: 0.7,
+                    lineJoin: 'round',
+                    dashArray: '8 8',
+                  }}
+                />
+              )}
+              <Polyline
+                positions={route.alternativeRoute.waypoints}
+                pathOptions={{ color: COLORS.blue500, weight: 5, opacity: 0.9, lineJoin: 'round' }}
+              />
+            </>
+          )}
+          {/* No alternative: render the chosen route as a single solid line. */}
+          {!route?.alternativeRoute && route && route.waypoints.length > 1 && (
             <Polyline
               positions={route.waypoints}
               pathOptions={{ color: COLORS.blue500, weight: 5, opacity: 0.85, lineJoin: 'round' }}

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -47,7 +47,7 @@ const PLAN_MAP_HTML = `<!DOCTYPE html>
   L.control.zoom({ position: 'bottomright' }).addTo(map);
 
   var pinMode = null;
-  var originMarker = null, destMarker = null, routeLine = null;
+  var originMarker = null, destMarker = null, routeLine = null, baselineLine = null;
 
   function makeIcon(color) {
     return L.divIcon({
@@ -84,12 +84,22 @@ const PLAN_MAP_HTML = `<!DOCTYPE html>
     destMarker = L.marker([lat, lng], { icon: makeIcon('#EF4444') }).addTo(map);
   };
 
-  window.showRoute = function(waypointsJson) {
-    if (routeLine) map.removeLayer(routeLine);
+  window.showRoute = function(waypointsJson, baselineWaypointsJson) {
+    if (routeLine) { map.removeLayer(routeLine); routeLine = null; }
+    if (baselineLine) { map.removeLayer(baselineLine); baselineLine = null; }
     var waypoints = JSON.parse(waypointsJson);
     if (waypoints.length < 2) return;
-    routeLine = L.polyline(waypoints, { color: '#3B82F6', weight: 5, opacity: 0.85 }).addTo(map);
-    map.fitBounds(routeLine.getBounds(), { padding: [40, 40] });
+    var baseline = baselineWaypointsJson ? JSON.parse(baselineWaypointsJson) : null;
+    if (baseline && baseline.length > 1) {
+      baselineLine = L.polyline(baseline, {
+        color: '#6B7280', weight: 4, opacity: 0.7, dashArray: '8 8'
+      }).addTo(map);
+    }
+    routeLine = L.polyline(waypoints, { color: '#3B82F6', weight: 5, opacity: 0.9 }).addTo(map);
+    var fitGroup = baselineLine
+      ? L.featureGroup([baselineLine, routeLine])
+      : routeLine;
+    map.fitBounds(fitGroup.getBounds(), { padding: [40, 40] });
   };
 
   window.fitBothPoints = function() {
@@ -101,6 +111,7 @@ const PLAN_MAP_HTML = `<!DOCTYPE html>
 
   window.clearRoute = function() {
     if (routeLine) { map.removeLayer(routeLine); routeLine = null; }
+    if (baselineLine) { map.removeLayer(baselineLine); baselineLine = null; }
   };
 </script>
 </body>
@@ -205,8 +216,12 @@ export default function PlanView() {
     if (result) {
       setRoute(result);
       if (result.waypoints.length > 1) {
+        const baselineArg =
+          result.alternativeRoute && result.baselineRoute
+            ? JSON.stringify(JSON.stringify(result.baselineRoute.waypoints))
+            : 'null';
         webViewRef.current?.injectJavaScript(
-          `window.showRoute(${JSON.stringify(JSON.stringify(result.waypoints))}); true;`
+          `window.showRoute(${JSON.stringify(JSON.stringify(result.waypoints))}, ${baselineArg}); true;`
         );
       }
     } else {

--- a/frontend/src/components/plan/PlanView.tsx
+++ b/frontend/src/components/plan/PlanView.tsx
@@ -92,7 +92,7 @@ const PLAN_MAP_HTML = `<!DOCTYPE html>
     var baseline = baselineWaypointsJson ? JSON.parse(baselineWaypointsJson) : null;
     if (baseline && baseline.length > 1) {
       baselineLine = L.polyline(baseline, {
-        color: '#6B7280', weight: 4, opacity: 0.7, dashArray: '8 8'
+        color: '#F97316', weight: 5, opacity: 0.9, dashArray: '10 8'
       }).addTo(map);
     }
     routeLine = L.polyline(waypoints, { color: '#3B82F6', weight: 5, opacity: 0.9 }).addTo(map);
@@ -360,6 +360,16 @@ export default function PlanView() {
             </View>
           </View>
 
+          {route.alternativeRoute && route.baselineRoute && (
+            <View style={s.baselineCompareRow}>
+              <View style={s.baselineSwatch} />
+              <Text style={s.baselineCompareLabel}>Direct (no avoidance):</Text>
+              <Text style={s.baselineCompareValue}>
+                {formatDistance(route.baselineRoute.distanceMeters)} · {formatTime(route.baselineRoute.estimatedTimeSeconds)}
+              </Text>
+            </View>
+          )}
+
           {route.warnings && route.warnings.length > 0 && (
             <View style={s.warningsBox}>
               {route.warnings.map((w, i) => (
@@ -512,6 +522,18 @@ const s = StyleSheet.create({
   },
   warningRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 6 },
   warningText: { flex: 1, fontSize: 12, color: COLORS.gray700, lineHeight: 17 },
+
+  baselineCompareRow: {
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    marginTop: 10, paddingTop: 8,
+    borderTopWidth: 1, borderTopColor: COLORS.gray100,
+  },
+  baselineSwatch: {
+    width: 22, height: 3,
+    backgroundColor: COLORS.orange500, borderRadius: 1.5,
+  },
+  baselineCompareLabel: { fontSize: 12, color: COLORS.gray500, fontWeight: '500' },
+  baselineCompareValue: { fontSize: 12, color: COLORS.gray800, fontWeight: '600' },
 
   overlay: {
     position: 'absolute', top: 0, left: 0, right: 0, bottom: 0,

--- a/frontend/src/components/plan/PlanView.web.tsx
+++ b/frontend/src/components/plan/PlanView.web.tsx
@@ -301,12 +301,42 @@ export default function PlanView() {
           />
           <ZoomControl position="bottomright" />
           <ClickHandler active={!!pinMode} onPick={handleMapClick} />
-          <FitBounds origin={originLL} dest={destLL} route={route?.waypoints ?? null} />
+          <FitBounds
+            origin={originLL}
+            dest={destLL}
+            route={
+              route
+                ? [
+                    ...(route.baselineRoute?.waypoints ?? route.waypoints ?? []),
+                    ...(route.alternativeRoute?.waypoints ?? []),
+                  ]
+                : null
+            }
+          />
 
           {originLL && <Marker position={originLL} icon={ORIGIN_ICON} />}
           {destLL   && <Marker position={destLL}   icon={DEST_ICON}   />}
 
-          {route && route.waypoints.length > 1 && (
+          {/* Baseline dashed underneath when there's also an alternative. */}
+          {route?.alternativeRoute && route.baselineRoute && route.baselineRoute.waypoints.length > 1 && (
+            <Polyline
+              positions={route.baselineRoute.waypoints}
+              pathOptions={{
+                color: COLORS.gray500,
+                weight: 4,
+                opacity: 0.7,
+                lineJoin: 'round',
+                dashArray: '8 8',
+              }}
+            />
+          )}
+          {route?.alternativeRoute && route.alternativeRoute.waypoints.length > 1 && (
+            <Polyline
+              positions={route.alternativeRoute.waypoints}
+              pathOptions={{ color: COLORS.blue500, weight: 5, opacity: 0.9, lineJoin: 'round' }}
+            />
+          )}
+          {!route?.alternativeRoute && route && route.waypoints.length > 1 && (
             <Polyline
               positions={route.waypoints}
               pathOptions={{ color: COLORS.blue500, weight: 5, opacity: 0.85, lineJoin: 'round' }}

--- a/frontend/src/components/plan/PlanView.web.tsx
+++ b/frontend/src/components/plan/PlanView.web.tsx
@@ -322,11 +322,11 @@ export default function PlanView() {
             <Polyline
               positions={route.baselineRoute.waypoints}
               pathOptions={{
-                color: COLORS.gray500,
-                weight: 4,
-                opacity: 0.7,
+                color: COLORS.orange500,
+                weight: 5,
+                opacity: 0.9,
                 lineJoin: 'round',
-                dashArray: '8 8',
+                dashArray: '10 8',
               }}
             />
           )}
@@ -366,6 +366,16 @@ export default function PlanView() {
                 <Text style={s.summaryLabel}>Avoided</Text>
               </View>
             </View>
+
+            {route.alternativeRoute && route.baselineRoute && (
+              <View style={s.baselineCompareRow}>
+                <View style={s.baselineSwatch} />
+                <Text style={s.baselineCompareLabel}>Direct (no avoidance):</Text>
+                <Text style={s.baselineCompareValue}>
+                  {formatDistance(route.baselineRoute.distanceMeters)} · {formatTime(route.baselineRoute.estimatedTimeSeconds)}
+                </Text>
+              </View>
+            )}
 
             {route.warnings && route.warnings.length > 0 && (
               <View style={s.warningsBox}>
@@ -583,6 +593,24 @@ const s = StyleSheet.create({
   },
   warningRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 6 },
   warningText: { flex: 1, fontSize: 12, color: COLORS.gray700, lineHeight: 17 },
+
+  baselineCompareRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginTop: 10,
+    paddingTop: 8,
+    borderTopWidth: 1,
+    borderTopColor: COLORS.gray100,
+  },
+  baselineSwatch: {
+    width: 22,
+    height: 3,
+    backgroundColor: COLORS.orange500,
+    borderRadius: 1.5,
+  },
+  baselineCompareLabel: { fontSize: 12, color: COLORS.gray500, fontWeight: '500' },
+  baselineCompareValue: { fontSize: 12, color: COLORS.gray800, fontWeight: '600' },
 
   // Guest prefs overlay
   overlay: {


### PR DESCRIPTION
## Description

  Replaces the misleading global "avoided" count on the route response with a per-trip metric, and now returns both the baseline and
  an optional avoidance alternative so the user can compare them on the map. Backend computes baseline first, then a second Valhalla
  pass that excludes all verified obstacles; the response includes baselineRoute and alternativeRoute (when it removes at least one
  baseline-blocking obstacle), with avoidedObstaclesCount as a set difference between baseline and chosen route. Frontend renders the
  baseline as a dashed orange line under the solid blue alternative, with a small comparison row showing the baseline's distance and
  time.

## Type of Change

  - feat — new feature
  - fix — bug fix
  - refactor — code refactor
  - docs — documentation
  - chore — maintenance / configuration
  - perf — performance improvement
  - test — adding or updating tests
  - style — formatting, missing semicolons, etc.

## Changes

  - Backend: two-pass routing in apps/routing/services.py — baseline first, then avoidance pass with all verified obstacles as
  exclude_locations; avoidedObstaclesCount = |on_baseline_ids − on_chosen_ids|; alternative only surfaced when it strictly removes at
  least one baseline-blocking obstacle. RouteResponseSerializer adds baselineRoute and nullable alternativeRoute; top-level fields
  kept as a mirror of the chosen route for backward compatibility.
  - Backend: replaced waypoint-only haversine proximity with a point-to-segment distance check so obstacles alongside the path (but
  between waypoints) are no longer missed. Added a merge migration for the two reports migration leaves (0002_comment,
  0005_report_bbox_index).
  - Frontend: updated RouteResult type and calculateRoute to normalize both legs. All four view files (MapView.tsx, MapView.web.tsx,
  PlanView.tsx, PlanView.web.tsx) render baseline (dashed orange) under alternative (solid blue) when both exist, fall back to a
  single polyline otherwise, and show a small "Direct (no avoidance)" comparison row with baseline distance + time.

## How to Test

  1. docker compose up (backend on :8000) and cd frontend && EXPO_PUBLIC_API_URL=http://localhost:8000 npm run web (Expo on :8081).
  2. Plan a route with no verified obstacles between origin and destination → expect one solid blue line, "Avoided: 0", no comparison
  row.
  3. Plan a route where a verified+outdoor obstacle sits on the direct path → expect a dashed orange baseline under a solid blue
  alternative, "Avoided ≥ 1", and the small "Direct (no avoidance): … · …" comparison row showing baseline's distance/time.
  4. Plan a route where Valhalla can't find a clean detour (obstacle on the only path) → expect a single solid blue line, the obstacle
   in the warnings list, isAccessible: false.
  5. Backend tests: cd backend && python -m pytest apps/routing/tests.py — 30 pass; 3 pre-existing failures unrelated to this PR
  (test_estimated_time_is_integer, WalkingSpeedFallbackTest ×2 — also failing on main).

## Screenshots (if applicable)

## Checklist

  - Commit messages follow <type>(<scope>): <subject> format
  - Branch is up to date with the target branch
  - No self-merge — at least 1 reviewer assigned
  - Closes #239

## Notes

  - Three pre-existing test failures in apps/routing/tests.py are present on main too and are out of scope here (FloatField returns
  float, not int; WalkingSpeedFallback mocks bypass _call_valhalla's internal fallback).
  - Includes a reports merge migration (0006_merge_0002_comment_0005_report_bbox_index) needed to start the backend after merging two
  parallel migration branches; safe (graph-join only, no schema change).
  - Avoidance now passes all verified outdoor obstacles to Valhalla, not just baseline-blocking ones — necessary so the alternative
  doesn't route through a different verified obstacle that simply wasn't on baseline.