### PR TITLE
fix(map): collapse route inputs into compact bar once route is calculated

### DIFF
--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -716,6 +716,28 @@ export default function MapView() {
                 </TouchableOpacity>
               </View>
 
+              {/* Collapsed route summary — shown when a route is calculated */}
+              {route ? (
+                <TouchableOpacity
+                  style={s.collapsedRouteBar}
+                  onPress={() => setRoute(null)}
+                  activeOpacity={0.8}
+                >
+                  <View style={s.collapsedRouteInner}>
+                    <View style={[s.dot, s.dotOrigin]} />
+                    <Text style={s.collapsedRouteText} numberOfLines={1}>
+                      {originQ.split(',')[0].trim()}
+                    </Text>
+                    <Ionicons name="arrow-forward" size={12} color={COLORS.gray400} />
+                    <View style={[s.dot, s.dotDest]} />
+                    <Text style={s.collapsedRouteText} numberOfLines={1}>
+                      {destQ.split(',')[0].trim()}
+                    </Text>
+                  </View>
+                  <Ionicons name="create-outline" size={18} color={COLORS.green700} />
+                </TouchableOpacity>
+              ) : (
+              <>
               {/* Saved places quick-select for origin */}
               {originFocused && savedPlaces.length > 0 && originQ.length === 0 && (
                 <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.savedChips} keyboardShouldPersistTaps="handled">
@@ -863,6 +885,8 @@ export default function MapView() {
                   <Ionicons name="alert-circle-outline" size={14} color={COLORS.red500} />
                   <Text style={s.errorText}>{routeError}</Text>
                 </View>
+              )}
+              </>
               )}
 
               {route && (
@@ -1163,6 +1187,32 @@ const s = StyleSheet.create({
   presetChipActive: { borderColor: COLORS.green600, backgroundColor: COLORS.green50 },
   presetChipText: { fontSize: 14, fontWeight: '600', color: COLORS.gray600 },
   presetChipTextActive: { color: COLORS.green700 },
+
+  // ── Collapsed route bar (shown in place of inputs when route is set) ─────
+  collapsedRouteBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: COLORS.gray50,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+    marginBottom: 4,
+  },
+  collapsedRouteInner: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginRight: 10,
+  },
+  collapsedRouteText: {
+    flex: 1,
+    fontSize: 13,
+    color: COLORS.gray700,
+    fontWeight: '500',
+  },
 
   // ── Route summary ──────────────────────────────────────────────────────────
   summaryCard: {

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -755,6 +755,28 @@ export default function MapView() {
                 </TouchableOpacity>
               </View>
 
+              {/* Collapsed route summary — shown when a route is calculated */}
+              {route ? (
+                <TouchableOpacity
+                  style={s.collapsedRouteBar}
+                  onPress={() => setRoute(null)}
+                  activeOpacity={0.8}
+                >
+                  <View style={s.collapsedRouteInner}>
+                    <View style={[s.dot, s.dotOrigin]} />
+                    <Text style={s.collapsedRouteText} numberOfLines={1}>
+                      {originQ.split(',')[0].trim()}
+                    </Text>
+                    <Ionicons name="arrow-forward" size={12} color={COLORS.gray400} />
+                    <View style={[s.dot, s.dotDest]} />
+                    <Text style={s.collapsedRouteText} numberOfLines={1}>
+                      {destQ.split(',')[0].trim()}
+                    </Text>
+                  </View>
+                  <Ionicons name="create-outline" size={18} color={COLORS.green700} />
+                </TouchableOpacity>
+              ) : (
+              <>
               {/* Saved places quick-select for origin */}
               {originFocused && savedPlaces.length > 0 && originQ.length === 0 && (
                 <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.savedChips} keyboardShouldPersistTaps="handled">
@@ -902,6 +924,8 @@ export default function MapView() {
                   <Ionicons name="alert-circle-outline" size={14} color={COLORS.red500} />
                   <Text style={s.errorText}>{routeError}</Text>
                 </View>
+              )}
+              </>
               )}
 
               {route && (
@@ -1196,6 +1220,32 @@ const s = StyleSheet.create({
   presetChipActive: { borderColor: COLORS.green600, backgroundColor: COLORS.green50 },
   presetChipText: { fontSize: 14, fontWeight: '600', color: COLORS.gray600 },
   presetChipTextActive: { color: COLORS.green700 },
+
+  // ── Collapsed route bar (shown in place of inputs when route is set) ─────
+  collapsedRouteBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: COLORS.gray50,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: COLORS.gray200,
+    marginBottom: 4,
+  },
+  collapsedRouteInner: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginRight: 10,
+  },
+  collapsedRouteText: {
+    flex: 1,
+    fontSize: 13,
+    color: COLORS.gray700,
+    fontWeight: '500',
+  },
 
   // ── Route summary ────────────────────────────────────────────────────────
   summaryCard: {


### PR DESCRIPTION
## Description
On the route planning panel (overlay on the map screen), the input form takes up over half the screen even after a route has been calculated. Origin/destination inputs, "Use current location", Get Route button, and saved places all remain visible, squeezing the map down to a narrow strip and making it hard to inspect the route on the map.

Collapse the input section into a single compact bar (showing `origin → destination` with an edit icon) once a route is returned. Tapping the edit icon clears the route and re-expands the full input form. Applied to both web (`MapView.web.tsx`) and native (`MapView.tsx`).

## Due Time
2026-05-15

## Acceptance Criteria
- [x] When a route is calculated, the input form (origin row, destination row, "Use current location", Get Route button, saved-place chips) is replaced with a single-line bar showing `origin → destination`
- [x] The collapsed bar shows an edit icon; tapping it clears the route and re-expands the full form
- [x] Changing origin or destination (via search, saved place, current location, or map pin) automatically clears the route — existing behaviour preserved
- [x] The summary card (distance / est. time / avoided + baseline comparison) remains visible below the collapsed bar
- [x] Implemented on both `MapView.web.tsx` (web) and `MapView.tsx` (native)

## Reviewer

## Notes
- Branch: `fix/plan-map-layout`
- The overlay panel lives inside `MapView.*.tsx` (not the standalone `PlanView.*.tsx`).
