### PR TITLE
feat(reports): accessibility standard violation chips on submit and detail

### DIFF
--- a/backend/apps/map/serializers.py
+++ b/backend/apps/map/serializers.py
@@ -66,7 +66,7 @@ class ObstacleDetailSerializer(serializers.Serializer):
     userUpvoted = serializers.SerializerMethodField()
     userFlagged = serializers.SerializerMethodField()
     userConfirmed = serializers.SerializerMethodField()
-    violations = serializers.JSONField()
+    violations = serializers.JSONField(default=list)
     photos = PhotoSerializer(many=True)
     statusHistory = StatusHistorySerializer(many=True, source="status_changes")
     createdAt = serializers.DateTimeField(source="created_at")

--- a/backend/apps/map/serializers.py
+++ b/backend/apps/map/serializers.py
@@ -66,6 +66,7 @@ class ObstacleDetailSerializer(serializers.Serializer):
     userUpvoted = serializers.SerializerMethodField()
     userFlagged = serializers.SerializerMethodField()
     userConfirmed = serializers.SerializerMethodField()
+    violations = serializers.JSONField()
     photos = PhotoSerializer(many=True)
     statusHistory = StatusHistorySerializer(many=True, source="status_changes")
     createdAt = serializers.DateTimeField(source="created_at")

