### PR TITLE
test(e2e): Playwright smoke test suite [QA]

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,54 @@
+name: E2E Smoke Tests
+
+# Runs the Playwright smoke suite (issue #178) against the deployed environment.
+#
+# Required repository configuration (Settings → Secrets and variables → Actions):
+#   Variables:
+#     E2E_BASE_URL   — URL of the deployed web app   (e.g. https://accessmap.vercel.app)
+#     E2E_API_URL    — URL of the deployed backend    (e.g. https://api.accessmap.example.com)
+#
+# To make a failure block merges to main, add this job ("E2E Smoke") as a
+# required status check under Settings → Branches → Branch protection rules.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: E2E Smoke
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke tests
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ vars.E2E_BASE_URL }}
+          PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL }}
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,8 +7,10 @@ name: E2E Smoke Tests
 #     E2E_BASE_URL   — URL of the deployed web app   (e.g. https://accessmap.vercel.app)
 #     E2E_API_URL    — URL of the deployed backend    (e.g. https://api.accessmap.example.com)
 #
-# To make a failure block merges to main, add this job ("E2E Smoke") as a
-# required status check under Settings → Branches → Branch protection rules.
+# Until both are set the test step is skipped (the job still succeeds) so PRs
+# aren't blocked by an unconfigured pipeline. To make a failure block merges to
+# main once configured, add this job ("E2E Smoke") as a required status check
+# under Settings → Branches → Branch protection rules.
 
 on:
   pull_request:
