### PR TITLE
refactor(frontend): drop ACTIVE pill and stub Badges card from profile (#253)

### DIFF
--- a/frontend/app/tabs/profile.tsx
+++ b/frontend/app/tabs/profile.tsx
@@ -88,10 +88,11 @@ export default function ProfileScreen() {
           <View style={{ flex: 1, minWidth: 0 }}>
             <Text style={s.name}>{user?.fullName || '—'}</Text>
             <Text style={s.email}>{user?.email || '—'}</Text>
-            <View style={s.badgeRow}>
-              <View style={[s.badge, s.badgeGreen]}><Ionicons name="shield-checkmark" size={12} color={COLORS.green700} /><Text style={[s.badgeText, { color: COLORS.green700 }]}>{user?.status || 'ACTIVE'}</Text></View>
-              {user?.role === 'TRUSTED_CONTRIBUTOR' && <TrustedContributorBadge />}
-            </View>
+            {user?.role === 'TRUSTED_CONTRIBUTOR' && (
+              <View style={s.badgeRow}>
+                <TrustedContributorBadge />
+              </View>
+            )}
           </View>
           <TouchableOpacity style={s.editBtn} onPress={() => { setEditing(!editing); setEditError(''); }}><Ionicons name="create-outline" size={16} color={COLORS.gray500} /></TouchableOpacity>
         </View>
@@ -153,11 +154,6 @@ export default function ProfileScreen() {
       </View>
 
       <View style={[s.card, { marginBottom: 20 }]}>
-        <View style={s.cardTitleRow}><Ionicons name="ribbon-outline" size={16} color={COLORS.green600} /><Text style={s.cardTitle}>Badges</Text></View>
-        <View style={s.stub}><View style={s.stubTag}><Text style={s.stubTagText}>MILESTONE 2</Text></View><Text style={s.stubP}>Earned badges from contributions and community activity.</Text></View>
-      </View>
-
-      <View style={[s.card, { marginBottom: 20 }]}>
         <View style={s.cardTitleRow}><Ionicons name="notifications-outline" size={16} color={COLORS.green600} /><Text style={s.cardTitle}>Notifications</Text></View>
         <View style={s.toggleRow}>
           <View style={{ flex: 1 }}>
@@ -213,10 +209,6 @@ const s = StyleSheet.create({
   name: { fontSize: 18, fontWeight: '800', color: COLORS.gray900 },
   email: { fontSize: 13, color: COLORS.gray500, marginTop: 1 },
   badgeRow: { flexDirection: 'row', gap: 8, marginTop: 8, flexWrap: 'wrap' },
-  badge: { flexDirection: 'row', alignItems: 'center', gap: 4, paddingHorizontal: 10, paddingVertical: 4, borderRadius: 100 },
-  badgeGreen: { backgroundColor: COLORS.green100 },
-  badgeAmber: { backgroundColor: COLORS.orange100 },
-  badgeText: { fontSize: 11, fontWeight: '700' },
   trustRow: { flexDirection: 'row', alignItems: 'center', gap: 14 },
   trustValue: { fontSize: 32, fontWeight: '800', color: COLORS.green700, minWidth: 56 },
   trustHint: { flex: 1, fontSize: 12, color: COLORS.gray500, lineHeight: 17 },
@@ -231,8 +223,6 @@ const s = StyleSheet.create({
   btnOutline: { flex: 1, backgroundColor: COLORS.white, paddingVertical: 11, borderRadius: 10, alignItems: 'center', borderWidth: 1.5, borderColor: COLORS.gray300 },
   btnOutlineText: { color: COLORS.gray700, fontSize: 14, fontWeight: '700' },
   stub: { backgroundColor: COLORS.gray50, borderWidth: 2, borderStyle: 'dashed', borderColor: COLORS.gray300, borderRadius: 10, padding: 20, alignItems: 'center' },
-  stubTag: { backgroundColor: COLORS.orange100, paddingHorizontal: 8, paddingVertical: 3, borderRadius: 100, marginBottom: 6 },
-  stubTagText: { fontSize: 10, fontWeight: '800', color: COLORS.orange500, letterSpacing: 0.5 },
   stubP: { fontSize: 13, color: COLORS.gray400, textAlign: 'center', lineHeight: 20 },
   placeRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10, paddingVertical: 10, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: COLORS.gray200 },
   placeLabel: { fontSize: 14, fontWeight: '600', color: COLORS.gray800 },

--- a/frontend/src/__tests__/TrustedContributorBadge.test.tsx
+++ b/frontend/src/__tests__/TrustedContributorBadge.test.tsx
@@ -125,10 +125,14 @@ describe('Profile screen — Trusted Contributor badge & Trust Score', () => {
       data: makeUser({ role: 'USER' }),
     } as any);
 
-    const { queryByTestId, findByTestId } = render(<ProfileScreen />);
+    const { queryByTestId, queryByText, findByTestId } = render(<ProfileScreen />);
     // Wait for the screen to finish loading (trust score renders after fetch)
     await findByTestId('trust-score-value');
     expect(queryByTestId('trusted-contributor-badge')).toBeNull();
+    // Regression guards for the profile-badges cleanup: the green ACTIVE pill
+    // and the MILESTONE 2 "Badges" stub card must not render.
+    expect(queryByText('ACTIVE')).toBeNull();
+    expect(queryByText(/MILESTONE 2/i)).toBeNull();
   });
 
   it('does NOT render the badge for unrelated roles (e.g. "ADMIN")', async () => {


### PR DESCRIPTION
Closes #253.

## What
Cleans up the profile screen so the only badge-related UI is the **Trusted Contributor** badge, and only when `role === 'TRUSTED_CONTRIBUTOR'`. Removes:

1. The green **ACTIVE** pill next to the user's name.
2. The **Badges** card at the bottom that just showed a *MILESTONE 2* placeholder.

## Why
Both elements carried no real information:

- The ACTIVE pill rendered for every signed-in user — there was no INACTIVE/SUSPENDED variant rendered anywhere — so it conveyed nothing.
- The Badges card was a dashed stub. Now that the Trusted Contributor badge already lives next to the user's name, the dedicated card had no content.

A `REGISTERED_USER` should see nothing badge-related on their profile; a `TRUSTED_CONTRIBUTOR` should see only that one badge. This PR enforces that.

## Scope
Frontend only. Trust-score gain + role promotion logic (`UNVERIFIED → VERIFIED → score bump → maybe promote` in `backend/apps/trust_scores/services.py`) is untouched. The promotion still fires only inside `apply_status_change_delta` when a report transitions UNVERIFIED → VERIFIED, exactly as before.

## Changes
- `frontend/app/tabs/profile.tsx`
  - Removed the ACTIVE pill (the green badge with the shield-checkmark icon).
  - Removed the entire "Badges" card with the MILESTONE 2 stub.
  - The TrustedContributorBadge is now rendered inline, conditionally, when `role === 'TRUSTED_CONTRIBUTOR'`.
  - Pruned the now-unused styles: `badge`, `badgeGreen`, `badgeAmber`, `badgeText`, `stubTag`, `stubTagText`. Kept `badgeRow`, `stub`, and `stubP` (still used).
- `frontend/src/__tests__/TrustedContributorBadge.test.tsx`
  - Extended the existing `role === 'USER'` test with two regression guards: `queryByText('ACTIVE')` and `queryByText(/MILESTONE 2/i)` must both be `null`.

## Testing
- Ran `npx jest` in `frontend/`: **181/181 tests pass** across 21 suites. The 22nd suite (`ReportForm.test.tsx`) fails identically on `main` due to a `react-native-webview` jest-setup issue — pre-existing, unrelated to this change.
- Manually verified in the running app:
  - As a `TRUSTED_CONTRIBUTOR`: only the Trusted Contributor badge appears next to the name; no ACTIVE pill; no Badges card at the bottom.
  - As a `REGISTERED_USER`: nothing badge-related appears.

## Acceptance Criteria (from #253)
- [x] No "ACTIVE" pill on the profile screen
- [x] No "Badges" stub card on the profile screen
- [x] Trusted Contributor badge still renders when `role === 'TRUSTED_CONTRIBUTOR'`
- [x] Profile shows nothing badge-related when `role === 'REGISTERED_USER'`
- [x] Existing `TrustedContributorBadge` tests still pass; extended with regression assertions