--- a/backend/apps/reports/accessibility_standards.json
+++ b/backend/apps/reports/accessibility_standards.json
@@ -1,0 +1,429 @@
+{
+  "version": "1.0",
+  "source": "T.C. Aile ve Sosyal Hizmetler Bakanlığı — Erişilebilirlik Kılavuzu — Binalar (2nd ed., 2024, ISBN 978-625-8402-08-7)",
+  "notes": [
+    "Each top-level key matches an ObstacleCategory enum value used in the backend (apps/reports/models.py) and frontend (types/report.ts).",
+    "The 'code' field is what gets persisted on a report.",
+    "The 'label' is the short user-facing chip text — already phrased qualitatively so the user does not need to measure.",
+    "'short' is one sentence the form may show under the chip as a hint.",
+    "'requirement' quotes the underlying standard (with the actual measurement from the PDF) for the detail screen.",
+    "'why' explains in plain language who is affected and why it matters.",
+    "'pdfRef' cites the section in the source PDF.",
+    "OTHER category and any category not listed here intentionally has no violation chips."
+  ],
+  "standards": {
+    "BROKEN_RAMP": [
+      {
+        "code": "RAMP_TOO_STEEP",
+        "label": "Too steep",
+        "short": "The slope feels too steep to climb safely.",
+        "requirement": "Maximum slope is 8% (1:12) for rises up to 15 cm. For taller rises the limit is lower: 7% up to 50 cm, 6% up to 100 cm, 5% above 100 cm.",
+        "why": "A steep ramp is unsafe for a wheelchair user without assistance and dangerous to descend in either direction.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_TOO_NARROW",
+        "label": "Too narrow",
+        "short": "Not wide enough for a wheelchair to pass.",
+        "requirement": "Clear width must be at least 100 cm, measured between handrails or curbs.",
+        "why": "A wheelchair plus handrails will not physically fit in a narrower ramp.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_NO_HANDRAIL",
+        "label": "No handrails",
+        "short": "Handrails are missing on one or both sides.",
+        "requirement": "Handrails required on both sides at 90 cm and 70 cm height for any rise greater than 15 cm or length greater than 2 m.",
+        "why": "People with limited balance, ambulatory disabled users and elderly users rely on handrails to use a ramp safely.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_SLIPPERY_OR_DAMAGED",
+        "label": "Slippery or damaged surface",
+        "short": "Surface is wet, smooth, cracked, or unstable.",
+        "requirement": "Surface must be flat, stable and non-slip in both wet and dry conditions (TS 13882 — outdoor ramps at least R11).",
+        "why": "Slippery or uneven ramps cause falls, especially when wet.",
+        "pdfRef": "§1.5, §1.7"
+      },
+      {
+        "code": "RAMP_NO_LANDING",
+        "label": "No landing at top or bottom",
+        "short": "No flat resting space at the ends.",
+        "requirement": "Flat landing of at least 150 × 150 cm at the top, bottom, every change of direction, and every 9 m along the ramp.",
+        "why": "Wheelchair users need a flat space to rest, open a door, or turn around.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_NO_EDGE_GUARD",
+        "label": "No edge protection",
+        "short": "Open edge with nothing to keep wheels from slipping off.",
+        "requirement": "Protective curb of at least 5 cm on any open edge of the ramp and its landings.",
+        "why": "Keeps a wheelchair wheel or cane from slipping off the side of the ramp.",
+        "pdfRef": "§1.5"
+      }
+    ],
+
+    "NARROW_SIDEWALK": [
+      {
+        "code": "SIDEWALK_TOO_NARROW",
+        "label": "Too narrow to pass",
+        "short": "Not wide enough for a wheelchair or stroller.",
+        "requirement": "Minimum clear walking path of 100 cm; 150 cm recommended where two-way traffic is expected.",
+        "why": "A wheelchair, walker, or stroller cannot pass through a narrower path.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "SIDEWALK_OBSTACLE_IN_PATH",
+        "label": "Obstacle in path",
+        "short": "Pole, sign, bench or planter sticking into the walking area.",
+        "requirement": "Nothing should protrude more than 10 cm into the walking path between 68.5 cm and 220 cm height; clear headroom is 220 cm.",
+        "why": "Protruding objects are invisible to blind users using a cane below knee level and cause head and shoulder injuries.",
+        "pdfRef": "§1.7, §7"
+      },
+      {
+        "code": "SIDEWALK_NO_CURB_RAMP",
+        "label": "No curb ramp at crossing",
+        "short": "Sidewalk meets the road with a step.",
+        "requirement": "A curb ramp is required wherever a sidewalk meets a road; a tactile warning surface should mark the top.",
+        "why": "Without a curb ramp wheelchair users cannot cross the street at all.",
+        "pdfRef": "§2.2"
+      },
+      {
+        "code": "SIDEWALK_UNEVEN",
+        "label": "Uneven surface",
+        "short": "Surface is bumpy, sloped sideways, or has small steps.",
+        "requirement": "Surface must be flat and stable; any level difference greater than 1.3 cm must be bridged by a ramp.",
+        "why": "Small steps trip elderly users and tip wheelchairs sideways.",
+        "pdfRef": "§1.4, §1.7"
+      }
+    ],
+
+    "DAMAGED_SURFACE": [
+      {
+        "code": "SURFACE_CRACKS_OR_HOLES",
+        "label": "Cracks or holes",
+        "short": "Visible cracks, potholes or missing pieces of pavement.",
+        "requirement": "Walking surfaces must be continuous, flat and stable.",
+        "why": "Cracks catch cane tips, wheelchair wheels and stroller wheels and cause falls.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "SURFACE_LOOSE_TILES",
+        "label": "Loose tiles or stones",
+        "short": "Paving stones move or wobble when stepped on.",
+        "requirement": "Surface materials must be firmly fixed and stable.",
+        "why": "Loose paving shifts under weight and causes falls.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "SURFACE_GRID_GAP",
+        "label": "Grid or drain gaps too wide",
+        "short": "Drain or grid slots run along the walking direction or are wide.",
+        "requirement": "Drain and grid openings must be at most 13 mm wide, oriented perpendicular to the walking direction.",
+        "why": "Wider or parallel gaps trap canes, wheelchair wheels and stroller wheels.",
+        "pdfRef": "§1.4"
+      },
+      {
+        "code": "SURFACE_STEP_OR_DROP",
+        "label": "Step or sudden drop",
+        "short": "There is a step where a ramp should be.",
+        "requirement": "Any level difference greater than 1.3 cm must be bridged by a ramp.",
+        "why": "Even a small step is an impassable barrier for a wheelchair.",
+        "pdfRef": "§1.4"
+      },
+      {
+        "code": "SURFACE_SLIPPERY_WET",
+        "label": "Slippery when wet",
+        "short": "Surface becomes slick in rain.",
+        "requirement": "Surface must remain non-slip in wet conditions (TS 13882; outdoor walking surfaces at least R10).",
+        "why": "Most accessibility falls happen on wet, smooth surfaces.",
+        "pdfRef": "§1.7"
+      }
+    ],
+
+    "ROAD_CONSTRUCTION": [
+      {
+        "code": "CONSTRUCTION_NO_DETOUR",
+        "label": "No accessible detour",
+        "short": "The path is blocked and there is no marked alternative.",
+        "requirement": "Construction that closes a pedestrian path must provide an accessible alternative route.",
+        "why": "Without a detour the area becomes impassable for wheelchair users.",
+        "pdfRef": "general"
+      },
+      {
+        "code": "CONSTRUCTION_UNMARKED_ROUTE",
+        "label": "Detour not marked",
+        "short": "It is unclear where pedestrians should walk.",
+        "requirement": "Temporary routes must be clearly marked with both visual and tactile signs.",
+        "why": "Blind and low-vision users cannot perceive an unmarked detour.",
+        "pdfRef": "general"
+      },
+      {
+        "code": "CONSTRUCTION_UNSAFE_BARRIERS",
+        "label": "Open hazard, no barrier",
+        "short": "Open trenches, machinery or holes with nothing protecting pedestrians.",
+        "requirement": "Open excavations, scaffolding bases and equipment must be enclosed by solid barriers detectable by a cane.",
+        "why": "Open hazards in walking paths cause serious injury, especially to blind users.",
+        "pdfRef": "general"
+      },
+      {
+        "code": "CONSTRUCTION_UNSAFE_TEMP_SURFACE",
+        "label": "Temporary surface unsafe",
+        "short": "Metal plates, boards or planks are loose or have gaps.",
+        "requirement": "Temporary walking surfaces must be flat, stable, non-slip and gap-free.",
+        "why": "Rocking metal plates and loose boards tip wheelchairs and catch canes.",
+        "pdfRef": "general"
+      }
+    ],
+
+    "BLOCKED_PATH": [
+      {
+        "code": "BLOCK_PERMANENT",
+        "label": "Permanently blocked",
+        "short": "The path is closed off and shows no sign of being temporary.",
+        "requirement": "Pedestrian paths must remain unobstructed (at least 100 cm clear).",
+        "why": "A permanent block forces a long, often unsafe detour into the road.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "BLOCK_VEHICLE",
+        "label": "Vehicle blocking path",
+        "short": "A parked car, scooter or delivery vehicle is in the walking area.",
+        "requirement": "Vehicles must not be parked on pedestrian routes.",
+        "why": "Forces wheelchair users into the road.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "BLOCK_VEGETATION",
+        "label": "Overgrown vegetation",
+        "short": "Branches or bushes have grown into the walking area.",
+        "requirement": "Vegetation must not encroach on the 100 cm walking corridor or 220 cm head clearance.",
+        "why": "Branches at head height are dangerous to blind users who cannot detect them with a cane.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "BLOCK_DEBRIS",
+        "label": "Trash or debris",
+        "short": "Garbage bags, leaves, or building debris pile up in the path.",
+        "requirement": "Walking surfaces must be kept clear.",
+        "why": "Tripping hazard, especially for low-vision and elderly users.",
+        "pdfRef": "§1.7"
+      }
+    ],
+
+    "BROKEN_ELEVATOR": [
+      {
+        "code": "ELEVATOR_OUT_OF_ORDER",
+        "label": "Out of order",
+        "short": "The elevator is not working.",
+        "requirement": "A functioning elevator is required for accessible vertical circulation in multi-floor buildings.",
+        "why": "When the only elevator is out of order, every floor above ground level is inaccessible.",
+        "pdfRef": "§8.1"
+      },
+      {
+        "code": "ELEVATOR_CABIN_TOO_SMALL",
+        "label": "Cabin too small",
+        "short": "A wheelchair does not fit inside.",
+        "requirement": "Cabin must be at least 120 × 150 cm (1.80 m²).",
+        "why": "A standard wheelchair will not fit inside smaller cabins.",
+        "pdfRef": "§8.1.1"
+      },
+      {
+        "code": "ELEVATOR_DOOR_TOO_NARROW",
+        "label": "Door too narrow",
+        "short": "A wheelchair does not fit through the door.",
+        "requirement": "Clear door opening at least 90 cm wide.",
+        "why": "Narrower doors cannot admit a standard wheelchair.",
+        "pdfRef": "§8.1.1"
+      },
+      {
+        "code": "ELEVATOR_NO_AUDIO",
+        "label": "No audio announcement",
+        "short": "Floors are not announced out loud.",
+        "requirement": "Audible announcement of the arriving floor is required inside the cabin.",
+        "why": "Blind users have no way to know which floor they are on.",
+        "pdfRef": "§8.1.2"
+      },
+      {
+        "code": "ELEVATOR_NO_BRAILLE",
+        "label": "No Braille / tactile buttons",
+        "short": "Buttons are touchscreen or flat with no raised markings.",
+        "requirement": "Buttons must be tactile with Braille labels, contrasting in color with their background.",
+        "why": "Blind users cannot operate a flat touchscreen.",
+        "pdfRef": "§8.1.2"
+      },
+      {
+        "code": "ELEVATOR_DOOR_CLOSES_FAST",
+        "label": "Door closes too fast",
+        "short": "Not enough time to enter or exit.",
+        "requirement": "The door must remain open for at least 6 seconds.",
+        "why": "Wheelchair users and people with mobility aids cannot board in time.",
+        "pdfRef": "§8.1.1"
+      },
+      {
+        "code": "ELEVATOR_FLOOR_GAP",
+        "label": "Step or gap at door",
+        "short": "Cabin floor does not line up with the building floor.",
+        "requirement": "Cabin floor must align with the landing within ±1 cm; no threshold.",
+        "why": "Any step or gap can trap a wheelchair wheel or trip a user.",
+        "pdfRef": "§8.1.1"
+      }
+    ],
+
+    "INACCESSIBLE_RESTROOM": [
+      {
+        "code": "WC_DOOR_TOO_NARROW",
+        "label": "Door too narrow",
+        "short": "A wheelchair does not fit through the door.",
+        "requirement": "Clear door opening at least 90 cm; door should open outward.",
+        "why": "Wheelchairs cannot fit through a narrower door.",
+        "pdfRef": "§6.1"
+      },
+      {
+        "code": "WC_NO_TURN_SPACE",
+        "label": "No turning space inside",
+        "short": "There is no room to turn a wheelchair around.",
+        "requirement": "A clear maneuvering circle of 150 cm diameter is required inside the accessible WC.",
+        "why": "Without it, a wheelchair user cannot turn around to leave.",
+        "pdfRef": "§6.1"
+      },
+      {
+        "code": "WC_NO_GRAB_BARS",
+        "label": "No grab bars",
+        "short": "Toilet has no support bars beside it.",
+        "requirement": "Grab bars on at least one side (preferably both), positioned 25–35 cm above seat height.",
+        "why": "Transferring from a wheelchair to a toilet requires grab bars for safety.",
+        "pdfRef": "§6.2"
+      },
+      {
+        "code": "WC_DOOR_OPENS_INWARD",
+        "label": "Door opens inward",
+        "short": "Door swings into the stall and blocks access.",
+        "requirement": "Accessible WC doors must open outward or slide.",
+        "why": "If a user falls inside, an inward-opening door cannot be opened from outside to help them.",
+        "pdfRef": "§6.1"
+      },
+      {
+        "code": "WC_NO_EMERGENCY_CALL",
+        "label": "No emergency call button",
+        "short": "There is no way to call for help.",
+        "requirement": "Emergency call cord reachable both while standing (around 122 cm) and from the floor (30–50 cm).",
+        "why": "A user who has fallen must be able to call for help from the floor.",
+        "pdfRef": "§6.1"
+      }
+    ],
+
+    "NARROW_CORRIDOR": [
+      {
+        "code": "CORRIDOR_TOO_NARROW",
+        "label": "Too narrow",
+        "short": "A wheelchair cannot fit through.",
+        "requirement": "Clear corridor width must be at least 120 cm.",
+        "why": "Narrower corridors cannot accommodate a wheelchair, especially with another person passing.",
+        "pdfRef": "§7"
+      },
+      {
+        "code": "CORRIDOR_CANNOT_TURN",
+        "label": "Cannot turn corner",
+        "short": "Wheelchair gets stuck at the turn.",
+        "requirement": "At 90° turns, clear width must be at least 120 cm in both directions; 150 cm recommended.",
+        "why": "A wheelchair cannot pivot in a tighter corner.",
+        "pdfRef": "§7"
+      },
+      {
+        "code": "CORRIDOR_OBSTACLES",
+        "label": "Obstacles in corridor",
+        "short": "Cabinets, signs or fixtures stick into the corridor.",
+        "requirement": "No object may protrude more than 10 cm into the corridor between 68.5 cm and 220 cm height.",
+        "why": "Protruding objects at chest or head height are undetectable by a cane.",
+        "pdfRef": "§7"
+      },
+      {
+        "code": "CORRIDOR_LOW_HEADROOM",
+        "label": "Low headroom",
+        "short": "Ceiling, ducts or stair undersides hang low.",
+        "requirement": "Minimum clear height of 220 cm along the entire corridor.",
+        "why": "Low ceilings cause head injuries, especially for blind users.",
+        "pdfRef": "§7"
+      }
+    ],
+
+    "HEAVY_DOOR": [
+      {
+        "code": "DOOR_TOO_HEAVY",
+        "label": "Too heavy to push",
+        "short": "Door takes significant effort to open.",
+        "requirement": "Doors must open without excessive force; closers should slow the door near the end.",
+        "why": "Heavy doors are unusable from a wheelchair or with limited grip strength.",
+        "pdfRef": "§5"
+      },
+      {
+        "code": "DOOR_HAS_THRESHOLD",
+        "label": "Threshold or step at door",
+        "short": "There is a bump or step in the doorway.",
+        "requirement": "No threshold is preferred; if unavoidable, max 1.3 cm and chamfered.",
+        "why": "Even a small threshold can stop a wheelchair or trip a user.",
+        "pdfRef": "§5.3"
+      },
+      {
+        "code": "DOOR_KNOB_HANDLE",
+        "label": "Knob handle (not a lever)",
+        "short": "Door has a round knob that must be twisted.",
+        "requirement": "Lever or D-shaped pull handles only — no round knobs.",
+        "why": "Knobs cannot be operated by people with limited hand strength or no grip.",
+        "pdfRef": "§5.2"
+      },
+      {
+        "code": "DOOR_HANDLE_BAD_HEIGHT",
+        "label": "Handle too high or low",
+        "short": "Handle is out of comfortable reach.",
+        "requirement": "Handle height between 90 cm and 110 cm above the floor.",
+        "why": "Handles outside this range are out of reach from a wheelchair or for children.",
+        "pdfRef": "§5.2"
+      },
+      {
+        "code": "DOOR_TOO_NARROW",
+        "label": "Doorway too narrow",
+        "short": "A wheelchair does not fit through.",
+        "requirement": "Interior doors must have a clear opening of at least 90 cm when open.",
+        "why": "Standard wheelchairs need at least 90 cm to pass through.",
+        "pdfRef": "§5.2"
+      }
+    ],
+
+    "SLIPPERY_FLOOR": [
+      {
+        "code": "FLOOR_WET_NO_WARNING",
+        "label": "Wet floor, no warning sign",
+        "short": "Floor is wet but nothing alerts you.",
+        "requirement": "Wet surfaces must be marked with visible warning signs.",
+        "why": "Unmarked wet floors cause falls, especially for elderly users.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "FLOOR_GLOSSY",
+        "label": "Polished or glossy",
+        "short": "Surface looks shiny and feels slick.",
+        "requirement": "Floors must be non-slip per TS 13882 (R10 minimum for interior public areas).",
+        "why": "Highly polished floors are dangerous for anyone with reduced balance.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "FLOOR_NO_ENTRANCE_MAT",
+        "label": "No mat at entrance",
+        "short": "Wet shoes track water onto the floor.",
+        "requirement": "Entrance areas should have a non-slip mat in wet weather.",
+        "why": "Wet shoes turn interior floors into slip hazards.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "FLOOR_RECENTLY_MOPPED",
+        "label": "Recently mopped, no sign",
+        "short": "Floor is wet from cleaning with nothing warning you.",
+        "requirement": "Cleaning in progress requires visible wet-floor signs.",
+        "why": "Most cleaning-related falls happen on freshly mopped floors with no warning.",
+        "pdfRef": "§1.7"
+      }
+    ]
+  }
+}

