### PR TITLE
feat(notifications): notify reporter when their report is closed

### DIFF
--- a/backend/apps/notifications/models.py
+++ b/backend/apps/notifications/models.py
@@ -5,6 +5,7 @@ from django.db import models
 class NotificationType(models.TextChoices):
     REPORT_VERIFIED = 'REPORT_VERIFIED', 'Report Verified'
     REPORT_RESOLVED = 'REPORT_RESOLVED', 'Report Resolved'
+    REPORT_CLOSED = 'REPORT_CLOSED', 'Report Closed'
 
 
 class Notification(models.Model):

--- a/backend/apps/notifications/services.py
+++ b/backend/apps/notifications/services.py
@@ -15,11 +15,25 @@ def _resolved_message(report: Report) -> str:
     )
 
 
-def create_status_change_notifications(report: Report, new_status: str) -> list[Notification]:
+def _closed_message(report: Report, reason: str | None = None) -> str:
+    base = f'Your report "{report.title}" has been closed.'
+    if reason:
+        return f'{base} {reason}'
+    return base
+
+
+def create_status_change_notifications(
+    report: Report,
+    new_status: str,
+    *,
+    actor_id: int | None = None,
+    reason: str | None = None,
+) -> list[Notification]:
     """Create in-app notifications for a report status transition.
 
     - VERIFIED: notify the reporter only.
     - RESOLVED_AWAITING_VALIDATION: notify reporter + all distinct upvoters.
+    - CLOSED: notify the reporter only (unless they performed the close action).
     Recipients with notifications_enabled=False are skipped silently.
     """
     if new_status == ReportStatus.VERIFIED:
@@ -35,6 +49,13 @@ def create_status_change_notifications(report: Report, new_status: str) -> list[
         recipient_ids = {report.reporter_id} | upvoter_ids
         message = _resolved_message(report)
         notif_type = NotificationType.REPORT_RESOLVED
+    elif new_status == ReportStatus.CLOSED:
+        # Don't self-notify when the reporter closed their own report.
+        if actor_id is not None and actor_id == report.reporter_id:
+            return []
+        recipient_ids = {report.reporter_id}
+        message = _closed_message(report, reason)
+        notif_type = NotificationType.REPORT_CLOSED
     else:
         return []
 

--- a/backend/apps/notifications/signals.py
+++ b/backend/apps/notifications/signals.py
@@ -7,7 +7,10 @@ from .services import create_status_change_notifications
 
 
 @receiver(report_status_changed)
-def handle_report_status_changed(sender, report, old_status, new_status, actor=None, **kwargs):
+def handle_report_status_changed(sender, report, old_status, new_status, actor=None, reason=None, **kwargs):
+    actor_id = actor.id if actor is not None else None
     transaction.on_commit(
-        lambda: create_status_change_notifications(report, new_status)
+        lambda: create_status_change_notifications(
+            report, new_status, actor_id=actor_id, reason=reason,
+        )
     )

--- a/backend/apps/notifications/tests.py
+++ b/backend/apps/notifications/tests.py
@@ -97,6 +97,52 @@ class CreateStatusChangeNotificationsTest(TestCase):
     def test_non_relevant_status_creates_nothing(self):
         reporter = make_user(email="reporter@test.com")
         report = make_report(reporter)
+        notifs = create_status_change_notifications(report, ReportStatus.UNVERIFIED)
+        self.assertEqual(notifs, [])
+
+    def test_closed_notifies_only_reporter(self):
+        reporter = make_user(email="reporter@test.com")
+        # Upvoters are NOT notified on CLOSED — only the reporter.
+        upvoter = make_user(email="up@test.com")
+        report = make_report(reporter, status=ReportStatus.RESOLVED_AWAITING_VALIDATION)
+        Interaction.objects.create(
+            report=report, user=upvoter, interaction_type=InteractionType.UPVOTE,
+        )
+
+        notifs = create_status_change_notifications(report, ReportStatus.CLOSED)
+
+        self.assertEqual(len(notifs), 1)
+        self.assertEqual(notifs[0].user_id, reporter.id)
+        self.assertEqual(notifs[0].notification_type, NotificationType.REPORT_CLOSED)
+        self.assertEqual(notifs[0].related_report_id, report.id)
+        self.assertIn(report.title, notifs[0].message)
+
+    def test_closed_skips_when_reporter_is_the_actor(self):
+        reporter = make_user(email="reporter@test.com")
+        report = make_report(reporter, status=ReportStatus.RESOLVED_AWAITING_VALIDATION)
+
+        notifs = create_status_change_notifications(
+            report, ReportStatus.CLOSED, actor_id=reporter.id,
+        )
+        self.assertEqual(notifs, [])
+
+    def test_closed_includes_reason_when_provided(self):
+        reporter = make_user(email="reporter@test.com")
+        report = make_report(reporter, status=ReportStatus.RESOLVED_AWAITING_VALIDATION)
+        other = make_user(email="other@test.com")
+
+        notifs = create_status_change_notifications(
+            report, ReportStatus.CLOSED,
+            actor_id=other.id,
+            reason='Community resolution confirmed.',
+        )
+        self.assertEqual(len(notifs), 1)
+        self.assertIn('Community resolution confirmed.', notifs[0].message)
+
+    def test_closed_respects_notifications_enabled_flag(self):
+        reporter = make_user(email="reporter@test.com", notifications_enabled=False)
+        report = make_report(reporter, status=ReportStatus.RESOLVED_AWAITING_VALIDATION)
+
         notifs = create_status_change_notifications(report, ReportStatus.CLOSED)
         self.assertEqual(notifs, [])
 
@@ -186,6 +232,55 @@ class UpvoteVerifiesAndNotifiesTest(TestCase):
 
         with self.captureOnCommitCallbacks(execute=True):
             self._vote_until_verified()
+
+        self.assertEqual(Notification.objects.filter(user=self.reporter).count(), 0)
+
+
+# ---------------------------------------------------------------------------
+# Integration: confirm-resolution threshold triggers REPORT_CLOSED notification
+# ---------------------------------------------------------------------------
+
+from django.test import override_settings
+
+
+@override_settings(RESOLUTION_CONFIRMATION_THRESHOLD=3)
+class ConfirmResolutionClosesAndNotifiesTest(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.reporter = make_user(email="reporter@test.com")
+        self.report = make_report(
+            self.reporter, status=ReportStatus.RESOLVED_AWAITING_VALIDATION,
+        )
+        self.url = f"/api/reports/{self.report.id}/confirm-resolution/"
+
+    def _confirm_to_threshold(self, last_actor):
+        """Two other users confirm, then `last_actor` confirms — closing the report."""
+        u1 = make_user(email="u1@test.com")
+        u2 = make_user(email="u2@test.com")
+        for u in (u1, u2):
+            self.client.force_authenticate(user=u)
+            self.client.post(self.url)
+        self.client.force_authenticate(user=last_actor)
+        return self.client.post(self.url)
+
+    def test_closed_transition_creates_notification_for_reporter(self):
+        outsider = make_user(email="closer@test.com")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self._confirm_to_threshold(outsider)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["status"], ReportStatus.CLOSED)
+
+        notifs = list(Notification.objects.filter(user=self.reporter))
+        self.assertEqual(len(notifs), 1)
+        self.assertEqual(notifs[0].notification_type, NotificationType.REPORT_CLOSED)
+        self.assertEqual(notifs[0].related_report_id, self.report.id)
+        self.assertIn(self.report.title, notifs[0].message)
+        self.assertIn('Community resolution confirmed.', notifs[0].message)
+
+    def test_no_notification_when_reporter_closes_their_own_report(self):
+        with self.captureOnCommitCallbacks(execute=True):
+            self._confirm_to_threshold(self.reporter)
 
         self.assertEqual(Notification.objects.filter(user=self.reporter).count(), 0)
 

--- a/backend/apps/reports/services.py
+++ b/backend/apps/reports/services.py
@@ -310,15 +310,26 @@ def register_resolution_confirmation(user, report_id) -> dict:
     ).count()
 
     if created and confirmation_count >= settings.RESOLUTION_CONFIRMATION_THRESHOLD:
