### PR TITLE
perf(map): debounce bounds fetch, cache icons, fix popup flash on bac…

### DIFF
--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -61,11 +61,15 @@ const ORIGIN_ICON = makeCircleIcon(COLORS.green700);
 const DEST_ICON = makeCircleIcon(COLORS.red500);
 const SEARCH_PIN_ICON = makeCircleIcon(COLORS.red500);
 
+const _indoorIconCache: Record<string, L.DivIcon> = {};
+
 /** Indoor obstacle: circle with a small white 'i' badge — same colour coding as outdoor.
  *  When `hollow` is true (unverified), inverts to white background +
  *  dashed category-colored border + category-colored 'i'. */
-const makeIndoorCircleIcon = (color: string, hollow = false) =>
-  L.divIcon({
+const makeIndoorCircleIcon = (color: string, hollow = false) => {
+  const key = `${color}:${hollow}`;
+  if (_indoorIconCache[key]) return _indoorIconCache[key];
+  const icon = L.divIcon({
     html: `<div style="
       width:22px;height:22px;border-radius:50%;
       background:${hollow ? 'white' : color};
@@ -79,6 +83,9 @@ const makeIndoorCircleIcon = (color: string, hollow = false) =>
     iconSize: [22, 22],
     iconAnchor: [11, 11],
   });
+  _indoorIconCache[key] = icon;
+  return icon;
+};
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
@@ -205,6 +212,7 @@ export default function MapView() {
   const router = useRouter();
   const mapRef = useRef<L.Map | null>(null);
   const autocompleteTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const boundsDebounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Obstacle state
   const [obstacles, setObstacles] = useState<Obstacle[]>([]);
@@ -212,7 +220,6 @@ export default function MapView() {
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
   const [boundsKey, setBoundsKey] = useState('');
   const [detailMap, setDetailMap] = useState<Record<string, ObstacleDetail | 'loading'>>({});
-  const prefetchedRef = useRef(false);
   const [showPassive, setShowPassive] = useState(false);
 
   // Search state
@@ -296,13 +303,6 @@ export default function MapView() {
   // ── Obstacle loading ─────────────────────────────────────────────────────
 
   useEffect(() => {
-    prefetchedRef.current = true;
-    fetchObstacles(DEFAULT_BBOX, false).then((data) => {
-      setObstacles((prev) => (prev.length === 0 ? data : prev));
-    });
-  }, []);
-
-  useEffect(() => {
     if (!currentBounds) return;
     let cancelled = false;
     fetchObstacles(
@@ -318,10 +318,11 @@ export default function MapView() {
   }, [boundsKey, showPassive]);
 
   const handleBoundsChange = useCallback((b: L.LatLngBounds, z: number) => {
-    setCurrentBounds(b);
     setZoom(z);
-    const key = `${b.getNorth().toFixed(4)},${b.getSouth().toFixed(4)},${b.getEast().toFixed(4)},${b.getWest().toFixed(4)}`;
-    setBoundsKey(key);
+    setCurrentBounds(b);
+    const key = `${b.getNorth().toFixed(3)},${b.getSouth().toFixed(3)},${b.getEast().toFixed(3)},${b.getWest().toFixed(3)}`;
+    if (boundsDebounceTimer.current) clearTimeout(boundsDebounceTimer.current);
+    boundsDebounceTimer.current = setTimeout(() => setBoundsKey(key), 400);
   }, []);
 
   const handlePinClick = useCallback(async (id: string) => {
@@ -549,7 +550,7 @@ export default function MapView() {
                       obs={obs}
                       detail={detail}
                       loading={detailLoading}
-                      onViewDetails={() => router.push(`/report/${obs.id}`)}
+                      onViewDetails={() => { mapRef.current?.closePopup(); router.push(`/report/${obs.id}`); }}
                     />
                   </Popup>
                 </Marker>
@@ -576,7 +577,7 @@ export default function MapView() {
                     obs={obs}
                     detail={detail}
                     loading={detailLoading}
-                    onViewDetails={() => router.push(`/report/${obs.id}`)}
+                    onViewDetails={() => { mapRef.current?.closePopup(); router.push(`/report/${obs.id}`); }}
                   />
                 </Popup>
               </CircleMarker>

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -213,6 +213,9 @@ export default function MapView() {
   const mapRef = useRef<L.Map | null>(null);
   const autocompleteTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const boundsDebounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const obstacleMapRef = useRef<Map<string, Obstacle>>(new Map());
+  const fetchedBoundsRef = useRef<{ north: number; south: number; east: number; west: number } | null>(null);
+  const lastShowPassiveRef = useRef<boolean>(false);
 
   // Obstacle state
   const [obstacles, setObstacles] = useState<Obstacle[]>([]);
@@ -304,16 +307,42 @@ export default function MapView() {
 
   useEffect(() => {
     if (!currentBounds) return;
+
+    const nb = {
+      north: currentBounds.getNorth(),
+      south: currentBounds.getSouth(),
+      east: currentBounds.getEast(),
+      west: currentBounds.getWest(),
+    };
+
+    if (lastShowPassiveRef.current !== showPassive) {
+      lastShowPassiveRef.current = showPassive;
+      obstacleMapRef.current.clear();
+      fetchedBoundsRef.current = null;
+    }
+
+    const fb = fetchedBoundsRef.current;
+    if (fb &&
+        nb.north <= fb.north &&
+        nb.south >= fb.south &&
+        nb.east <= fb.east &&
+        nb.west >= fb.west) {
+      return;
+    }
+
     let cancelled = false;
-    fetchObstacles(
-      {
-        north: currentBounds.getNorth(),
-        south: currentBounds.getSouth(),
-        east: currentBounds.getEast(),
-        west: currentBounds.getWest(),
-      },
-      showPassive,
-    ).then((data) => { if (!cancelled) setObstacles(data); });
+    fetchObstacles(nb, showPassive).then((data) => {
+      if (cancelled) return;
+      for (const obs of data) obstacleMapRef.current.set(obs.id, obs);
+      const cur = fetchedBoundsRef.current;
+      fetchedBoundsRef.current = cur ? {
+        north: Math.max(cur.north, nb.north),
+        south: Math.min(cur.south, nb.south),
+        east: Math.max(cur.east, nb.east),
+        west: Math.min(cur.west, nb.west),
+      } : nb;
+      setObstacles([...obstacleMapRef.current.values()]);
+    });
     return () => { cancelled = true; };
   }, [boundsKey, showPassive]);
 

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -216,10 +216,10 @@ export default function MapView() {
   const obstacleMapRef = useRef<Map<string, Obstacle>>(new Map());
   const fetchedBoundsRef = useRef<{ north: number; south: number; east: number; west: number } | null>(null);
   const lastShowPassiveRef = useRef<boolean>(false);
+  const currentBoundsRef = useRef<L.LatLngBounds | null>(null);
 
   // Obstacle state
   const [obstacles, setObstacles] = useState<Obstacle[]>([]);
-  const [currentBounds, setCurrentBounds] = useState<L.LatLngBounds | null>(null);
   const [zoom, setZoom] = useState(DEFAULT_ZOOM);
   const [boundsKey, setBoundsKey] = useState('');
   const [detailMap, setDetailMap] = useState<Record<string, ObstacleDetail | 'loading'>>({});
@@ -306,13 +306,14 @@ export default function MapView() {
   // ── Obstacle loading ─────────────────────────────────────────────────────
 
   useEffect(() => {
-    if (!currentBounds) return;
+    const b = currentBoundsRef.current;
+    if (!b) return;
 
     const nb = {
-      north: currentBounds.getNorth(),
-      south: currentBounds.getSouth(),
-      east: currentBounds.getEast(),
-      west: currentBounds.getWest(),
+      north: b.getNorth(),
+      south: b.getSouth(),
+      east: b.getEast(),
+      west: b.getWest(),
     };
 
     if (lastShowPassiveRef.current !== showPassive) {
@@ -347,11 +348,13 @@ export default function MapView() {
   }, [boundsKey, showPassive]);
 
   const handleBoundsChange = useCallback((b: L.LatLngBounds, z: number) => {
-    setZoom(z);
-    setCurrentBounds(b);
+    currentBoundsRef.current = b;
     const key = `${b.getNorth().toFixed(3)},${b.getSouth().toFixed(3)},${b.getEast().toFixed(3)},${b.getWest().toFixed(3)}`;
     if (boundsDebounceTimer.current) clearTimeout(boundsDebounceTimer.current);
-    boundsDebounceTimer.current = setTimeout(() => setBoundsKey(key), 400);
+    boundsDebounceTimer.current = setTimeout(() => {
+      setZoom(z);
+      setBoundsKey(key);
+    }, 400);
   }, []);
 
   const handlePinClick = useCallback(async (id: string) => {


### PR DESCRIPTION
## Description
Addresses several performance issues in the web map view: redundant API calls on mount and during pan/zoom, expensive icon object recreation on every render, and a visual glitch where the Leaflet popup appears semi-transparent when returning to the map from a report detail screen.

## Type of Change
- [x] `perf` — performance improvement
- [x] `fix` — bug fix

## Changes
- Debounce `handleBoundsChange` by 400ms so rapid pan/zoom events don't each fire a separate obstacle fetch
- Cache `L.divIcon` instances in a module-level map keyed by `category:hollow` — avoids reconstructing DOM-heavy icon objects on every React render
- Call `mapRef.current?.closePopup()` before pushing to the detail route — prevents Leaflet's CSS fade-in animation from replaying on the already-mounted popup when the user navigates back
- Remove the initial `useEffect` that fetched `DEFAULT_BBOX` on mount; `BoundsWatcher` fires immediately and fetches the real viewport, making the extra call redundant

## How to Test
1. Open the map and pan/zoom rapidly — verify only one fetch fires per movement (check Network tab; requests should be spaced ≥400ms)
2. Tap any obstacle marker to open its popup, then tap "View Details" — navigate back and confirm the popup is fully opaque, not fading in
3. On first load, verify only a single `/api/map/obstacles` request is made (not two in quick succession)

## Screenshots (if applicable)
N/A

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #251

## Notes
These fixes apply to `MapView.web.tsx` (Leaflet/web). The native `MapView.tsx` (WebView) has a separate rendering path and is not affected by this PR.