--- a/backend/apps/reports/accessibility_standards.py
+++ b/backend/apps/reports/accessibility_standards.py
@@ -1,0 +1,23 @@
+"""Catalog of accessibility-standard violation codes per ObstacleCategory.
+
+The JSON file shipped alongside this module is a copy of the repo's
+`context/accessibility_standards.json` (source of truth, kept uncommitted).
+Any update to that file must be reflected here too.
+"""
+import json
+from pathlib import Path
+
+_CATALOG_PATH = Path(__file__).resolve().parent / "accessibility_standards.json"
+
+with _CATALOG_PATH.open(encoding="utf-8") as _f:
+    _CATALOG = json.load(_f)
+
+# {category: [entry, ...]} — entries kept as full dicts so callers (e.g. tests
+# or future docs endpoint) can read requirement/why/pdfRef if needed.
+STANDARDS_BY_CATEGORY: dict[str, list[dict]] = _CATALOG.get("standards", {})
+
+# {category: {code1, code2, ...}} — used for fast category-scoped validation.
+CODES_BY_CATEGORY: dict[str, set[str]] = {
+    category: {entry["code"] for entry in entries}
+    for category, entries in STANDARDS_BY_CATEGORY.items()
+}

--- a/backend/apps/reports/migrations/0004_report_violations.py
+++ b/backend/apps/reports/migrations/0004_report_violations.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('reports', '0003_report_severity_alter_report_category'),
+        ('reports', '0002_comment'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='report',
+            name='violations',
+            field=models.JSONField(blank=True, default=list),
+        ),
+    ]

--- a/backend/apps/reports/migrations/0005_remove_severity_violations_default.py
+++ b/backend/apps/reports/migrations/0005_remove_severity_violations_default.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    """Unblock report creation by realigning the DB with the model.
+
+    - ``severity`` was added by 0003 but later removed from the model with no
+      removal migration, leaving a NOT-NULL column with no DB default. Every
+      INSERT failed with an IntegrityError. Drop the column to match the model.
+    - ``violations`` (added in 0004) needs a DB-level DEFAULT so older deploys
+      that don't yet know about the column can still INSERT successfully.
+    - Bring Photo's Meta options in line with the model.
+    """
+
+    dependencies = [
+        ('reports', '0004_report_violations'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='photo',
+            options={'ordering': ['uploaded_at']},
+        ),
+        migrations.RemoveField(
+            model_name='report',
+            name='severity',
+        ),
+        migrations.RunSQL(
+            sql="ALTER TABLE reports ALTER COLUMN violations SET DEFAULT '[]'::jsonb;",
+            reverse_sql="ALTER TABLE reports ALTER COLUMN violations DROP DEFAULT;",
+        ),
+    ]

--- a/backend/apps/reports/models.py
+++ b/backend/apps/reports/models.py
@@ -64,6 +64,10 @@ class Report(models.Model):
     latitude = models.DecimalField(max_digits=9, decimal_places=6)
     longitude = models.DecimalField(max_digits=9, decimal_places=6)
     is_indoor = models.BooleanField(default=False)
+    # Codes from apps.reports.accessibility_standards. Empty list when the
+    # reporter skipped the optional "Accessibility issues" section, or when
+    # the report's category has no entries in the catalog (e.g. OTHER).
+    violations = models.JSONField(default=list, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/backend/apps/reports/serializers.py
+++ b/backend/apps/reports/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from .accessibility_standards import CODES_BY_CATEGORY
 from .models import Comment, ObstacleCategory, ReportContext
 
 
@@ -22,6 +23,39 @@ class ReportSerializer(serializers.Serializer):
         min_length=1,
         max_length=3,
     )
+    violations = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        default=list,
+    )
+
+    def validate(self, attrs):
+        violations = attrs.get("violations") or []
+        if not violations:
+            return attrs
+
+        category = attrs.get("category")
+        allowed = CODES_BY_CATEGORY.get(category, set())
+        if not allowed:
+            raise serializers.ValidationError({
+                "violations": (
+                    "This category has no accessibility-standard entries; "
+                    "violations must be empty."
+                ),
+            })
+
+        unknown = [code for code in violations if code not in allowed]
+        if unknown:
+            raise serializers.ValidationError({
+                "violations": (
+                    f"Unknown or wrong-category violation codes: {sorted(set(unknown))}."
+                ),
+            })
+
+        # De-duplicate while preserving order.
+        seen = set()
+        attrs["violations"] = [c for c in violations if not (c in seen or seen.add(c))]
+        return attrs
 
 class ReportResponseSerializer(serializers.Serializer):
     reportId = serializers.UUIDField(source="id")

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -55,6 +55,7 @@ def create_report(reporter, validated_data) -> Report:
                 context=validated_data["context"],
                 latitude=location["lat"],
                 longitude=location["lng"],
+                violations=validated_data.get("violations") or [],
             )
 
             photo_objects = []

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -198,6 +198,61 @@ class ReportSerializerTest(TestCase):
         s = ReportSerializer(data=payload)
         self.assertTrue(s.is_valid(), s.errors)
 