@@ -28,25 +30,40 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Check configuration
+        id: cfg
+        working-directory: .
+        run: |
+          if [ -n "${{ vars.E2E_BASE_URL }}" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=E2E skipped::Set repo variables E2E_BASE_URL and E2E_API_URL to run the smoke suite against the deployed environment."
+          fi
+
       - name: Set up Node.js
+        if: steps.cfg.outputs.enabled == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
 
       - name: Install dependencies
+        if: steps.cfg.outputs.enabled == 'true'
         run: npm install --legacy-peer-deps
 
       - name: Install Playwright browsers
+        if: steps.cfg.outputs.enabled == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Run smoke tests
+        if: steps.cfg.outputs.enabled == 'true'
         env:
           PLAYWRIGHT_BASE_URL: ${{ vars.E2E_BASE_URL }}
           PLAYWRIGHT_API_URL: ${{ vars.E2E_API_URL }}
         run: npm run test:e2e
 
       - name: Upload Playwright report
-        if: ${{ !cancelled() }}
+        if: ${{ steps.cfg.outputs.enabled == 'true' && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: playwright-report

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,12 @@ node_modules/
 dist/
 package-lock.json
 
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
 # IDE
 .idea/
 .vscode/

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -4,7 +4,8 @@ import type { Page } from '@playwright/test';
 // driving the UI for every precondition. Mirrors src/services/auth.ts and
 // src/api/reports.ts.
 
-export const API_URL = process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8000';
+// `||` not `??`: CI passes the var through as "" when the repo variable is unset.
+export const API_URL = process.env.PLAYWRIGHT_API_URL || 'http://localhost:8000';
 
 // Boğaziçi University campus — the app centres its map here.
 export const BOUN_CENTER = { lat: 41.0847, lng: 29.0503 };

--- a/frontend/e2e/helpers/api.ts
+++ b/frontend/e2e/helpers/api.ts
@@ -1,0 +1,117 @@
+import type { Page } from '@playwright/test';
+
+// Direct backend calls used to set up test fixtures (accounts, reports) without
+// driving the UI for every precondition. Mirrors src/services/auth.ts and
+// src/api/reports.ts.
+
+export const API_URL = process.env.PLAYWRIGHT_API_URL ?? 'http://localhost:8000';
+
+// Boğaziçi University campus — the app centres its map here.
+export const BOUN_CENTER = { lat: 41.0847, lng: 29.0503 };
+
+// 1×1 transparent PNG, raw base64 (no data-URI prefix) — matches what the app
+// sends (PhotoEntry.b64 from expo-image-picker). Backend only checks it's a
+// non-empty string, but a real PNG keeps things honest.
+const PNG_1PX_B64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+export interface Tokens {
+  access: string;
+  refresh: string;
+}
+
+export interface TestUser extends Tokens {
+  email: string;
+  password: string;
+  fullName: string;
+}
+
+function uniqueEmail(prefix = 'e2e'): string {
+  return `${prefix}+${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
+}
+
+async function postJson(path: string, body: unknown, token?: string) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`POST ${path} → ${res.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+/** Register a fresh account and return its credentials + tokens. */
+export async function registerUser(prefix = 'e2e'): Promise<TestUser> {
+  const email = uniqueEmail(prefix);
+  const password = 'E2ePassw0rd!';
+  const fullName = 'E2E Tester';
+  const data = await postJson('/api/auth/register/', {
+    email,
+    password,
+    fullName,
+    birthDate: '2000-01-01',
+  });
+  // RegisterResponse: { ..., accessToken, refreshToken }
+  let access: string = data.accessToken ?? data.access ?? '';
+  let refresh: string = data.refreshToken ?? data.refresh ?? '';
+  if (!access) {
+    // Some backends only issue tokens on login — fall back to that.
+    const login = await postJson('/api/auth/login/', { email, password });
+    access = login.access;
+    refresh = login.refresh;
+  }
+  return { email, password, fullName, access, refresh };
+}
+
+/** Log in and return tokens. */
+export async function loginUser(email: string, password: string): Promise<Tokens> {
+  const data = await postJson('/api/auth/login/', { email, password });
+  return { access: data.access, refresh: data.refresh };
+}
+
+/** Create a report via the API and return its id. */
+export async function createReport(
+  token: string,
+  overrides: Partial<{ category: string; description: string; lat: number; lng: number }> = {},
+): Promise<string> {
+  const data = await postJson(
+    '/api/reports/',
+    {
+      location: {
+        lat: overrides.lat ?? BOUN_CENTER.lat,
+        lng: overrides.lng ?? BOUN_CENTER.lng,
+      },
+      context: 'OUTDOOR',
+      category: overrides.category ?? 'BROKEN_RAMP',
+      description: overrides.description ?? 'E2E smoke fixture report',
+      photos: [PNG_1PX_B64],
+      violations: [],
+    },
+    token,
+  );
+  const id = data.reportId ?? data.id ?? data.report_id;
+  if (!id) throw new Error(`Report created but no id in response: ${JSON.stringify(data)}`);
+  return String(id);
+}
+
+/**
+ * Seed auth tokens into the web app's storage so a page loads already signed in.
+ * The web build keeps tokens in localStorage under `am_access` / `am_refresh`
+ * (see src/services/auth.ts). Must be called before navigating to an app route.
+ */
+export async function seedAuth(page: Page, tokens: Tokens, baseURL: string): Promise<void> {
+  await page.addInitScript(
+    ([access, refresh]) => {
+      window.localStorage.setItem('am_access', access);
+      window.localStorage.setItem('am_refresh', refresh);
+    },
+    [tokens.access, tokens.refresh],
+  );
+  // Touch the origin once so localStorage is scoped correctly on first real nav.
+  await page.goto(baseURL);
+}

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  BOUN_CENTER,
+  createReport,
+  registerUser,
+  seedAuth,
+} from './helpers/api';
+
+// ── E2E smoke suite (issue #178) ────────────────────────────────────────────
+// Covers the core user flows so integration bugs (CORS, routing, auth) surface
+// in CI rather than during the demo. Runs against a deployed environment via
+// PLAYWRIGHT_BASE_URL / PLAYWRIGHT_API_URL (see playwright.config.ts).
+//
+// React-Native-Web note: TouchableOpacity renders as a <div> with no button
+// role, and screen headers often repeat the button's label, so we locate
+// tappable controls by visible text and disambiguate with .last().
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:8081';
+
+// 1×1 transparent PNG — enough for expo-image-picker's web file reader.
+const PNG_1PX = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function tapByText(page: Page, text: string) {
+  // Last match = the button (headers/subtitles with the same label come first).
+  return page.getByText(text, { exact: true }).last().click();
+}
+
+test.describe('AccessMap smoke', () => {
+  test('register → login → view map → submit report', async ({ page, context }) => {
+    // Report form's "Current Location" mode reads navigator.geolocation.
+    await context.grantPermissions(['geolocation'], { origin: BASE_URL });
+    await context.setGeolocation({ latitude: BOUN_CENTER.lat, longitude: BOUN_CENTER.lng });
+
+    const email = `e2e+ui-${Date.now()}-${Math.random().toString(36).slice(2, 7)}@example.com`;
+    const password = 'E2ePassw0rd!';
+
+    // ── Register via the UI ──
+    await page.goto('/auth/register');
+    await page.getByPlaceholder('your@email.com').fill(email);
+    await page.getByPlaceholder('Ahmet Yılmaz').fill('E2E Tester');
+    await page.getByPlaceholder('YYYY-MM-DD').fill('2000-01-01');
+    await page.getByPlaceholder('Min 8 chars').fill(password);
+    await page.getByPlaceholder('Re-enter').fill(password);
+    await tapByText(page, 'Create Account');
+
+    // Registration signs the user in and lands on the map tab.
+    await expect(page).toHaveURL(/\/tabs(\/index)?(\?|#|$)/, { timeout: 30_000 });
+
+    // ── View map ──
+    await expect(page.getByPlaceholder('Search for a location')).toBeVisible({ timeout: 20_000 });
+
+    // ── Submit a report ──
+    await page.goto('/tabs/report');
+    // Default location mode is "Current Location"; wait out the geolocation fetch.
+    await expect(page.getByText('Detecting your location…')).toHaveCount(0, { timeout: 20_000 });
+
+    await tapByText(page, 'Broken Ramp');
+    await page
+      .getByPlaceholder('Describe the obstacle — size, severity, how it affects accessibility…')
+      .fill('E2E smoke: broken ramp near campus gate, no alternative accessible route.');
+
+    // A photo is required. expo-image-picker (web) opens a native file dialog.
+    const chooserPromise = page.waitForEvent('filechooser');
+    await tapByText(page, 'Gallery');
+    const chooser = await chooserPromise;
+    await chooser.setFiles({ name: 'obstacle.png', mimeType: 'image/png', buffer: PNG_1PX });
+    // Thumbnail replaces the "No photo added yet" placeholder once decoded.
+    await expect(page.getByText('No photo added yet')).toHaveCount(0, { timeout: 15_000 });
+
+    await tapByText(page, 'Submit Report');
+    await expect(page.getByText('Report Received!')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('login → request route between two campus points', async ({ page }) => {
+    const user = await registerUser('route');
+
+    // ── Login via the UI ──
+    await page.goto('/auth/login');
+    await page.getByPlaceholder('your@email.com').fill(user.email);
+    await page.getByPlaceholder('Enter password').fill(user.password);
+    await tapByText(page, 'Sign In');
+
+    await expect(page).toHaveURL(/\/tabs(\/index)?(\?|#|$)/, { timeout: 30_000 });
+
+    // ── Request a route between two campus points ──
+    // Pick a destination from the map search (this also opens the route panel),
+    // then a start point, then calculate. Search hits the backend geocoder and
+    // falls back to Nominatim — adjust the terms if the deployed geocoder
+    // indexes campus places under different names.
+    const search = page.getByPlaceholder('Search for a location');
+    await expect(search).toBeVisible({ timeout: 20_000 });
+    await search.fill('Bebek, Istanbul');
+    await page.getByText(/Bebek/i).first().click({ timeout: 20_000 });
+
+    await tapByText(page, 'Plan Route');
+
+    const origin = page.getByPlaceholder('Origin — search or drop pin');
+    await expect(origin).toBeVisible({ timeout: 10_000 });
+    await origin.fill('Etiler, Istanbul');
+    await page.getByText(/Etiler/i).first().click({ timeout: 20_000 });
+
+    await tapByText(page, 'Get Route');
+
+    // Route summary panel shows Distance / Est. time once a route comes back.
+    await expect(page.getByText('Est. time')).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText('Distance')).toBeVisible();
+  });
+
+  test('upvote a report → count increments', async ({ page }) => {
+    // Author and report come from the API; the upvoter cannot be the owner.
+    const author = await registerUser('author');
+    const reportId = await createReport(author.access, {
+      description: 'E2E smoke fixture — upvote target',
+    });
+    const voter = await registerUser('voter');
+
+    await seedAuth(page, voter, BASE_URL);
+    await page.goto(`/report/${reportId}`);
+
+    const upvoteBtn = page.getByTestId('upvote-button');
+    const upvoteCount = page.getByTestId('upvote-count');
+    await expect(upvoteBtn).toBeVisible({ timeout: 20_000 });
+
+    const readCount = async () =>
+      parseInt((await upvoteCount.textContent())?.match(/\d+/)?.[0] ?? '0', 10);
+
+    const before = await readCount();
+    await upvoteBtn.click();
+
+    await expect.poll(readCount, { timeout: 15_000 }).toBe(before + 1);
+  });
+});

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -15,7 +15,7 @@ import {
 // role, and screen headers often repeat the button's label, so we locate
 // tappable controls by visible text and disambiguate with .last().
 
-const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:8081';
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8081';
 
 // 1×1 transparent PNG — enough for expo-image-picker's web file reader.
 const PNG_1PX = Buffer.from(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "react-native-webview": "13.15.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@testing-library/react-native": "^12.9.0",
         "@types/jest": "^29.5.14",
         "@types/leaflet": "^1.9.14",
@@ -2573,6 +2574,21 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -9247,6 +9263,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,10 @@
     "web": "expo start --web",
     "build:web": "expo export --platform web",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.2",
@@ -33,6 +36,7 @@
     "react-native-webview": "13.15.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@testing-library/react-native": "^12.9.0",
     "@types/jest": "^29.5.14",
     "@types/leaflet": "^1.9.14",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -7,7 +7,8 @@ import { defineConfig, devices } from '@playwright/test';
 //
 // In CI, set both to the deployed URLs as repository secrets/variables.
 
-const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:8081';
+// `||` not `??`: CI passes the var through as "" when the repo variable is unset.
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:8081';
 
 export default defineConfig({
   testDir: './e2e',

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E smoke suite — runs against a deployed environment (or a local `expo start --web`).
+//
+//   PLAYWRIGHT_BASE_URL   URL of the running web app   (default: http://localhost:8081)
+//   PLAYWRIGHT_API_URL    URL of the backend API      (default: http://localhost:8000)
+//
+// In CI, set both to the deployed URLs as repository secrets/variables.
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:8081';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  // Tests create accounts/reports via the API; keep them serial so a flaky
+  // network call can't cascade and so output stays readable.
+  workers: 1,
+  retries: process.env.CI ? 2 : 0,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }], ['list']]
+    : [['html', { open: 'never' }], ['list']],
+  use: {
+    baseURL: BASE_URL,
+    headless: true,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});


### PR DESCRIPTION
## Description
Adds an end-to-end smoke test suite (Playwright) covering the core user flows so integration bugs (CORS, routing, auth) are caught in CI before the final demo rather than during it.

## Type of Change
- [x] `test` — adding or updating tests
- [x] `chore` — maintenance / configuration

## Changes
- Add Playwright + `frontend/playwright.config.ts` — targets a deployed environment via `PLAYWRIGHT_BASE_URL` / `PLAYWRIGHT_API_URL` (defaults to `localhost:8081` / `localhost:8000`)
- Add 3 smoke tests in `frontend/e2e/smoke.spec.ts`:
  - register → login → view map → submit report
  - login → request route between two campus points
  - upvote a report → count increments
- Add `frontend/e2e/helpers/api.ts` — sets up fixtures (accounts, reports) via the API and seeds auth tokens into `localStorage`
- Add `.github/workflows/e2e.yml` — "E2E Smoke" job, runs on PR + push to main + manual dispatch
- Add `test:e2e` / `test:e2e:headed` / `test:e2e:report` npm scripts

## How to Test
Locally (the web dev server needs Node 20+ — Node 18 fails on metro's `toReversed`):
1. `cd frontend && npx playwright install chromium` (one-time)
2. Backend: `docker-compose up` from the repo root
3. Web app: `npx expo start --web --port 8081`
4. `npm run test:e2e`

In CI: set repo Variables `E2E_BASE_URL` (deployed web URL) and `E2E_API_URL` (deployed backend URL). The workflow then runs the suite on every PR.

Verified locally: 3/3 passing, including under `--repeat-each=2`.

## Screenshots (if applicable)
N/A — no UI changes.

## Checklist
- [x] Commit messages follow `<type>(<scope>): <subject>` format
- [x] Branch is up to date with the target branch
- [ ] No self-merge — at least 1 reviewer assigned
- [ ] Conflicts resolved by PR author

## Related Issue
- Closes #178

## Notes
- To satisfy the "any failure blocks merge to main" acceptance criterion, add the **E2E Smoke** check as a required status check under Settings → Branches → branch protection (repo setting, not expressible in the workflow YAML).
- The route test's location search falls back to the public Nominatim API when the backend geocoder returns no results. Nominatim rate-limits, so that test is the most likely to flake in CI until the deployed `/api/map/search` has campus data.