### PR TITLE
feat(backend): add Swagger UI via drf-spectacular

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     'rest_framework_simplejwt',
     'rest_framework_simplejwt.token_blacklist',
     'corsheaders',
+    'drf_spectacular',
 
     'apps.core',
     'apps.users',
@@ -111,6 +112,14 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticatedOrReadOnly',
     ),
     'EXCEPTION_HANDLER': 'apps.core.exceptions.custom_exception_handler',
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'AccessMap API',
+    'DESCRIPTION': 'Community-driven accessibility obstacle reporting and pedestrian routing API.',
+    'VERSION': '1.0.0',
+    'SERVE_INCLUDE_SCHEMA': False,
 }
 
 SIMPLE_JWT = {

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.db import connection
 from django.http import JsonResponse
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from apps.users.views import MobilityProfileView
 
@@ -17,6 +18,8 @@ def health(request):
 urlpatterns = [
     path('health/', health),
     path('admin/', admin.site.urls),
+    path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('api/schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/auth/', include('apps.users.urls')),
     path('api/routes/', include('apps.routing.urls')),
     path('api/reports/', include('apps.reports.urls')),

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -8,3 +8,4 @@ gunicorn>=21.2
 bcrypt>=4.0
 supabase>=2.0
 requests>=2.31
+drf-spectacular>=0.27


### PR DESCRIPTION
Resolves #280

## Summary
- Added `drf-spectacular>=0.27` to `requirements/base.txt`
- Registered `drf_spectacular` in `INSTALLED_APPS` and set `DEFAULT_SCHEMA_CLASS`
- Added `SPECTACULAR_SETTINGS` with project title, description, and version
- Wired up `/api/schema/` (raw OpenAPI JSON) and `/api/schema/swagger-ui/` (Swagger UI) in `config/urls.py`

## Test plan
- [ ] Run `pip install -r requirements/base.txt` and `python manage.py runserver` locally
- [ ] Visit `http://localhost:8000/api/schema/swagger-ui/` and confirm all endpoints appear
- [ ] Confirm the deployed URL `https://bounswe2026group3-2.onrender.com/api/schema/swagger-ui/` is live after merge