+    # --- Accessibility violations ---
+
+    def test_violations_omitted_is_valid(self):
+        # Existing clients that don't know about violations still validate.
+        from apps.reports.serializers import ReportSerializer
+        payload = self._valid_payload()
+        s = ReportSerializer(data=payload)
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["violations"], [])
+
+    def test_violations_empty_list_is_valid(self):
+        from apps.reports.serializers import ReportSerializer
+        s = ReportSerializer(data=self._valid_payload(violations=[]))
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(s.validated_data["violations"], [])
+
+    def test_violations_valid_codes_for_category(self):
+        from apps.reports.serializers import ReportSerializer
+        s = ReportSerializer(data=self._valid_payload(
+            violations=["RAMP_TOO_STEEP", "RAMP_NO_HANDRAIL"],
+        ))
+        self.assertTrue(s.is_valid(), s.errors)
+        self.assertEqual(
+            s.validated_data["violations"],
+            ["RAMP_TOO_STEEP", "RAMP_NO_HANDRAIL"],
+        )
+
+    def test_violations_unknown_code_rejected(self):
+        from apps.reports.serializers import ReportSerializer
+        s = ReportSerializer(data=self._valid_payload(
+            violations=["RAMP_TOO_STEEP", "TOTALLY_FAKE_CODE"],
+        ))
+        self.assertFalse(s.is_valid())
+        self.assertIn("violations", s.errors)
+
+    def test_violations_wrong_category_rejected(self):
+        # ELEVATOR_OUT_OF_ORDER belongs to BROKEN_ELEVATOR, not BROKEN_RAMP.
+        from apps.reports.serializers import ReportSerializer
+        s = ReportSerializer(data=self._valid_payload(
+            category="BROKEN_RAMP",
+            violations=["ELEVATOR_OUT_OF_ORDER"],
+        ))
+        self.assertFalse(s.is_valid())
+        self.assertIn("violations", s.errors)
+
+    def test_violations_rejected_for_other_category(self):
+        # OTHER has no entries in the catalog — any violation is invalid.
+        from apps.reports.serializers import ReportSerializer
+        s = ReportSerializer(data=self._valid_payload(
+            category="OTHER",
+            violations=["RAMP_TOO_STEEP"],
+        ))
+        self.assertFalse(s.is_valid())
+        self.assertIn("violations", s.errors)
+
 
 # ---------------------------------------------------------------------------
 # View: POST /api/reports/

--- a/backend/apps/reports/tests.py
+++ b/backend/apps/reports/tests.py
@@ -804,3 +804,47 @@ class DecayUnverifiedReportsCommandTest(TestCase):
         old.refresh_from_db()
         self.assertEqual(recent.status, ReportStatus.UNVERIFIED)
         self.assertEqual(old.status, ReportStatus.PASSIVE)
+
+
+# ---------------------------------------------------------------------------
+# Serializer: ObstacleDetailSerializer — violations field
+# ---------------------------------------------------------------------------
+
+class ObstacleDetailSerializerViolationsTest(TestCase):
+    def _make_mock_report(self, violations=None):
+        import uuid as _uuid
+        from unittest.mock import PropertyMock
+        r = MagicMock()
+        r.id = _uuid.uuid4()
+        r.reporter.id = _uuid.uuid4()
+        r.reporter.role = "REGISTERED_USER"
+        r.latitude = 41.0837
+        r.longitude = 29.051
+        r.category = ObstacleCategory.BROKEN_RAMP
+        r.context = ReportContext.OUTDOOR
+        r.status = ReportStatus.UNVERIFIED
+        r.description = "Test report"
+        r.violations = violations if violations is not None else []
+        r.interactions.all.return_value = []
+        r.photos.all.return_value = []
+        r.status_changes.all.return_value = []
+        r.created_at = None
+        return r
+
+    def test_violations_returned_in_detail(self):
+        from apps.map.serializers import ObstacleDetailSerializer
+        report = self._make_mock_report(violations=["RAMP_TOO_STEEP", "RAMP_NO_HANDRAIL"])
+        data = ObstacleDetailSerializer(report).data
+        self.assertEqual(data["violations"], ["RAMP_TOO_STEEP", "RAMP_NO_HANDRAIL"])
+
+    def test_empty_violations_returned_as_empty_list(self):
+        from apps.map.serializers import ObstacleDetailSerializer
+        report = self._make_mock_report(violations=[])
+        data = ObstacleDetailSerializer(report).data
+        self.assertEqual(data["violations"], [])
+
+    def test_violations_key_always_present(self):
+        from apps.map.serializers import ObstacleDetailSerializer
+        report = self._make_mock_report()
+        data = ObstacleDetailSerializer(report).data
+        self.assertIn("violations", data)

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import {
-  ActivityIndicator, Image, ScrollView, StyleSheet,
+  ActivityIndicator, Image, Modal, Pressable, ScrollView, StyleSheet,
   Text, TouchableOpacity, View,
 } from 'react-native';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -11,6 +11,7 @@ import { getMe, isLoggedIn } from '../../src/services/auth';
 import InteractionBar from '../../src/components/reports/InteractionBar';
 import ConfirmResolutionButton from '../../src/components/reports/ConfirmResolutionButton';
 import DiscussionSection from '../../src/components/reports/DiscussionSection';
