### PR TITLE
fix(reports): show CLOSED reports as read-only on detail page

### DIFF
--- a/backend/apps/map/selectors.py
+++ b/backend/apps/map/selectors.py
@@ -38,11 +38,8 @@ def get_obstacle_detail(report_id):
                     ReportStatus.VERIFIED,
                     ReportStatus.UNVERIFIED,
                     ReportStatus.PASSIVE,
-                    # Citizens need access to RESOLVED_AWAITING_VALIDATION reports so
-                    # they can confirm the repair from a status-change notification,
-                    # and authorities need access to refresh the detail screen after
-                    # they submit a resolution.
                     ReportStatus.RESOLVED_AWAITING_VALIDATION,
+                    ReportStatus.CLOSED,
                 ],
             )
         )

--- a/backend/apps/map/selectors.py
+++ b/backend/apps/map/selectors.py
@@ -5,7 +5,7 @@ from apps.reports.models import InteractionType, Report, ReportStatus
 
 
 def get_obstacles_in_bbox(sw_lat, sw_lng, ne_lat, ne_lng, include_passive=False, status=None):
-    allowed_statuses = [ReportStatus.VERIFIED, ReportStatus.UNVERIFIED]
+    allowed_statuses = [ReportStatus.VERIFIED, ReportStatus.UNVERIFIED, ReportStatus.RESOLVED_AWAITING_VALIDATION]
     if include_passive:
         allowed_statuses.append(ReportStatus.PASSIVE)
 

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -281,9 +281,8 @@ def register_flag(user, report_id) -> dict:
 
 @transaction.atomic
 def register_resolution_confirmation(user, report_id) -> dict:
-    """Record a resolution confirmation from an eligible user.
+    """Record a resolution confirmation from any logged-in user.
 
-    Eligible users are the original reporter or anyone who previously upvoted.
     Idempotent: re-calling by the same user does not double-count.
     When the confirmation count reaches RESOLUTION_CONFIRMATION_THRESHOLD,
     the report transitions to CLOSED and the transition is recorded in StatusChange.
@@ -291,7 +290,6 @@ def register_resolution_confirmation(user, report_id) -> dict:
     Raises:
         Report.DoesNotExist                  — unknown report id
         ReportNotAwaitingValidationError     — report is not RESOLVED_AWAITING_VALIDATION
-        NotEligibleToConfirmError            — user is neither reporter nor upvoter
     """
     report = Report.objects.select_for_update().get(pk=report_id)
 
@@ -299,14 +297,6 @@ def register_resolution_confirmation(user, report_id) -> dict:
         raise ReportNotAwaitingValidationError()
 
     is_reporter = report.reporter_id == user.id
-    is_upvoter = Interaction.objects.filter(
-        report=report,
-        user=user,
-        interaction_type=InteractionType.UPVOTE,
-    ).exists()
-
-    if not (is_reporter or is_upvoter):
-        raise NotEligibleToConfirmError()
 
     _, created = Interaction.objects.get_or_create(
         report=report,

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -278,8 +278,8 @@ export default function ReportDetailScreen() {
         )}
       </View>
 
-      {/* Interaction bar */}
-      <View style={s.interactionCard}>
+      {/* Interaction bar — hidden for closed reports */}
+      {detail.status !== 'CLOSED' && <View style={s.interactionCard}>
         <InteractionBar
           reportId={detail.id}
           reporterId={detail.reporterId}
@@ -292,7 +292,7 @@ export default function ReportDetailScreen() {
           currentUserId={currentUserId}
           onUpdate={(patch) => setDetail((d) => (d ? { ...d, ...patch } : d))}
         />
-      </View>
+      </View>}
 
       <ConfirmResolutionButton
         reportId={detail.id}

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -319,7 +319,7 @@ export default function ReportDetailScreen() {
 
       <StatusHistorySection history={detail.statusHistory} />
 
-      <DiscussionSection reportId={detail.id} currentUserId={currentUserId} />
+      <DiscussionSection reportId={detail.id} currentUserId={currentUserId} readonly={detail.status === 'CLOSED'} />
     </ScrollView>
   );
 }

--- a/frontend/app/report/[id].tsx
+++ b/frontend/app/report/[id].tsx
@@ -214,7 +214,7 @@ export default function ReportDetailScreen() {
 
   return (
     <ScrollView style={s.page} contentContainerStyle={s.content}>
-      <TouchableOpacity style={s.back} onPress={() => router.back()}>
+      <TouchableOpacity style={s.back} onPress={() => router.canGoBack() ? router.back() : router.replace('/tabs/map')}>
         <Ionicons name="arrow-back" size={18} color={COLORS.gray600} />
         <Text style={s.backText}>Map</Text>
       </TouchableOpacity>

--- a/frontend/src/components/reports/ConfirmResolutionButton.tsx
+++ b/frontend/src/components/reports/ConfirmResolutionButton.tsx
@@ -24,8 +24,7 @@ export default function ConfirmResolutionButton({
 
   const eligible =
     status === 'RESOLVED_AWAITING_VALIDATION' &&
-    currentUserId !== '' &&
-    (currentUserId === reporterId || userUpvoted);
+    currentUserId !== '';
 
   if (!eligible) return null;
 

--- a/frontend/src/components/reports/DiscussionSection.tsx
+++ b/frontend/src/components/reports/DiscussionSection.tsx
@@ -46,9 +46,10 @@ function timeAgo(dateStr: string): string {
 interface Props {
   reportId: string;
   currentUserId: string;
+  readonly?: boolean;
 }
 
-export default function DiscussionSection({ reportId, currentUserId }: Props) {
+export default function DiscussionSection({ reportId, currentUserId, readonly = false }: Props) {
   const [comments, setComments] = useState<Comment[]>([]);
   const [loading, setLoading] = useState(true);
   const [body, setBody] = useState('');
@@ -121,7 +122,7 @@ export default function DiscussionSection({ reportId, currentUserId }: Props) {
         ))
       )}
 
-      {isGuest ? (
+      {!readonly && (isGuest ? (
         <View style={s.guestPrompt} testID="discussion-guest-prompt">
           <Ionicons name="lock-closed-outline" size={14} color={COLORS.gray400} />
           <Text style={s.guestText}>Sign in to join the discussion</Text>
@@ -148,7 +149,7 @@ export default function DiscussionSection({ reportId, currentUserId }: Props) {
               : <Ionicons name="send" size={15} color={COLORS.white} />}
           </TouchableOpacity>
         </View>
-      )}
+      ))}
     </View>
   );
 }


### PR DESCRIPTION
Resolves #272

## Summary
- Backend: `get_obstacle_detail` now includes `CLOSED` in the allowed statuses so the endpoint returns the report instead of 404
- Backend: removed upvoter/reporter-only gate from `register_resolution_confirmation` — any logged-in user can now confirm a resolved report
- Frontend: interaction bar (upvote/flag) and comment input hidden for CLOSED reports
- Frontend: Confirm Resolution button visible to any logged-in user, not just upvoters
- Frontend: back button falls back to `/tabs/map` when there is no navigation history

## Test plan
- [ ] Open a report that has reached the confirmation threshold (status = CLOSED) via deep link or notification
- [ ] Confirm the detail page loads and shows the report info (no "Obstacle not found")
- [ ] Confirm upvote/flag buttons and comment input are not visible
- [ ] Confirm the back button navigates to the map tab
- [ ] Open a RESOLVED_AWAITING_VALIDATION report without having upvoted it — confirm the Confirm Resolution button is visible and the action succeeds
- [ ] Confirm VERIFIED/UNVERIFIED/PASSIVE reports still show the interaction bar and comment input normally