### PR TITLE
feat(map): stale-while-revalidate refresh for obstacles

### DIFF
--- a/frontend/src/components/map/MapView.tsx
+++ b/frontend/src/components/map/MapView.tsx
@@ -14,7 +14,7 @@ import SavePlaceModal from './SavePlaceModal';
 import { useLocation } from '../../hooks/useLocation';
 import { COLORS } from '../../constants/theme';
 import { HIGH_DETAIL_ZOOM } from '../../constants/mapConstants';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -399,6 +399,23 @@ export default function MapView() {
     if (!currentBoundsRef.current || !readyRef.current) return;
     loadObstacles(currentBoundsRef.current);
   }, [showPassive, loadObstacles]);
+
+  // Refetch every time the map regains focus so newly-submitted reports and
+  // status changes (e.g. CLOSED via confirm-resolution) appear/disappear
+  // without a manual reload. The WebView atomically swaps markers when the
+  // fetch resolves, so old markers stay visible during the refresh.
+  const hasFocusedOnceRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!hasFocusedOnceRef.current) {
+        hasFocusedOnceRef.current = true;
+        return;
+      }
+      if (currentBoundsRef.current && readyRef.current) {
+        loadObstacles(currentBoundsRef.current);
+      }
+    }, [loadObstacles]),
+  );
 
   // ── Autocomplete for main search ─────────────────────────────────────────
 

--- a/frontend/src/components/map/MapView.web.tsx
+++ b/frontend/src/components/map/MapView.web.tsx
@@ -93,6 +93,11 @@ const BOUN_CENTER: [number, number] = [41.0847, 29.0503];
 const DEFAULT_ZOOM = 16;
 const DEFAULT_BBOX = { north: 41.095, south: 41.074, east: 29.065, west: 29.035 };
 