+import { getStandardByCode, type AccessibilityStandard } from '../../src/constants/accessibilityStandards';
 
 function formatDate(iso: string): string {
   if (!iso) return '';
@@ -108,6 +109,71 @@ const CATEGORY_COLOR: Record<string, string> = {
   OTHER: COLORS.gray500,
 };
 
+function ViolationDetailModal({
+  standard, onClose,
+}: { standard: AccessibilityStandard | null; onClose: () => void }) {
+  return (
+    <Modal
+      visible={standard !== null}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable style={s.modalBackdrop} onPress={onClose}>
+        <Pressable style={s.modalCard} onPress={(e) => e.stopPropagation()}>
+          {standard && (
+            <>
+              <View style={s.modalHeader}>
+                <Text style={s.modalTitle}>{standard.label}</Text>
+                <TouchableOpacity onPress={onClose} hitSlop={8}>
+                  <Ionicons name="close" size={20} color={COLORS.gray500} />
+                </TouchableOpacity>
+              </View>
+              <Text style={s.modalSectionLabel}>Requirement</Text>
+              <Text style={s.modalBody}>{standard.requirement}</Text>
+              <Text style={s.modalSectionLabel}>Why it matters</Text>
+              <Text style={s.modalBody}>{standard.why}</Text>
+              <Text style={s.modalRef}>Source: {standard.pdfRef}</Text>
+            </>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function ViolationsSection({ codes }: { codes: string[] }) {
+  const [open, setOpen] = useState<AccessibilityStandard | null>(null);
+  if (!codes.length) return null;
+  const entries = codes
+    .map((code) => getStandardByCode(code))
+    .filter((s): s is AccessibilityStandard => s !== null);
+  if (!entries.length) return null;
+  return (
+    <View style={s.violationsCard}>
+      <View style={s.violationsHeading}>
+        <Ionicons name="alert-circle-outline" size={16} color={COLORS.gray700} />
+        <Text style={s.violationsHeadingText}>Accessibility issues</Text>
+      </View>
+      <View style={s.violationsWrap}>
+        {entries.map((std) => (
+          <TouchableOpacity
+            key={std.code}
+            style={s.violationChip}
+            onPress={() => setOpen(std)}
+            activeOpacity={0.7}
+          >
+            <View style={s.violationDot} />
+            <Text style={s.violationChipText}>{std.label}</Text>
+            <Ionicons name="information-circle-outline" size={12} color={COLORS.gray500} />
+          </TouchableOpacity>
+        ))}
+      </View>
+      <ViolationDetailModal standard={open} onClose={() => setOpen(null)} />
+    </View>
+  );
+}
+
 export default function ReportDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const router = useRouter();
@@ -201,6 +267,8 @@ export default function ReportDetailScreen() {
         {detail.description ? (
           <Text style={s.description}>{detail.description}</Text>
         ) : null}
+
+        <ViolationsSection codes={detail.violations} />
 
         {detail.photos.length > 0 && (
           <ScrollView horizontal showsHorizontalScrollIndicator={false} style={s.photoRow}>
@@ -357,4 +425,33 @@ const s = StyleSheet.create({
   historyReason: { fontSize: 12, color: COLORS.gray600, marginTop: 2 },
   historyPhoto: { width: '100%', height: 140, borderRadius: 8, marginTop: 8 },
   historyTime: { fontSize: 11, color: COLORS.gray400, marginTop: 4 },
+
+  // Accessibility issues section (inside main card, between description and photos)
+  violationsCard:        { marginBottom: 12 },
+  violationsHeading:     { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 8 },
+  violationsHeadingText: { fontSize: 13, fontWeight: '700', color: COLORS.gray700 },
+  violationsWrap:        { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+  violationChip: {
+    flexDirection: 'row', alignItems: 'center', gap: 5,
+    borderRadius: 20, paddingHorizontal: 10, paddingVertical: 4,
+    backgroundColor: COLORS.white, borderWidth: 1, borderColor: COLORS.gray200,
+  },
+  violationDot:     { width: 6, height: 6, borderRadius: 3, backgroundColor: COLORS.orange500 },
+  violationChipText:{ fontSize: 12, fontWeight: '600', color: COLORS.gray700 },
+
+  // Modal — standard detail
+  modalBackdrop: {
+    flex: 1, backgroundColor: 'rgba(17,24,39,0.45)',
+    alignItems: 'center', justifyContent: 'center', paddingHorizontal: 24,
+  },
+  modalCard: {
+    width: '100%', maxWidth: 420,
+    backgroundColor: COLORS.white, borderRadius: 14,
+    padding: 18, gap: 8,
+  },
+  modalHeader:       { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+  modalTitle:        { fontSize: 16, fontWeight: '700', color: COLORS.gray900, flex: 1 },
+  modalSectionLabel: { fontSize: 11, fontWeight: '700', color: COLORS.gray500, letterSpacing: 0.5, marginTop: 6, textTransform: 'uppercase' },
+  modalBody:         { fontSize: 13, lineHeight: 19, color: COLORS.gray700 },
+  modalRef:          { fontSize: 11, color: COLORS.gray400, marginTop: 8 },
 });

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -133,7 +133,6 @@ function ViolationDetailModal({
               <Text style={s.modalBody}>{standard.requirement}</Text>
               <Text style={s.modalSectionLabel}>Why it matters</Text>
               <Text style={s.modalBody}>{standard.why}</Text>
-              <Text style={s.modalRef}>Source: {standard.pdfRef}</Text>
             </>
           )}
         </Pressable>

--- a/frontend/src/__tests__/ReportForm.test.tsx
+++ b/frontend/src/__tests__/ReportForm.test.tsx
@@ -11,6 +11,11 @@ import ReportForm from '../components/reports/ReportForm';
 
 // ── Mocks ──────────────────────────────────────────────────────────
 
+jest.mock('../components/reports/LocationPicker', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: () => <View testID="location-picker" /> };
+});
+
 jest.mock('expo-location', () => ({
   requestForegroundPermissionsAsync: jest.fn().mockResolvedValue({ status: 'granted' }),
   getCurrentPositionAsync: jest.fn().mockResolvedValue({
@@ -116,5 +121,22 @@ describe('ReportForm', () => {
     // We verify submitReport is not called if pressed while loading
     fireEvent.press(btn);
     expect(getSubmitReport()).not.toHaveBeenCalled();
+  });
+
+  it('does NOT show accessibility chip section before a category is selected', async () => {
+    const { queryByText } = await renderAndWaitReady();
+    expect(queryByText(/What.s wrong here\?/i)).toBeNull();
+  });
+
+  it('shows accessibility chip section after selecting a chip-supported category', async () => {
+    const { getByText, findByText } = await renderAndWaitReady();
+    fireEvent.press(getByText('Broken Ramp'));
+    await expect(findByText(/What.s wrong here\?/i)).resolves.toBeTruthy();
+  });
+
+  it('does NOT show accessibility chip section when OTHER category is selected', async () => {
+    const { getByText, queryByText } = await renderAndWaitReady();
+    fireEvent.press(getByText('Other'));
+    expect(queryByText(/What.s wrong here\?/i)).toBeNull();
   });
 });

--- a/frontend/src/__tests__/reports.api.test.ts
+++ b/frontend/src/__tests__/reports.api.test.ts
@@ -81,4 +81,16 @@ describe('submitReport (mock mode)', () => {
     expect(body.location.lat).toBe(41.084312);
     expect(body.location.lng).toBe(29.051988);
   });
+
+  it('includes violations in request body when provided', async () => {
+    await submitReport({ ...BASE_PAYLOAD, violations: ['RAMP_TOO_STEEP', 'RAMP_NO_HANDRAIL'] });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.violations).toEqual(['RAMP_TOO_STEEP', 'RAMP_NO_HANDRAIL']);
+  });
+
+  it('sends empty violations array when violations is empty', async () => {
+    await submitReport({ ...BASE_PAYLOAD, violations: [] });
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.violations).toEqual([]);
+  });
 });

--- a/frontend/src/api/map.ts
+++ b/frontend/src/api/map.ts
@@ -35,6 +35,7 @@ export interface ObstacleDetail extends Obstacle {
   userUpvoted: boolean;
   userFlagged: boolean;
   userConfirmed: boolean;
+  violations: string[];
   reporterId: string;
   createdAt: string;
   statusHistory: StatusChange[];
@@ -129,6 +130,7 @@ export async function fetchObstacleDetail(id: string): Promise<ObstacleDetail | 
       userUpvoted: raw.userUpvoted ?? false,
       userFlagged: raw.userFlagged ?? false,
       userConfirmed: raw.userConfirmed ?? false,
+      violations: Array.isArray(raw.violations) ? raw.violations : [],
       reporterId: raw.reporterId ?? '',
       createdAt: raw.createdAt ?? '',
       statusHistory: (raw.statusHistory ?? []).map((h: any) => ({

--- a/frontend/src/components/reports/ReportForm.tsx
+++ b/frontend/src/components/reports/ReportForm.tsx
@@ -9,6 +9,7 @@ import { searchLocations, searchNominatim, reverseGeocode, type SearchResult } f
 import { parseDRFError } from '../../services/auth';
 import LocationPicker from './LocationPicker';
 import type { ObstacleCategory, ReportContext, SubmitReportResponse } from '../../types/report';
+import { getStandardsForCategory } from '../../constants/accessibilityStandards';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
@@ -38,6 +39,7 @@ export default function ReportForm({ onSuccess }: Props) {
   const loc = useLocation();
   const [context, setContext]       = useState<ReportContext>('OUTDOOR');
   const [category, setCategory]     = useState<ObstacleCategory | null>(null);
+  const [violations, setViolations] = useState<string[]>([]);
   const [photos, setPhotos]         = useState<PhotoEntry[]>([]);
   const [description, setDescription] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -110,6 +112,17 @@ export default function ReportForm({ onSuccess }: Props) {
   function addPhoto(p: PhotoEntry)   { setPhotos(prev => [...prev, p]); setPhotoError(''); }
   function removePhoto(i: number)    { setPhotos(prev => prev.filter((_, idx) => idx !== i)); }
   function toggleCategory(v: ObstacleCategory) { setCategory(prev => prev === v ? null : v); }
+  function toggleViolation(code: string) {
+    setViolations(prev =>
+      prev.includes(code) ? prev.filter(c => c !== code) : [...prev, code]
+    );
+  }
+
+  // Clear selected accessibility issues whenever the category changes — the
+  // chip list is category-scoped and stale codes would fail backend validation.
+  useEffect(() => { setViolations([]); }, [category]);
+
+  const categoryStandards = getStandardsForCategory(category);
 
   // Debounced search
   const handleSearchInput = useCallback((text: string) => {
@@ -205,6 +218,7 @@ export default function ReportForm({ onSuccess }: Props) {
         category,
         description: description.trim(),
         photos: photos.map(p => p.b64),
+        violations,
         ...(context === 'INDOOR' && {
           buildingName: buildingName.trim(),
           floor: floor.trim() || undefined,
@@ -456,6 +470,40 @@ export default function ReportForm({ onSuccess }: Props) {
           </View>
         </View>
 
+        {/* ── Accessibility issues ── */}
+        {categoryStandards.length > 0 && (
+          <View style={s.card}>
+            <View style={s.cardTitleRow}>
+              <Ionicons name="alert-circle-outline" size={18} color={COLORS.green600} />
+              <Text style={s.cardTitle}>
+                What's wrong here? <Text style={s.optional}>(optional)</Text>
+              </Text>
+            </View>
+            <View style={s.violationsWrap}>
+              {categoryStandards.map(std => {
+                const active = violations.includes(std.code);
+                return (
+                  <TouchableOpacity
+                    key={std.code}
+                    style={[s.violationChip, active && s.violationChipActive]}
+                    onPress={() => toggleViolation(std.code)}
+                    activeOpacity={0.8}
+                  >
+                    <Ionicons
+                      name={active ? 'checkmark-circle' : 'ellipse-outline'}
+                      size={14}
+                      color={active ? COLORS.green700 : COLORS.gray400}
+                    />
+                    <Text style={[s.violationChipLabel, active && s.violationChipLabelActive]}>
+                      {std.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </View>
+          </View>
+        )}
+
         {/* ── Photo ── */}
         <View style={s.card}>
           <View style={s.cardTitleRow}>
@@ -542,6 +590,12 @@ const s = StyleSheet.create({
   tileActive:      { borderColor: COLORS.green600, backgroundColor: COLORS.green50 },
   tileLabel:       { fontSize: 12, fontWeight: '600', color: COLORS.gray500, textAlign: 'center' as const },
   tileLabelActive: { color: COLORS.green700 },
+  // Accessibility-issue chips — multi-select toggles, same color tokens as tileActive
+  violationsWrap:        { flexDirection: 'row' as const, flexWrap: 'wrap' as const, gap: 8 },
+  violationChip:         { flexDirection: 'row' as const, alignItems: 'center' as const, gap: 6, paddingHorizontal: 12, paddingVertical: 8, borderRadius: 20, borderWidth: 1.5, borderColor: COLORS.gray200, backgroundColor: COLORS.white },
+  violationChipActive:   { borderColor: COLORS.green600, backgroundColor: COLORS.green50 },
+  violationChipLabel:    { fontSize: 12, fontWeight: '600', color: COLORS.gray600 },
+  violationChipLabelActive: { color: COLORS.green700 },
   // Description
   textarea:        { borderWidth: 1.5, borderColor: COLORS.gray300, borderRadius: 10, paddingHorizontal: 14, paddingVertical: 12, fontSize: 14, color: COLORS.gray900, minHeight: 96 },
   // Error banner

--- a/frontend/src/constants/accessibilityStandards.json
+++ b/frontend/src/constants/accessibilityStandards.json
@@ -1,0 +1,429 @@
+{
+  "version": "1.0",
+  "source": "T.C. Aile ve Sosyal Hizmetler Bakanlığı — Erişilebilirlik Kılavuzu — Binalar (2nd ed., 2024, ISBN 978-625-8402-08-7)",
+  "notes": [
+    "Each top-level key matches an ObstacleCategory enum value used in the backend (apps/reports/models.py) and frontend (types/report.ts).",
+    "The 'code' field is what gets persisted on a report.",
+    "The 'label' is the short user-facing chip text — already phrased qualitatively so the user does not need to measure.",
+    "'short' is one sentence the form may show under the chip as a hint.",
+    "'requirement' quotes the underlying standard (with the actual measurement from the PDF) for the detail screen.",
+    "'why' explains in plain language who is affected and why it matters.",
+    "'pdfRef' cites the section in the source PDF.",
+    "OTHER category and any category not listed here intentionally has no violation chips."
+  ],
+  "standards": {
+    "BROKEN_RAMP": [
+      {
+        "code": "RAMP_TOO_STEEP",
+        "label": "Too steep",
+        "short": "The slope feels too steep to climb safely.",
+        "requirement": "Maximum slope is 8% (1:12) for rises up to 15 cm. For taller rises the limit is lower: 7% up to 50 cm, 6% up to 100 cm, 5% above 100 cm.",
+        "why": "A steep ramp is unsafe for a wheelchair user without assistance and dangerous to descend in either direction.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_TOO_NARROW",
+        "label": "Too narrow",
+        "short": "Not wide enough for a wheelchair to pass.",
+        "requirement": "Clear width must be at least 100 cm, measured between handrails or curbs.",
+        "why": "A wheelchair plus handrails will not physically fit in a narrower ramp.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_NO_HANDRAIL",
+        "label": "No handrails",
+        "short": "Handrails are missing on one or both sides.",
+        "requirement": "Handrails required on both sides at 90 cm and 70 cm height for any rise greater than 15 cm or length greater than 2 m.",
+        "why": "People with limited balance, ambulatory disabled users and elderly users rely on handrails to use a ramp safely.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_SLIPPERY_OR_DAMAGED",
+        "label": "Slippery or damaged surface",
+        "short": "Surface is wet, smooth, cracked, or unstable.",
+        "requirement": "Surface must be flat, stable and non-slip in both wet and dry conditions (TS 13882 — outdoor ramps at least R11).",
+        "why": "Slippery or uneven ramps cause falls, especially when wet.",
+        "pdfRef": "§1.5, §1.7"
+      },
+      {
+        "code": "RAMP_NO_LANDING",
+        "label": "No landing at top or bottom",
+        "short": "No flat resting space at the ends.",
+        "requirement": "Flat landing of at least 150 × 150 cm at the top, bottom, every change of direction, and every 9 m along the ramp.",
+        "why": "Wheelchair users need a flat space to rest, open a door, or turn around.",
+        "pdfRef": "§1.5"
+      },
+      {
+        "code": "RAMP_NO_EDGE_GUARD",
+        "label": "No edge protection",
+        "short": "Open edge with nothing to keep wheels from slipping off.",
+        "requirement": "Protective curb of at least 5 cm on any open edge of the ramp and its landings.",
+        "why": "Keeps a wheelchair wheel or cane from slipping off the side of the ramp.",
+        "pdfRef": "§1.5"
+      }
+    ],
+
+    "NARROW_SIDEWALK": [
+      {
+        "code": "SIDEWALK_TOO_NARROW",
+        "label": "Too narrow to pass",
+        "short": "Not wide enough for a wheelchair or stroller.",
+        "requirement": "Minimum clear walking path of 100 cm; 150 cm recommended where two-way traffic is expected.",
+        "why": "A wheelchair, walker, or stroller cannot pass through a narrower path.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "SIDEWALK_OBSTACLE_IN_PATH",
+        "label": "Obstacle in path",
+        "short": "Pole, sign, bench or planter sticking into the walking area.",
+        "requirement": "Nothing should protrude more than 10 cm into the walking path between 68.5 cm and 220 cm height; clear headroom is 220 cm.",
+        "why": "Protruding objects are invisible to blind users using a cane below knee level and cause head and shoulder injuries.",
+        "pdfRef": "§1.7, §7"
+      },
+      {
+        "code": "SIDEWALK_NO_CURB_RAMP",
+        "label": "No curb ramp at crossing",
+        "short": "Sidewalk meets the road with a step.",
+        "requirement": "A curb ramp is required wherever a sidewalk meets a road; a tactile warning surface should mark the top.",
+        "why": "Without a curb ramp wheelchair users cannot cross the street at all.",
+        "pdfRef": "§2.2"
+      },
+      {
+        "code": "SIDEWALK_UNEVEN",
+        "label": "Uneven surface",
+        "short": "Surface is bumpy, sloped sideways, or has small steps.",
+        "requirement": "Surface must be flat and stable; any level difference greater than 1.3 cm must be bridged by a ramp.",
+        "why": "Small steps trip elderly users and tip wheelchairs sideways.",
+        "pdfRef": "§1.4, §1.7"
+      }
+    ],
+
+    "DAMAGED_SURFACE": [
+      {
+        "code": "SURFACE_CRACKS_OR_HOLES",
+        "label": "Cracks or holes",
+        "short": "Visible cracks, potholes or missing pieces of pavement.",
+        "requirement": "Walking surfaces must be continuous, flat and stable.",
+        "why": "Cracks catch cane tips, wheelchair wheels and stroller wheels and cause falls.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "SURFACE_LOOSE_TILES",
+        "label": "Loose tiles or stones",
+        "short": "Paving stones move or wobble when stepped on.",
+        "requirement": "Surface materials must be firmly fixed and stable.",
+        "why": "Loose paving shifts under weight and causes falls.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "SURFACE_GRID_GAP",
+        "label": "Grid or drain gaps too wide",
+        "short": "Drain or grid slots run along the walking direction or are wide.",
+        "requirement": "Drain and grid openings must be at most 13 mm wide, oriented perpendicular to the walking direction.",
+        "why": "Wider or parallel gaps trap canes, wheelchair wheels and stroller wheels.",
+        "pdfRef": "§1.4"
+      },
+      {
+        "code": "SURFACE_STEP_OR_DROP",
+        "label": "Step or sudden drop",
+        "short": "There is a step where a ramp should be.",
+        "requirement": "Any level difference greater than 1.3 cm must be bridged by a ramp.",
+        "why": "Even a small step is an impassable barrier for a wheelchair.",
+        "pdfRef": "§1.4"
+      },
+      {
+        "code": "SURFACE_SLIPPERY_WET",
+        "label": "Slippery when wet",
+        "short": "Surface becomes slick in rain.",
+        "requirement": "Surface must remain non-slip in wet conditions (TS 13882; outdoor walking surfaces at least R10).",
+        "why": "Most accessibility falls happen on wet, smooth surfaces.",
+        "pdfRef": "§1.7"
+      }
+    ],
+
+    "ROAD_CONSTRUCTION": [
+      {
+        "code": "CONSTRUCTION_NO_DETOUR",
+        "label": "No accessible detour",
+        "short": "The path is blocked and there is no marked alternative.",
+        "requirement": "Construction that closes a pedestrian path must provide an accessible alternative route.",
+        "why": "Without a detour the area becomes impassable for wheelchair users.",
+        "pdfRef": "general"
+      },
+      {
+        "code": "CONSTRUCTION_UNMARKED_ROUTE",
+        "label": "Detour not marked",
+        "short": "It is unclear where pedestrians should walk.",
+        "requirement": "Temporary routes must be clearly marked with both visual and tactile signs.",
+        "why": "Blind and low-vision users cannot perceive an unmarked detour.",
+        "pdfRef": "general"
+      },
+      {
+        "code": "CONSTRUCTION_UNSAFE_BARRIERS",
+        "label": "Open hazard, no barrier",
+        "short": "Open trenches, machinery or holes with nothing protecting pedestrians.",
+        "requirement": "Open excavations, scaffolding bases and equipment must be enclosed by solid barriers detectable by a cane.",
+        "why": "Open hazards in walking paths cause serious injury, especially to blind users.",
+        "pdfRef": "general"
+      },
+      {
+        "code": "CONSTRUCTION_UNSAFE_TEMP_SURFACE",
+        "label": "Temporary surface unsafe",
+        "short": "Metal plates, boards or planks are loose or have gaps.",
+        "requirement": "Temporary walking surfaces must be flat, stable, non-slip and gap-free.",
+        "why": "Rocking metal plates and loose boards tip wheelchairs and catch canes.",
+        "pdfRef": "general"
+      }
+    ],
+
+    "BLOCKED_PATH": [
+      {
+        "code": "BLOCK_PERMANENT",
+        "label": "Permanently blocked",
+        "short": "The path is closed off and shows no sign of being temporary.",
+        "requirement": "Pedestrian paths must remain unobstructed (at least 100 cm clear).",
+        "why": "A permanent block forces a long, often unsafe detour into the road.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "BLOCK_VEHICLE",
+        "label": "Vehicle blocking path",
+        "short": "A parked car, scooter or delivery vehicle is in the walking area.",
+        "requirement": "Vehicles must not be parked on pedestrian routes.",
+        "why": "Forces wheelchair users into the road.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "BLOCK_VEGETATION",
+        "label": "Overgrown vegetation",
+        "short": "Branches or bushes have grown into the walking area.",
+        "requirement": "Vegetation must not encroach on the 100 cm walking corridor or 220 cm head clearance.",
+        "why": "Branches at head height are dangerous to blind users who cannot detect them with a cane.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "BLOCK_DEBRIS",
+        "label": "Trash or debris",
+        "short": "Garbage bags, leaves, or building debris pile up in the path.",
+        "requirement": "Walking surfaces must be kept clear.",
+        "why": "Tripping hazard, especially for low-vision and elderly users.",
+        "pdfRef": "§1.7"
+      }
+    ],
+
+    "BROKEN_ELEVATOR": [
+      {
+        "code": "ELEVATOR_OUT_OF_ORDER",
+        "label": "Out of order",
+        "short": "The elevator is not working.",
+        "requirement": "A functioning elevator is required for accessible vertical circulation in multi-floor buildings.",
+        "why": "When the only elevator is out of order, every floor above ground level is inaccessible.",
+        "pdfRef": "§8.1"
+      },
+      {
+        "code": "ELEVATOR_CABIN_TOO_SMALL",
+        "label": "Cabin too small",
+        "short": "A wheelchair does not fit inside.",
+        "requirement": "Cabin must be at least 120 × 150 cm (1.80 m²).",
+        "why": "A standard wheelchair will not fit inside smaller cabins.",
+        "pdfRef": "§8.1.1"
+      },
+      {
+        "code": "ELEVATOR_DOOR_TOO_NARROW",
+        "label": "Door too narrow",
+        "short": "A wheelchair does not fit through the door.",
+        "requirement": "Clear door opening at least 90 cm wide.",
+        "why": "Narrower doors cannot admit a standard wheelchair.",
+        "pdfRef": "§8.1.1"
+      },
+      {
+        "code": "ELEVATOR_NO_AUDIO",
+        "label": "No audio announcement",
+        "short": "Floors are not announced out loud.",
+        "requirement": "Audible announcement of the arriving floor is required inside the cabin.",
+        "why": "Blind users have no way to know which floor they are on.",
+        "pdfRef": "§8.1.2"
+      },
+      {
+        "code": "ELEVATOR_NO_BRAILLE",
+        "label": "No Braille / tactile buttons",
+        "short": "Buttons are touchscreen or flat with no raised markings.",
+        "requirement": "Buttons must be tactile with Braille labels, contrasting in color with their background.",
+        "why": "Blind users cannot operate a flat touchscreen.",
+        "pdfRef": "§8.1.2"
+      },
+      {
+        "code": "ELEVATOR_DOOR_CLOSES_FAST",
+        "label": "Door closes too fast",
+        "short": "Not enough time to enter or exit.",
+        "requirement": "The door must remain open for at least 6 seconds.",
+        "why": "Wheelchair users and people with mobility aids cannot board in time.",
+        "pdfRef": "§8.1.1"
+      },
+      {
+        "code": "ELEVATOR_FLOOR_GAP",
+        "label": "Step or gap at door",
+        "short": "Cabin floor does not line up with the building floor.",
+        "requirement": "Cabin floor must align with the landing within ±1 cm; no threshold.",
+        "why": "Any step or gap can trap a wheelchair wheel or trip a user.",
+        "pdfRef": "§8.1.1"
+      }
+    ],
+
+    "INACCESSIBLE_RESTROOM": [
+      {
+        "code": "WC_DOOR_TOO_NARROW",
+        "label": "Door too narrow",
+        "short": "A wheelchair does not fit through the door.",
+        "requirement": "Clear door opening at least 90 cm; door should open outward.",
+        "why": "Wheelchairs cannot fit through a narrower door.",
+        "pdfRef": "§6.1"
+      },
+      {
+        "code": "WC_NO_TURN_SPACE",
+        "label": "No turning space inside",
+        "short": "There is no room to turn a wheelchair around.",
+        "requirement": "A clear maneuvering circle of 150 cm diameter is required inside the accessible WC.",
+        "why": "Without it, a wheelchair user cannot turn around to leave.",
+        "pdfRef": "§6.1"
+      },
+      {
+        "code": "WC_NO_GRAB_BARS",
+        "label": "No grab bars",
+        "short": "Toilet has no support bars beside it.",
+        "requirement": "Grab bars on at least one side (preferably both), positioned 25–35 cm above seat height.",
+        "why": "Transferring from a wheelchair to a toilet requires grab bars for safety.",
+        "pdfRef": "§6.2"
+      },
+      {
+        "code": "WC_DOOR_OPENS_INWARD",
+        "label": "Door opens inward",
+        "short": "Door swings into the stall and blocks access.",
+        "requirement": "Accessible WC doors must open outward or slide.",
+        "why": "If a user falls inside, an inward-opening door cannot be opened from outside to help them.",
+        "pdfRef": "§6.1"
+      },
+      {
+        "code": "WC_NO_EMERGENCY_CALL",
+        "label": "No emergency call button",
+        "short": "There is no way to call for help.",
+        "requirement": "Emergency call cord reachable both while standing (around 122 cm) and from the floor (30–50 cm).",
+        "why": "A user who has fallen must be able to call for help from the floor.",
+        "pdfRef": "§6.1"
+      }
+    ],
+
+    "NARROW_CORRIDOR": [
+      {
+        "code": "CORRIDOR_TOO_NARROW",
+        "label": "Too narrow",
+        "short": "A wheelchair cannot fit through.",
+        "requirement": "Clear corridor width must be at least 120 cm.",
+        "why": "Narrower corridors cannot accommodate a wheelchair, especially with another person passing.",
+        "pdfRef": "§7"
+      },
+      {
+        "code": "CORRIDOR_CANNOT_TURN",
+        "label": "Cannot turn corner",
+        "short": "Wheelchair gets stuck at the turn.",
+        "requirement": "At 90° turns, clear width must be at least 120 cm in both directions; 150 cm recommended.",
+        "why": "A wheelchair cannot pivot in a tighter corner.",
+        "pdfRef": "§7"
+      },
+      {
+        "code": "CORRIDOR_OBSTACLES",
+        "label": "Obstacles in corridor",
+        "short": "Cabinets, signs or fixtures stick into the corridor.",
+        "requirement": "No object may protrude more than 10 cm into the corridor between 68.5 cm and 220 cm height.",
+        "why": "Protruding objects at chest or head height are undetectable by a cane.",
+        "pdfRef": "§7"
+      },
+      {
+        "code": "CORRIDOR_LOW_HEADROOM",
+        "label": "Low headroom",
+        "short": "Ceiling, ducts or stair undersides hang low.",
+        "requirement": "Minimum clear height of 220 cm along the entire corridor.",
+        "why": "Low ceilings cause head injuries, especially for blind users.",
+        "pdfRef": "§7"
+      }
+    ],
+
+    "HEAVY_DOOR": [
+      {
+        "code": "DOOR_TOO_HEAVY",
+        "label": "Too heavy to push",
+        "short": "Door takes significant effort to open.",
+        "requirement": "Doors must open without excessive force; closers should slow the door near the end.",
+        "why": "Heavy doors are unusable from a wheelchair or with limited grip strength.",
+        "pdfRef": "§5"
+      },
+      {
+        "code": "DOOR_HAS_THRESHOLD",
+        "label": "Threshold or step at door",
+        "short": "There is a bump or step in the doorway.",
+        "requirement": "No threshold is preferred; if unavoidable, max 1.3 cm and chamfered.",
+        "why": "Even a small threshold can stop a wheelchair or trip a user.",
+        "pdfRef": "§5.3"
+      },
+      {
+        "code": "DOOR_KNOB_HANDLE",
+        "label": "Knob handle (not a lever)",
+        "short": "Door has a round knob that must be twisted.",
+        "requirement": "Lever or D-shaped pull handles only — no round knobs.",
+        "why": "Knobs cannot be operated by people with limited hand strength or no grip.",
+        "pdfRef": "§5.2"
+      },
+      {
+        "code": "DOOR_HANDLE_BAD_HEIGHT",
+        "label": "Handle too high or low",
+        "short": "Handle is out of comfortable reach.",
+        "requirement": "Handle height between 90 cm and 110 cm above the floor.",
+        "why": "Handles outside this range are out of reach from a wheelchair or for children.",
+        "pdfRef": "§5.2"
+      },
+      {
+        "code": "DOOR_TOO_NARROW",
+        "label": "Doorway too narrow",
+        "short": "A wheelchair does not fit through.",
+        "requirement": "Interior doors must have a clear opening of at least 90 cm when open.",
+        "why": "Standard wheelchairs need at least 90 cm to pass through.",
+        "pdfRef": "§5.2"
+      }
+    ],
+
+    "SLIPPERY_FLOOR": [
+      {
+        "code": "FLOOR_WET_NO_WARNING",
+        "label": "Wet floor, no warning sign",
+        "short": "Floor is wet but nothing alerts you.",
+        "requirement": "Wet surfaces must be marked with visible warning signs.",
+        "why": "Unmarked wet floors cause falls, especially for elderly users.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "FLOOR_GLOSSY",
+        "label": "Polished or glossy",
+        "short": "Surface looks shiny and feels slick.",
+        "requirement": "Floors must be non-slip per TS 13882 (R10 minimum for interior public areas).",
+        "why": "Highly polished floors are dangerous for anyone with reduced balance.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "FLOOR_NO_ENTRANCE_MAT",
+        "label": "No mat at entrance",
+        "short": "Wet shoes track water onto the floor.",
+        "requirement": "Entrance areas should have a non-slip mat in wet weather.",
+        "why": "Wet shoes turn interior floors into slip hazards.",
+        "pdfRef": "§1.7"
+      },
+      {
+        "code": "FLOOR_RECENTLY_MOPPED",
+        "label": "Recently mopped, no sign",
+        "short": "Floor is wet from cleaning with nothing warning you.",
+        "requirement": "Cleaning in progress requires visible wet-floor signs.",
+        "why": "Most cleaning-related falls happen on freshly mopped floors with no warning.",
+        "pdfRef": "§1.7"
+      }
+    ]
+  }
+}

--- a/frontend/src/constants/accessibilityStandards.ts
+++ b/frontend/src/constants/accessibilityStandards.ts
@@ -1,0 +1,36 @@
+// Catalog of accessibility-standard violation entries, keyed by ObstacleCategory.
+// Source of truth: context/accessibility_standards.json at the repo root
+// (uncommitted). The bundled JSON next to this file is a copy that must be
+// kept in sync.
+
+import catalog from './accessibilityStandards.json';
+import type { ObstacleCategory } from '../types/report';
+
+export interface AccessibilityStandard {
+  code: string;
+  label: string;
+  short: string;
+  requirement: string;
+  why: string;
+  pdfRef: string;
+}
+
+type StandardsMap = Partial<Record<ObstacleCategory, AccessibilityStandard[]>>;
+
+export const STANDARDS_BY_CATEGORY: StandardsMap =
+  (catalog as { standards: StandardsMap }).standards ?? {};
+
+export function getStandardsForCategory(
+  category: ObstacleCategory | null,
+): AccessibilityStandard[] {
+  if (!category) return [];
+  return STANDARDS_BY_CATEGORY[category] ?? [];
+}
+
+export function getStandardByCode(code: string): AccessibilityStandard | null {
+  for (const entries of Object.values(STANDARDS_BY_CATEGORY)) {
+    const hit = entries?.find((e) => e.code === code);
+    if (hit) return hit;
+  }
+  return null;
+}

--- a/frontend/src/types/report.ts
+++ b/frontend/src/types/report.ts
@@ -25,6 +25,7 @@ export interface SubmitReportPayload {
   category: ObstacleCategory | null;
   description: string;
   photos: string[]; // base64-encoded image strings
+  violations?: string[];
   buildingName?: string;
   floor?: string;
   isIndoor?: boolean;


### PR DESCRIPTION
## Description

Adds a multi-select accessibility-issues section to the report submission form and renders the selected chips on the report detail screen. Each chip maps to a specific Turkish accessibility standard (TS-9111 / Bakanlık Kılavuzu 2024) and opens a modal with the requirement and why it matters when tapped.

## Type of Change
- [x] `feat` — new feature
- [x] `test` — adding or updating tests

## Changes
- **Backend**: `Report.violations` JSONField added; `ReportSerializer` validates codes are category-scoped; `ObstacleDetailSerializer` exposes them on GET; `accessibility_standards.json` catalog (10 categories, sourced from T.C. Aile ve Sosyal Hizmetler Bakanlığı kılavuzu)
- **Backend**: Migrations 0004 (add violations column) and 0005 (drop orphaned severity column, set DB default) — already applied to shared Supabase DB
- **Frontend**: "What's wrong here? (optional)" chip section in `ReportForm` between Category and Photo; hidden for OTHER / no category; resets on category change
- **Frontend**: `ViolationsSection` in report detail renders chips between description and photos; tap opens modal with requirement and why it matters; "Source" line removed from modal (internal catalog reference, not useful to end users)
- **Tests**: `ObstacleDetailSerializerViolationsTest` (3 backend cases, no DB needed); 2 new `reports.api.test` cases (violations forwarded in POST body); 3 new `ReportForm.test` cases (chip section visibility); fixed pre-existing `ReportForm` test suite crash caused by missing `LocationPicker` mock

## How to Test

1. Start backend: `cd backend && ./venv/bin/python manage.py runserver 0.0.0.0:8000`
2. Start frontend pointing at local backend: `cd frontend && EXPO_PUBLIC_API_URL=http://localhost:8000 npx expo start -c`
3. Open app in browser at `http://localhost:8081`
4. Report a new obstacle — select a category (e.g. Broken Ramp) → "What's wrong here?" section appears → select one or more chips → submit
5. Find the report on the map and open it → chips appear between description and photos → tap a chip → modal shows requirement and why it matters (no "Source" line)

> **Note**: indoor obstacles only render on the map at zoom level ≥ 18.

## Screenshots (if applicable)

_UI changes: chip section in form, chip rendering + modal on detail screen._

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #261

## Notes

- The shared Supabase DB already has migrations applied — no `migrate` needed after merge
- `is_indoor` boolean and `context` field are currently out of sync (tracked separately)