+        from apps.reports.signals import report_status_changed
+
         old_status = report.status
         report.status = ReportStatus.CLOSED
         report.save(update_fields=['status', 'updated_at'])
+        close_reason = 'Community resolution confirmed.'
         StatusChange.objects.create(
             report=report,
             changed_by=user,
             old_status=old_status,
             new_status=ReportStatus.CLOSED,
-            reason='Community resolution confirmed.',
+            reason=close_reason,
+        )
+        report_status_changed.send(
+            sender=Report,
+            report=report,
+            old_status=old_status,
+            new_status=ReportStatus.CLOSED,
+            actor=user,
+            reason=close_reason,
         )
 
     return {


### PR DESCRIPTION
## Description

Adds a `REPORT_CLOSED` in-app notification that fires when a report transitions to `CLOSED` via community resolution confirmation reaching the threshold. Previously reporters had no way to know their report was closed without manually checking. The notification includes the closure reason and skips delivery when the reporter themselves performed the final confirmation (self-notification guard).

## Type of Change
- [x] `feat` — new feature

## Changes
- Added `NotificationType.REPORT_CLOSED` to the notification model
- Extended `create_status_change_notifications` with a `CLOSED` branch: notifies reporter only, appends `StatusChange.reason` to the message when provided, and skips if `actor_id == reporter_id`
- `register_resolution_confirmation` now emits `report_status_changed` with `actor` and `reason` after the `CLOSED` transition — this was the only status transition that did not fire the signal
- Signal handler updated to forward `actor.id` and `reason` kwargs to the service

## How to Test
1. Create a report as User A.
2. Log in as 2 other users and call `POST /api/reports/<id>/confirm-resolution/` from each.
3. Log in as a 3rd other user (not User A) and confirm — this pushes the count to the threshold and closes the report.
4. Check User A's notifications (`GET /api/notifications/`) — a `REPORT_CLOSED` notification should appear with the report title and closure reason.
5. Repeat but have User A perform the final confirmation — no notification should be created (self-notification guard).

## Screenshots (if applicable)
N/A — backend-only change; notification appears in the existing Notifications tab UI.

## Checklist
- [ ] Commit messages follow `<type>(<scope>): <subject>` format
- [ ] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #273

## Notes
- `NotificationType.REPORT_CLOSED` is a new `CharField` choice value — no DB migration needed since choices are enforced at the Python layer only.
- Tapping the notification navigates to `/report/:id` via the existing generic handler in `notifications.tsx` — no frontend changes needed.