+// Cached obstacle data is considered fresh for this long. After this window
+// the next bounds-change interaction (pan/zoom) refetches even within the
+// already-covered region, so long-idle sessions still pick up new reports.
+const OBSTACLE_CACHE_TTL_MS = 60_000;
+
 const CATEGORY_COLOR: Record<string, string> = {
   BROKEN_RAMP: COLORS.red500,
   NARROW_SIDEWALK: COLORS.orange500,
@@ -228,6 +233,7 @@ export default function MapView() {
   const obstacleMapRef = useRef<Map<string, Obstacle>>(new Map());
   const fetchedBoundsRef = useRef<{ north: number; south: number; east: number; west: number } | null>(null);
   const lastShowPassiveRef = useRef<boolean>(false);
+  const lastFetchedAtRef = useRef<number>(0);
   const currentBoundsRef = useRef<L.LatLngBounds | null>(null);
 
   // Obstacle state
@@ -353,18 +359,23 @@ export default function MapView() {
       west: b.getWest(),
     };
 
-    if (lastShowPassiveRef.current !== showPassive) {
+    const passiveChanged = lastShowPassiveRef.current !== showPassive;
+    if (passiveChanged) {
       lastShowPassiveRef.current = showPassive;
-      obstacleMapRef.current.clear();
-      fetchedBoundsRef.current = null;
+      // Don't clear the cache here — the post-fetch reconciliation below
+      // removes any stale PASSIVE entries (when toggling off) and merges in
+      // newly-returned ones (when toggling on). Keeping old markers visible
+      // until new data lands avoids a brief empty-map flash.
     }
 
     const fb = fetchedBoundsRef.current;
-    if (fb &&
-        nb.north <= fb.north &&
-        nb.south >= fb.south &&
-        nb.east <= fb.east &&
-        nb.west >= fb.west) {
+    const ttlExpired = Date.now() - lastFetchedAtRef.current > OBSTACLE_CACHE_TTL_MS;
+    const alreadyCovered = fb &&
+      nb.north <= fb.north &&
+      nb.south >= fb.south &&
+      nb.east <= fb.east &&
+      nb.west >= fb.west;
+    if (alreadyCovered && !passiveChanged && !ttlExpired) {
       return;
     }
 
@@ -393,6 +404,7 @@ export default function MapView() {
         east: Math.max(cur.east, nb.east),
         west: Math.min(cur.west, nb.west),
       } : nb;
+      lastFetchedAtRef.current = Date.now();
       setObstacles([...obstacleMapRef.current.values()]);
     });
     return () => { cancelled = true; };
@@ -400,11 +412,13 @@ export default function MapView() {
 
   // Refetch every time the map regains focus so newly-submitted reports and
   // status changes made on the detail screen (e.g. CLOSED via confirm
-  // resolution) appear/disappear without a manual reload. Invalidating the
-  // fetched-bounds union bypasses the zoom-in skip below.
+  // resolution) appear/disappear without a manual reload. Resetting the
+  // last-fetched timestamp forces the next effect run to bypass the
+  // already-covered shortcut while leaving the cached bounds and markers
+  // intact (stale-while-revalidate: old data stays visible during fetch).
   useFocusEffect(
     useCallback(() => {
-      fetchedBoundsRef.current = null;
+      lastFetchedAtRef.current = 0;
       setRefreshNonce((n) => n + 1);
     }, []),
   );


### PR DESCRIPTION
## Description
Obstacles on the map only refetch when the visible bounds change to a new uncovered area. If another user reports a new obstacle (or one changes status) while the current user is looking at the map, the change isn't picked up until a manual reload. This PR adds stale-while-revalidate refresh with two new triggers — focus and a 60 s TTL — and ensures old markers stay visible until the response lands, so the map never briefly blanks out.

## Type of Change
- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `refactor` — code refactor
- [ ] `docs` — documentation
- [ ] `chore` — maintenance / configuration
- [ ] `perf` — performance improvement
- [ ] `test` — adding or updating tests
- [ ] `style` — formatting, missing semicolons, etc.

## Changes

**Web (`MapView.web.tsx`):**
- Toggling "Show inactive" no longer clears the cache synchronously. The existing post-fetch reconciliation already removes stale `PASSIVE` entries when toggling off and merges in new ones when toggling on, so the synchronous clear can be dropped — eliminating a brief empty-map flash.
- Added a 60 s TTL (`OBSTACLE_CACHE_TTL_MS`) on the already-covered-bounds shortcut: if the user has been idle in the same area for longer than that, the next pan/zoom triggers a refetch even though the bbox is technically already cached.
- Switched the focus-effect refresh from nuking `fetchedBoundsRef` to just resetting `lastFetchedAtRef`, preserving the cached bounds union while still forcing the next effect run to refetch.

**Native (`MapView.tsx`):**
- Added a `useFocusEffect` that refetches the current bbox whenever the map screen regains focus. Uses `hasFocusedOnceRef` to skip the initial mount (the existing initial-fetch effect already covers it, so we avoid a double-fetch on first load). The WebView swaps markers atomically when the response lands, so old markers remain visible during the refresh.

## How to Test
1. Open the map (web). Note the obstacles shown.
2. From another browser/session, submit a new report inside the visible area.
3. Switch back to the map tab — focus event should trigger a refetch; the new obstacle should appear without a manual reload.
4. Toggle "Show inactive" on/off — existing markers should remain visible throughout; PASSIVE markers appear/disappear after the fetch resolves rather than the map momentarily emptying.
5. Stay idle on the map for >60 s, then pan or zoom slightly — a refetch should fire even though the bbox was already cached.
6. On native: navigate to another tab (e.g. Report) and back — the map should refetch on focus. Initial app launch should fetch exactly once (no double-fetch).

## Screenshots (if applicable)
N/A — behavioural change, no UI surface change.

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #275

## Notes
- Cache layer reuses existing `obstacleMapRef` / `fetchedBoundsRef` plus a new `lastFetchedAtRef` for TTL. No new state libraries introduced.
- Post-fetch reconciliation (already in main) drops cache entries within the queried bbox that the server no longer returns, so obstacles transitioning to `CLOSED` are removed correctly on refetch.
- Server-side caching (ETag / `Cache-Control`) is a separate follow-up, not in this PR.
