### PR TITLE
fix(frontend): remove duplicate Notifications heading and max slope gradient input

### DIFF
--- a/frontend/app/tabs/notifications.tsx
+++ b/frontend/app/tabs/notifications.tsx
@@ -90,8 +90,6 @@ export default function NotificationsScreen() {
       contentContainerStyle={s.scroll}
       refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} tintColor={COLORS.green700} />}
     >
-      <Text style={s.heading}>Notifications</Text>
-
       {notifications.length === 0 ? (
         <View style={s.empty} testID="notifications-empty">
           <Ionicons name="notifications-outline" size={48} color={COLORS.gray300} />
@@ -137,8 +135,7 @@ const s = StyleSheet.create({
   page: { flex: 1, backgroundColor: COLORS.gray100 },
   scroll: { paddingTop: 12, paddingHorizontal: 14 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: COLORS.gray100, paddingHorizontal: 32 },
-  heading: { fontSize: 22, fontWeight: '800', color: COLORS.gray900, marginBottom: 14 },
-  empty: { alignItems: 'center', paddingVertical: 60, gap: 10 },
+empty: { alignItems: 'center', paddingVertical: 60, gap: 10 },
   emptyText: { fontSize: 16, fontWeight: '700', color: COLORS.gray500 },
   emptySub: { fontSize: 13, color: COLORS.gray400, textAlign: 'center' },
   disabledTitle: { fontSize: 16, fontWeight: '700', color: COLORS.gray600, marginTop: 14 },

--- a/frontend/src/__tests__/MobilityProfileCard.test.tsx
+++ b/frontend/src/__tests__/MobilityProfileCard.test.tsx
@@ -4,7 +4,6 @@
  * without any network or timer dependencies.
  */
 
-import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { MobilityProfileCard } from '../components/profile/MobilityProfileCard';
 import * as hookModule from '../hooks/useMobilityProfile';
@@ -110,89 +109,6 @@ it('renders all 7 aid type chips in edit mode', () => {
 });
 
 // ── 8 ────────────────────────────────────────────────────────────────────────
-it('hides the gradient input when both slope toggles are off', () => {
-  mockUseHook.mockReturnValue({ ...baseHook, profile: null });
-  const { getByTestId, queryByTestId } = render(<MobilityProfileCard />);
-
-  fireEvent.press(getByTestId('setup-prompt'));
-
-  expect(queryByTestId('gradient-input')).toBeNull();
-});
-
-// ── 9 ────────────────────────────────────────────────────────────────────────
-it('does NOT show the gradient input when only avoidStairs is toggled on', () => {
-  mockUseHook.mockReturnValue({ ...baseHook, profile: null });
-  const { getByTestId, queryByTestId } = render(<MobilityProfileCard />);
-
-  fireEvent.press(getByTestId('setup-prompt'));
-  fireEvent(getByTestId('avoid-stairs-switch'), 'valueChange', true);
-
-  expect(queryByTestId('gradient-input')).toBeNull();
-});
-
-// ── 10 ───────────────────────────────────────────────────────────────────────
-it('reveals the gradient input only when avoidSteepSlopes is toggled on', () => {
-  mockUseHook.mockReturnValue({ ...baseHook, profile: null });
-  const { getByTestId } = render(<MobilityProfileCard />);
-
-  fireEvent.press(getByTestId('setup-prompt'));
-  fireEvent(getByTestId('avoid-slopes-switch'), 'valueChange', true);
-
-  expect(getByTestId('gradient-input')).toBeTruthy();
-});
-
-// ── 11 ───────────────────────────────────────────────────────────────────────
-it('blocks save and shows error when gradient exceeds 25%', async () => {
-  const mockSave = jest.fn();
-  mockUseHook.mockReturnValue({ ...baseHook, profile: null, save: mockSave });
-  const { getByTestId, getByText } = render(<MobilityProfileCard />);
-
-  fireEvent.press(getByTestId('setup-prompt'));
-  fireEvent(getByTestId('avoid-slopes-switch'), 'valueChange', true);
-  fireEvent.changeText(getByTestId('gradient-input'), '30');
-  fireEvent.press(getByTestId('save-button'));
-
-  await waitFor(() => {
-    expect(getByText('Gradient cannot exceed 25%.')).toBeTruthy();
-  });
-  expect(mockSave).not.toHaveBeenCalled();
-});
-
-// ── 12 ───────────────────────────────────────────────────────────────────────
-it('blocks save and shows error when gradient is negative', async () => {
-  const mockSave = jest.fn();
-  mockUseHook.mockReturnValue({ ...baseHook, profile: null, save: mockSave });
-  const { getByTestId, getByText } = render(<MobilityProfileCard />);
-
-  fireEvent.press(getByTestId('setup-prompt'));
-  fireEvent(getByTestId('avoid-slopes-switch'), 'valueChange', true);
-  fireEvent.changeText(getByTestId('gradient-input'), '-5');
-  fireEvent.press(getByTestId('save-button'));
-
-  await waitFor(() => {
-    expect(getByText('Gradient cannot be negative.')).toBeTruthy();
-  });
-  expect(mockSave).not.toHaveBeenCalled();
-});
-
-// ── 13 ───────────────────────────────────────────────────────────────────────
-it('blocks save and shows error when avoidSteepSlopes is on but gradient is empty', async () => {
-  const mockSave = jest.fn();
-  mockUseHook.mockReturnValue({ ...baseHook, profile: null, save: mockSave });
-  const { getByTestId, getByText } = render(<MobilityProfileCard />);
-
-  fireEvent.press(getByTestId('setup-prompt'));
-  fireEvent(getByTestId('avoid-slopes-switch'), 'valueChange', true);
-  // leave gradient input empty
-  fireEvent.press(getByTestId('save-button'));
-
-  await waitFor(() => {
-    expect(getByText('Please enter a gradient value.')).toBeTruthy();
-  });
-  expect(mockSave).not.toHaveBeenCalled();
-});
-
-// ── 14 ───────────────────────────────────────────────────────────────────────
 it('calls save with the correct payload when the form is valid', async () => {
   const mockSave = jest.fn().mockResolvedValue(undefined);
   mockUseHook.mockReturnValue({ ...baseHook, profile: null, save: mockSave });
@@ -202,7 +118,6 @@ it('calls save with the correct payload when the form is valid', async () => {
   fireEvent.press(getByTestId('chip-WHEELCHAIR'));
   fireEvent(getByTestId('avoid-stairs-switch'), 'valueChange', true);
   fireEvent(getByTestId('avoid-slopes-switch'), 'valueChange', true);
-  fireEvent.changeText(getByTestId('gradient-input'), '8');
   fireEvent.press(getByTestId('save-button'));
 
   await waitFor(() => {
@@ -210,12 +125,12 @@ it('calls save with the correct payload when the form is valid', async () => {
       mobilityAid: 'WHEELCHAIR',
       avoidStairs: true,
       avoidSteepSlopes: true,
-      maxSlopeGradient: 8,
+      maxSlopeGradient: null,
     });
   });
 });
 
-// ── 15 ───────────────────────────────────────────────────────────────────────
+// ── 9 ────────────────────────────────────────────────────────────────────────
 it('shows only the selected aid type in view mode, not all chips', () => {
   mockUseHook.mockReturnValue({ ...baseHook, profile: MOCK_PROFILE }); // WHEELCHAIR selected
   const { getByText, queryByText } = render(<MobilityProfileCard />);
@@ -227,15 +142,13 @@ it('shows only the selected aid type in view mode, not all chips', () => {
   expect(queryByText('Crutches')).toBeNull();
 });
 
-// ── 16 ───────────────────────────────────────────────────────────────────────
+// ── 10 ───────────────────────────────────────────────────────────────────────
 it('shows an error banner when save throws', async () => {
   const mockSave = jest.fn().mockRejectedValue(new Error('Network error'));
   mockUseHook.mockReturnValue({ ...baseHook, profile: null, save: mockSave });
   const { getByTestId, getByText } = render(<MobilityProfileCard />);
 
   fireEvent.press(getByTestId('setup-prompt'));
-  fireEvent(getByTestId('avoid-slopes-switch'), 'valueChange', true);
-  fireEvent.changeText(getByTestId('gradient-input'), '8');
   fireEvent.press(getByTestId('save-button'));
 
   await waitFor(() => {

--- a/frontend/src/components/profile/MobilityProfileCard.tsx
+++ b/frontend/src/components/profile/MobilityProfileCard.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import {
   View,
   Text,
   TouchableOpacity,
   Switch,
-  TextInput,
   ActivityIndicator,
   StyleSheet,
 } from 'react-native';
@@ -27,7 +26,6 @@ export function MobilityProfileCard() {
   const [form, setForm] = useState<MobilityProfilePayload>(BLANK);
   const [saving, setSaving] = useState(false);
   const [saveErr, setSaveErr] = useState('');
-  const [gradientErr, setGradientErr] = useState('');
   const [successMsg, setSuccessMsg] = useState('');
 
   function startEdit() {
@@ -48,36 +46,12 @@ export function MobilityProfileCard() {
   function cancelEdit() {
     setEditing(false);
     setSaveErr('');
-    setGradientErr('');
-  }
-
-  function validateGradient(): boolean {
-    if (!form.avoidSteepSlopes) return true;
-    if (form.maxSlopeGradient === null) {
-      setGradientErr('Please enter a gradient value.');
-      return false;
-    }
-    if (form.maxSlopeGradient < 0) {
-      setGradientErr('Gradient cannot be negative.');
-      return false;
-    }
-    if (form.maxSlopeGradient > 25) {
-      setGradientErr('Gradient cannot exceed 25%.');
-      return false;
-    }
-    setGradientErr('');
-    return true;
   }
 
   async function handleSave() {
-    if (!validateGradient()) return;
     setSaving(true);
     setSaveErr('');
-    const payload: MobilityProfilePayload = {
-      ...form,
-      // Clear gradient when avoidSteepSlopes is off
-      maxSlopeGradient: form.avoidSteepSlopes ? form.maxSlopeGradient : null,
-    };
+    const payload: MobilityProfilePayload = { ...form, maxSlopeGradient: null };
     try {
       await save(payload);
       setEditing(false);
@@ -89,8 +63,6 @@ export function MobilityProfileCard() {
       setSaving(false);
     }
   }
-
-  const showGradient = form.avoidSteepSlopes;
 
   // ── Loading ──────────────────────────────────────────────────────────────
   if (loading) {
@@ -185,15 +157,6 @@ export function MobilityProfileCard() {
             />
             <Text style={s.infoText}>Avoid steep slopes</Text>
           </View>
-          {profile.maxSlopeGradient != null && (
-            <View style={s.infoRow}>
-              <Ionicons name="trending-up-outline" size={18} color={COLORS.blue500} />
-              <Text style={s.infoText}>
-                Max slope:{' '}
-                <Text style={{ fontWeight: '700' }}>{profile.maxSlopeGradient}%</Text>
-              </Text>
-            </View>
-          )}
         </View>
       )}
 
@@ -226,36 +189,11 @@ export function MobilityProfileCard() {
             <Switch
               testID="avoid-slopes-switch"
               value={form.avoidSteepSlopes}
-              onValueChange={v => {
-                setForm(f => ({ ...f, avoidSteepSlopes: v }));
-                if (!v) setGradientErr('');
-              }}
+              onValueChange={v => setForm(f => ({ ...f, avoidSteepSlopes: v }))}
               trackColor={{ false: COLORS.gray300, true: COLORS.green400 }}
               thumbColor={form.avoidSteepSlopes ? COLORS.green700 : COLORS.white}
             />
           </View>
-
-          {showGradient && (
-            <View style={s.gradientBlock}>
-              <Text style={s.fieldLabel}>MAX SLOPE GRADIENT (%)</Text>
-              <TextInput
-                testID="gradient-input"
-                style={s.gradientInput}
-                value={form.maxSlopeGradient != null ? String(form.maxSlopeGradient) : ''}
-                onChangeText={t => {
-                  const n = parseFloat(t);
-                  setForm(f => ({ ...f, maxSlopeGradient: isNaN(n) ? null : n }));
-                }}
-                keyboardType="decimal-pad"
-                placeholder="e.g. 8  (0 – 25%)"
-                placeholderTextColor={COLORS.gray400}
-                accessibilityLabel="Maximum slope gradient in percent"
-              />
-              {!!gradientErr && (
-                <Text style={s.gradientErrText}>{gradientErr}</Text>
-              )}
-            </View>
-          )}
 
           {!!saveErr && (
             <View style={s.errBanner}>
@@ -356,26 +294,6 @@ const s = StyleSheet.create({
     fontSize: 14,
     fontWeight: '500',
     color: COLORS.gray800,
-  },
-  gradientBlock: {
-    marginTop: 4,
-    marginBottom: 4,
-  },
-  gradientErrText: {
-    fontSize: 12,
-    color: COLORS.red600,
-    fontWeight: '500',
-    marginTop: 5,
-  },
-  gradientInput: {
-    borderWidth: 1.5,
-    borderColor: COLORS.gray300,
-    borderRadius: 10,
-    paddingHorizontal: 14,
-    paddingVertical: 11,
-    fontSize: 15,
-    color: COLORS.gray900,
-    backgroundColor: COLORS.white,
   },
   errBanner: {
     flexDirection: 'row',


### PR DESCRIPTION
## Description
Two minor UI fixes: removes a duplicate "Notifications" screen heading (the tab-bar header already shows it) and removes the max slope gradient numeric input from the Mobility Profile form (the avoid-steep-slopes toggle stays, but the numeric field is gone).

## Type of Change
- [x] `fix` — bug fix

## Changes
- `notifications.tsx`: removed in-component `<Text>Notifications</Text>` heading and its style entry
- `MobilityProfileCard.tsx`: removed `maxSlopeGradient` numeric input, its validation logic, the view-mode max slope info row, and associated state/styles; `maxSlopeGradient` is always sent as `null` in the save payload
- `MobilityProfileCard.test.tsx`: removed gradient-input tests (8–13, 16 old numbering), updated payload test to expect `maxSlopeGradient: null`, renumbered suite to 10 tests

## How to Test
1. Open the Notifications tab — only one "Notifications" heading should be visible (in the green tab header), not a second one below it.
2. Open Profile → Mobility Profile → edit mode → toggle "Avoid steep slopes" on — no numeric input should appear below the toggle.
3. Save the profile — it should succeed with `maxSlopeGradient: null`.

## Screenshots (if applicable)
N/A

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [x] No self-merge — at least 1 reviewer assigned
- [x] Conflicts resolved by PR author

## Related Issue
- Closes #269

## Notes
N/A