### PR TITLE
feat(frontend): tap a saved place on profile to focus it on the map (#255)

### DIFF
--- a/frontend/app/tabs/profile.tsx
+++ b/frontend/app/tabs/profile.tsx
@@ -139,6 +139,20 @@ export default function ProfileScreen() {
                 {!!place.address && <Text style={s.placeAddress} numberOfLines={1}>{place.address}</Text>}
               </View>
               <TouchableOpacity
+                testID={`open-on-map-${place.id}`}
+                onPress={() => router.push({
+                  pathname: '/tabs',
+                  params: {
+                    focusLat: String(place.latitude),
+                    focusLng: String(place.longitude),
+                    focusName: place.address || place.label,
+                  },
+                })}
+                style={s.deleteBtn}
+              >
+                <Ionicons name="map-outline" size={16} color={COLORS.green700} />
+              </TouchableOpacity>
+              <TouchableOpacity
                 testID={`delete-place-${place.id}`}
                 onPress={() => handleDeletePlace(place.id)}
                 disabled={deletingId === place.id}

--- a/frontend/src/__tests__/ProfileSavedPlaces.test.tsx
+++ b/frontend/src/__tests__/ProfileSavedPlaces.test.tsx
@@ -102,3 +102,55 @@ it('keeps the item if deletion fails', async () => {
   expect(mockDeleteSavedPlace).toHaveBeenCalledWith('p1');
   expect(getByTestId('saved-place-p1')).toBeTruthy();
 });
+
+it('opens the map with the address as focusName when the map button is pressed', async () => {
+  mockGetSavedPlaces.mockResolvedValue(MOCK_PLACES);
+  const { getByTestId } = render(<ProfileScreen />);
+
+  await waitFor(() => expect(getByTestId('open-on-map-p1')).toBeTruthy());
+
+  await act(async () => {
+    fireEvent.press(getByTestId('open-on-map-p1'));
+  });
+
+  expect(mockRouter.push).toHaveBeenCalledWith({
+    pathname: '/tabs',
+    params: { focusLat: '41', focusLng: '29', focusName: '123 Main St' },
+  });
+  expect(mockDeleteSavedPlace).not.toHaveBeenCalled();
+});
+
+it('falls back to the label as focusName when the saved place has no address', async () => {
+  mockGetSavedPlaces.mockResolvedValue(MOCK_PLACES);
+  const { getByTestId } = render(<ProfileScreen />);
+
+  await waitFor(() => expect(getByTestId('open-on-map-p2')).toBeTruthy());
+
+  await act(async () => {
+    fireEvent.press(getByTestId('open-on-map-p2'));
+  });
+
+  expect(mockRouter.push).toHaveBeenCalledWith({
+    pathname: '/tabs',
+    params: { focusLat: '41.1', focusLng: '29.1', focusName: 'Work' },
+  });
+});
+
+it('pressing delete does not also trigger map navigation', async () => {
+  mockGetSavedPlaces.mockResolvedValue(MOCK_PLACES);
+  const { getByTestId } = render(<ProfileScreen />);
+
+  await waitFor(() => expect(getByTestId('delete-place-p1')).toBeTruthy());
+
+  await act(async () => {
+    fireEvent.press(getByTestId('delete-place-p1'));
+  });
+
+  expect(mockDeleteSavedPlace).toHaveBeenCalledWith('p1');
+  // The map-focus push must not fire just because the row was rendered or
+  // the delete button was pressed.
+  const mapPush = mockRouter.push.mock.calls.find(
+    (call) => typeof call[0] === 'object' && (call[0] as any)?.pathname === '/tabs',
+  );
+  expect(mapPush).toBeUndefined();
+});

--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -14,7 +14,7 @@ import SavePlaceModal from './SavePlaceModal';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
 import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -293,10 +293,44 @@ export default function MapView() {
   const source = useMemo(() => ({ html: MAP_HTML }), []);
   const prefetchedRef = useRef<Obstacle[] | null>(null);
 
+  // Deep-link focus (e.g. tapping a saved place on the profile screen).
+  // Held in a ref so the READY handler can apply it if the WebView wasn't
+  // ready when the params arrived.
+  const pendingFocusRef = useRef<SearchResult | null>(null);
+  const params = useLocalSearchParams<{ focusLat?: string; focusLng?: string; focusName?: string }>();
+  const focusLat = typeof params.focusLat === 'string' ? params.focusLat : null;
+  const focusLng = typeof params.focusLng === 'string' ? params.focusLng : null;
+  const focusName = typeof params.focusName === 'string' ? params.focusName : null;
+
   // Filter state
   const [showPassive, setShowPassive] = useState(false);
 
   const { location: currentLocation } = useLocation();
+
+  useEffect(() => {
+    if (!focusLat || !focusLng || !focusName) return;
+    const lat = parseFloat(focusLat);
+    const lng = parseFloat(focusLng);
+    if (Number.isNaN(lat) || Number.isNaN(lng)) return;
+
+    const result: SearchResult = { id: `focus:${lat},${lng}`, name: focusName, latitude: lat, longitude: lng };
+    setQuery(result.name);
+    setSuggestions([]);
+    setSelectedLocation(result);
+    setSearchFocused(false);
+    setDest({ lat: result.latitude, lng: result.longitude, label: result.name });
+    setDestQ(result.name);
+
+    if (readyRef.current) {
+      webViewRef.current?.injectJavaScript(
+        `window.setSearchPin(${result.latitude}, ${result.longitude}); window.setDest(${result.latitude}, ${result.longitude}); true;`,
+      );
+    } else {
+      pendingFocusRef.current = result;
+    }
+
+    router.setParams({ focusLat: undefined, focusLng: undefined, focusName: undefined });
+  }, [focusLat, focusLng, focusName, router]);
 
   // ── Saved places ─────────────────────────────────────────────────────────
 
@@ -548,6 +582,13 @@ export default function MapView() {
         if (prefetchedRef.current) {
           pushObstacles(prefetchedRef.current, false);
           prefetchedRef.current = null;
+        }
+        if (pendingFocusRef.current) {
+          const f = pendingFocusRef.current;
+          pendingFocusRef.current = null;
+          webViewRef.current?.injectJavaScript(
+            `window.setSearchPin(${f.latitude}, ${f.longitude}); window.setDest(${f.latitude}, ${f.longitude}); true;`,
+          );
         }
       } else if (msg.type === 'BOUNDS_CHANGE') {
         const bbox = { north: msg.north, south: msg.south, east: msg.east, west: msg.west };

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -25,7 +25,7 @@ import SavePlaceModal from './SavePlaceModal';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
 import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -269,6 +269,30 @@ export default function MapView() {
   const [destFocused, setDestFocused] = useState(false);
 
   const { location: currentLocation } = useLocation();
+
+  // Deep-link focus (e.g. tapping a saved place on the profile screen).
+  const params = useLocalSearchParams<{ focusLat?: string; focusLng?: string; focusName?: string }>();
+  const focusLat = typeof params.focusLat === 'string' ? params.focusLat : null;
+  const focusLng = typeof params.focusLng === 'string' ? params.focusLng : null;
+  const focusName = typeof params.focusName === 'string' ? params.focusName : null;
+
+  useEffect(() => {
+    if (!focusLat || !focusLng || !focusName) return;
+    const lat = parseFloat(focusLat);
+    const lng = parseFloat(focusLng);
+    if (Number.isNaN(lat) || Number.isNaN(lng)) return;
+
+    const result: SearchResult = { id: `focus:${lat},${lng}`, name: focusName, latitude: lat, longitude: lng };
+    setQuery(result.name);
+    setSuggestions([]);
+    setSelectedLocation(result);
+    setSearchFocused(false);
+    setSearchPinLL([result.latitude, result.longitude]);
+    setDest({ lat: result.latitude, lng: result.longitude, label: result.name });
+    setDestQ(result.name);
+
+    router.setParams({ focusLat: undefined, focusLng: undefined, focusName: undefined });
+  }, [focusLat, focusLng, focusName, router]);
 
   // ── Saved places ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Description
Adds a small map-icon button next to each saved place on the profile screen. Tapping it switches to the Map tab and focuses the saved location — exactly like picking it from the map's search bar — drops the red search pin and auto-fills the route destination. The search bar shows the saved place's address (with label fallback when the address is missing).

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes
- `frontend/app/tabs/profile.tsx` — new `map-outline` `TouchableOpacity` next to the trash button on each saved-place row, pushes `/tabs` with `focusLat`, `focusLng`, `focusName` (address with label fallback).
- `frontend/src/components/map/MapView.tsx` — consumes focus params via `useLocalSearchParams`, mirrors `handleSelectSuggestion` behavior (search pin + destination auto-fill), clears params via `router.setParams` so revisiting the tab does not re-trigger. Pending focus held in a ref and applied from the `READY` message handler for the cold-WebView case.
- `frontend/src/components/map/MapView.web.tsx` — same params consumption; relies on the existing `FlyTo` Leaflet component (no readiness plumbing needed).
- `frontend/src/__tests__/ProfileSavedPlaces.test.tsx` — three new tests covering the navigation params, the label fallback when no address is set, and delete-button isolation.

## How to Test
1. Sign in and open the route planner. Save a destination (e.g. a place with a real street address).
2. Go to the **Profile** tab — the saved place appears with a green map icon and a red trash icon.
3. Tap the green map icon → Map tab opens; the red search pin is dropped on the saved coordinates; the search bar shows the saved place's address; the destination field is pre-filled.
4. Tap the trash icon on a saved place → the place is removed and the Map tab is **not** opened.
5. Switch to another tab and come back to **Map** → the previous focus is **not** re-applied (params are consumed once).
6. From `frontend/`, run `npx jest src/__tests__/ProfileSavedPlaces.test.tsx` — all 8 tests should pass.

## Screenshots (if applicable)
N/A — small UI addition (one icon button). Behavior matches existing search-bar selection.

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #255

## Notes
- Navigation uses Expo Router params, consistent with the pattern already used in \`app/auth/forgot-password.tsx\` and \`app/report/[id].tsx\`.
- Full frontend test suite: **184/184 pass** across 21 suites. The 22nd suite (\`ReportForm.test.tsx\`) fails identically on \`main\` due to a pre-existing \`react-native-webview\` jest-setup issue — unrelated to this PR.